### PR TITLE
Add Vercel API log-context skill, fetch script, and repo guidance

### DIFF
--- a/.codex/skills/vercel-api-log-context/SKILL.md
+++ b/.codex/skills/vercel-api-log-context/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: vercel-api-log-context
+description: Fetch and analyze Vercel deployment logs through API to debug frontend/backend errors with additional context. Use when a user provides a Vercel logs link, deployment URL, request id, or reports production/preview errors that need recent log evidence.
+---
+
+# Vercel API Log Context
+
+## 1) Validate access and identifiers
+1. Ensure `VERCEL_TOKEN` is available.
+2. Resolve `teamId` and `projectId` when missing.
+3. If a dashboard URL is provided, parse `selectedLogId` and timestamp for time-window targeting.
+
+## 2) Pull latest deployment logs (default path)
+Run:
+
+```bash
+tools/vercel/fetch_latest_deployment_logs.sh 10
+```
+
+This returns the latest 10 log events in descending time order.
+
+## 3) Deepen context for reported frontend errors
+When a user reports a frontend error:
+1. Capture error text, route, time, environment (preview/production).
+2. Pull latest deployment logs first.
+3. If needed, fetch more events (e.g. 50/100) and filter by:
+   - `error`, `TypeError`, `TS`, `500`, `timeout`, `failed`
+   - route/function related keywords
+4. Correlate log timestamps with the user's reported time.
+5. Summarize likely root cause + confidence + missing data.
+
+## 4) Command snippets
+Get latest deployment uid:
+
+```bash
+TEAM_ID='<team_id>'
+PROJECT_ID='<project_id>'
+curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
+  "https://api.vercel.com/v6/deployments?teamId=$TEAM_ID&projectId=$PROJECT_ID&limit=1" \
+  | jq -r '.deployments[0].uid'
+```
+
+Get events for a deployment:
+
+```bash
+DEPLOY_UID='<deployment_uid>'
+curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
+  "https://api.vercel.com/v3/deployments/$DEPLOY_UID/events?teamId=$TEAM_ID&limit=1000"
+```
+
+Get last 10 sorted by time:
+
+```bash
+curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" "https://api.vercel.com/v3/deployments/$DEPLOY_UID/events?teamId=$TEAM_ID&limit=1000" \
+  | jq 'sort_by(.created) | reverse | .[:10]'
+```
+
+## 5) Output format
+Return:
+1. Time range checked (UTC)
+2. Last 10 logs (structured)
+3. Error-correlated lines
+4. Next action (code fix / config fix / additional logs needed)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@
 - For each feature or task, create and save a markdown plan file in `docs/plans/`.
 - Name plan files with a `YYYY-MM-DD-HH-mm` prefix using 24-hour time (optionally appending a timezone such as `-UTC`).
 
+## API debugging workflow
+- When debugging API/interface errors, try the `vercel-api-log-context` skill first to collect Vercel deployment log context before proposing fixes.
+
 ## GitHub Agentic Workflows (gh-aw)
 
 This repository uses [GitHub Agentic Workflows](https://github.github.com/gh-aw/) to run AI coding agents on a schedule or in response to repository events.

--- a/docs/plans/2026-04-01-10-59-UTC-vercel-log-retrieval.md
+++ b/docs/plans/2026-04-01-10-59-UTC-vercel-log-retrieval.md
@@ -1,0 +1,28 @@
+# Background
+用户提供了一个 Vercel 日志页面链接（`/askman-dev/bricks/logs?...selectedLogId=...`），希望在容器环境中直接拿到对应日志内容。
+
+# Goals
+1. 尝试通过可用凭据和 API 访问该日志。
+2. 若无法直接按 `selectedLogId` 精确提取，至少拿到同项目的最新可访问构建日志。
+3. 记录可复现命令，便于后续继续排查。
+
+# Implementation Plan (phased)
+## Phase 1: 识别访问方式与鉴权
+- 验证日志页面是否需要登录重定向。
+- 检查环境变量是否存在 `VERCEL_TOKEN`。
+
+## Phase 2: 通过 Vercel API 枚举团队/项目/部署
+- 查询 team（slug: `askman-dev`）。
+- 查询项目 `bricks` 的 `projectId`。
+- 枚举最新部署并提取 deployment uid。
+
+## Phase 3: 拉取部署构建日志并检索目标标识
+- 调用 `GET /v3/deployments/{uid}/events` 获取构建日志流。
+- 在最近部署事件中检索 `selectedLogId` 前缀（`qpksf`）。
+- 若无命中，输出可访问日志样本与下一步建议（在 dashboard 中按时间定位 runtime log）。
+
+# Acceptance Criteria
+- 能确认页面是否登录受限（有明确 HTTP 重定向证据）。
+- 能用 `VERCEL_TOKEN` 成功调用 Vercel API 并返回 `askman-dev/bricks` 项目信息。
+- 能成功获取至少一个 deployment 的 build events 日志。
+- 提供可复现命令（`curl`/`jq`）用于后续继续定位。

--- a/docs/plans/2026-04-01-11-07-UTC-vercel-api-last10-logs-and-skill.md
+++ b/docs/plans/2026-04-01-11-07-UTC-vercel-api-last10-logs-and-skill.md
@@ -1,0 +1,30 @@
+# Background
+用户要求我继续执行：
+1) 实际拿到按时间排序的最后 10 条 Vercel 日志；
+2) 总结一套可复用的方法，用于后续前端报错时快速通过日志补充上下文；
+3) 将方法沉淀为一个可触发的 skill。
+
+# Goals
+1. 使用 `VERCEL_TOKEN` + API 获取 `askman-dev/bricks` 最新部署日志，并按时间倒序提取最后 10 条。
+2. 把可复用步骤脚本化，降低重复操作成本。
+3. 新增 skill，明确触发条件、标准流程和输出格式，支持后续排障。
+
+# Implementation Plan (phased)
+## Phase 1: 拉取最后 10 条日志
+- 查询 teamId / projectId / 最新 deployment uid。
+- 调用 `GET /v3/deployments/{uid}/events`。
+- 用 `jq` 进行 `sort_by(.created) | reverse | .[:10]` 输出。
+
+## Phase 2: 沉淀脚本
+- 新增 `tools/vercel/fetch_latest_deployment_logs.sh`，支持参数化 team/project/limit。
+- 默认输出最近 10 条，时间字段转成 UTC 字符串。
+
+## Phase 3: 沉淀 skill
+- 新增 `.codex/skills/vercel-api-log-context/SKILL.md`。
+- 写明前端报错场景下的日志排查流程、关键命令、上下文提取规范。
+- 运行 skill 校验工具检查 frontmatter 合法性。
+
+# Acceptance Criteria
+- 命令能返回 `askman-dev/bricks` 最新 deployment 的最后 10 条日志（按时间倒序）。
+- 新脚本可独立执行并输出结构化 JSON。
+- 新 skill 能描述触发条件、操作步骤、产出模板，且通过基础校验。

--- a/docs/plans/2026-04-01-12-39-UTC-agentsmd-api-debug-skill-routing.md
+++ b/docs/plans/2026-04-01-12-39-UTC-agentsmd-api-debug-skill-routing.md
@@ -1,0 +1,20 @@
+# Background
+The user asked to update the repository-level AGENTS.md guidance so that, when debugging API errors, the agent explicitly attempts to use the `vercel-api-log-context` skill to gather log context.
+
+# Goals
+1. Add a clear instruction in `AGENTS.md` for API/interface error debugging workflows.
+2. Ensure the instruction references the existing `vercel-api-log-context` skill by name.
+3. Keep the change minimal and easy to discover for future agent runs.
+
+# Implementation Plan (phased)
+## Phase 1: Update repository guidance
+- Add a dedicated section in `AGENTS.md` for API debugging behavior.
+- Insert an instruction that says to try `vercel-api-log-context` when troubleshooting API errors.
+
+## Phase 2: Verify formatting and placement
+- Confirm the new section is visible in the top-level guidance.
+- Confirm wording is imperative and unambiguous.
+
+# Acceptance Criteria
+- `AGENTS.md` includes a section that explicitly instructs agents to try the `vercel-api-log-context` skill during API error debugging.
+- The instruction is in the repository root `AGENTS.md` and applies to the full repo scope.

--- a/tools/vercel/fetch_latest_deployment_logs.sh
+++ b/tools/vercel/fetch_latest_deployment_logs.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEAM_ID="${TEAM_ID:-team_r9AW1oyPBmobWS7diUr7oYlz}"
+PROJECT_ID="${PROJECT_ID:-prj_clgP2QZnYLQxJuRrSVIiDjv612t4}"
+LIMIT="${1:-10}"
+
+if [[ -z "${VERCEL_TOKEN:-}" ]]; then
+  echo "ERROR: VERCEL_TOKEN is required" >&2
+  exit 1
+fi
+
+DEPLOY_UID=$(curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
+  "https://api.vercel.com/v6/deployments?teamId=${TEAM_ID}&projectId=${PROJECT_ID}&limit=1" \
+  | jq -r '.deployments[0].uid')
+
+if [[ -z "$DEPLOY_UID" || "$DEPLOY_UID" == "null" ]]; then
+  echo "ERROR: Could not find latest deployment uid" >&2
+  exit 1
+fi
+
+curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
+  "https://api.vercel.com/v3/deployments/${DEPLOY_UID}/events?teamId=${TEAM_ID}&limit=1000" \
+  | jq --argjson limit "$LIMIT" '
+    sort_by(.created)
+    | reverse
+    | .[:$limit]
+    | map({
+        created_utc: (.created / 1000 | strftime("%Y-%m-%dT%H:%M:%SZ")),
+        type,
+        text,
+        deploymentId,
+        id
+      })
+  '


### PR DESCRIPTION
### Motivation
- Provide an on-repo, repeatable workflow to fetch recent Vercel deployment logs for investigating frontend/backend errors. 
- Make it easy for agents to attempt log collection before proposing fixes by surfacing a named skill and usage guidance. 
- Capture the investigative plan and reproducible commands so humans and agents can re-run API calls in the container environment.

### Description
- Add a new skill file at `.codex/skills/vercel-api-log-context/SKILL.md` documenting when to run the skill, the step-by-step workflow, and example `curl`/`jq` commands to query the Vercel API. 
- Add a helper shell script `tools/vercel/fetch_latest_deployment_logs.sh` that requires `VERCEL_TOKEN`, accepts an optional `LIMIT` (default 10), looks up the latest deployment via `/v6/deployments`, fetches events from `/v3/deployments/{uid}/events`, sorts by `.created` and returns the most recent N entries with `created_utc`, `type`, `text`, `deploymentId`, and `id`. 
- Update `AGENTS.md` to recommend trying the `vercel-api-log-context` skill when debugging API/interface errors so agent workflows will attempt log collection first. 
- Add three planning documents in `docs/plans/` that record the background, goals, phased implementation plans, and acceptance criteria for log retrieval, scriptification, and agent routing.

### Testing
- No automated tests were run as part of this change. 
- The script was added executable (`mode 100755`) and is written with `set -euo pipefail` and `jq` usage to be robust in CI environments, but it has not been executed by CI in this PR. 
- Skill and documentation were added only and require downstream validation by existing repository tooling or manual runs to confirm API access and outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccfa973d40832dabf051e3292eb900)