### PR TITLE
Move model picker to Session Settings, add model-aware sessions, and remove composer voice button

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 /// Actions that can be triggered from the chat navigation page.
-enum ChatNavigationAction { manageAgents, sessionSettings, appSettings }
+enum ChatNavigationAction { manageAgents, appSettings }
 
 /// Full-page navigation for chat-related routes.
 class ChatNavigationPage extends StatelessWidget {
@@ -30,13 +30,6 @@ class ChatNavigationPage extends StatelessWidget {
               title: const Text('Manage Agents'),
               onTap: () {
                 Navigator.pop(context, ChatNavigationAction.manageAgents);
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.people_outline),
-              title: const Text('Session Settings'),
-              onTap: () {
-                Navigator.pop(context, ChatNavigationAction.sessionSettings);
               },
             ),
             ListTile(

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:workspace_fs/workspace_fs.dart';
 
 import '../agents/agents_screen.dart';
+import '../settings/llm_config_service.dart';
 import '../settings/settings_screen.dart';
 import '../session/session_settings_page.dart';
 import '../../services/agents_repository_factory.dart';
@@ -42,14 +43,18 @@ class _ChatScreenState extends State<ChatScreen> {
   final AgentClient _client = AgentCoreClient();
   final Map<String, AgentSession> _sessions = {};
   StreamSubscription<AgentSessionEvent>? _currentSubscription;
+  final LlmConfigService _llmConfigService = const LlmConfigService();
   AgentsRepository? _agentsRepository;
   List<AgentDefinition> _agents = [];
   AgentDefinition? _activeAgent;
+  List<LlmConfig> _configuredModels = const [];
+  String? _activeModelId;
 
   @override
   void initState() {
     super.initState();
     _loadAgents();
+    _loadModelPreferences();
   }
 
   @override
@@ -84,6 +89,37 @@ class _ChatScreenState extends State<ChatScreen> {
       _agents = definitions;
       _activeAgent ??= definitions.isNotEmpty ? definitions.first : null;
     });
+  }
+
+  Future<void> _loadModelPreferences() async {
+    try {
+      final configs = await _llmConfigService.fetchConfigs();
+      if (!mounted) return;
+      final defaultConfig = configs.firstWhere(
+        (config) => config.isDefault,
+        orElse: () => configs.isNotEmpty
+            ? configs.first
+            : const LlmConfig(
+                slotId: '',
+                provider: LlmProvider.anthropic,
+                baseUrl: '',
+                apiKey: '',
+                defaultModel: 'claude-sonnet-4-5',
+              ),
+      );
+      setState(() {
+        _configuredModels = configs;
+        if (_activeModelId == null || _activeModelId!.trim().isEmpty) {
+          _activeModelId = defaultConfig.defaultModel;
+        }
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _configuredModels = const [];
+        _activeModelId ??= 'claude-sonnet-4-5';
+      });
+    }
   }
 
   Future<List<AgentDefinition>> _readAgentDefinitions(
@@ -127,7 +163,7 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   AgentSettings _settingsForAgent(AgentDefinition? agent) {
-    final modelId = _resolveModelId(agent?.model);
+    final modelId = _resolveModelId(_activeModelId ?? agent?.model);
     return AgentSettings(
       provider: _providerForModel(modelId),
       model: modelId,
@@ -157,7 +193,8 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Future<AgentSession> _sessionForAgent(AgentDefinition? agent) async {
-    final key = agent?.name ?? '_default';
+    final key =
+        '${agent?.name ?? '_default'}::${_resolveModelId(_activeModelId ?? agent?.model)}';
     final existing = _sessions[key];
     if (existing != null) return existing;
     final session = _client.createSession(_settingsForAgent(agent));
@@ -359,9 +396,6 @@ class _ChatScreenState extends State<ChatScreen> {
       case ChatNavigationAction.manageAgents:
         await _openAgentsScreen();
         break;
-      case ChatNavigationAction.sessionSettings:
-        _openSessionSettings();
-        break;
       case ChatNavigationAction.appSettings:
         await _openSettingsScreen();
         break;
@@ -372,7 +406,12 @@ class _ChatScreenState extends State<ChatScreen> {
     Navigator.push(
       context,
       MaterialPageRoute<void>(
-        builder: (_) => SessionSettingsPage(coordinator: _participantManager),
+        builder: (_) => SessionSettingsPage(
+          coordinator: _participantManager,
+          currentModel: _activeModelId ?? 'claude-sonnet-4-5',
+          availableModels: _availableModelIds,
+          onModelSelected: _onModelSelectedFromSessionSettings,
+        ),
       ),
     ).then((_) => setState(() {}));
   }
@@ -394,7 +433,57 @@ class _ChatScreenState extends State<ChatScreen> {
       MaterialPageRoute<void>(builder: (_) => const SettingsScreen()),
     );
     if (!mounted) return;
+    await _loadModelPreferences();
     setState(() {});
+  }
+
+  List<String> get _availableModelIds {
+    final seen = <String>{};
+    final values = <String>[];
+    for (final config in _configuredModels) {
+      final modelId = config.defaultModel.trim();
+      if (modelId.isEmpty || seen.contains(modelId)) continue;
+      seen.add(modelId);
+      values.add(modelId);
+    }
+    if (values.isEmpty &&
+        _activeModelId != null &&
+        _activeModelId!.isNotEmpty) {
+      values.add(_activeModelId!);
+    }
+    return values;
+  }
+
+  Future<void> _onModelSelectedFromSessionSettings(String modelId) async {
+    if (modelId == _activeModelId) return;
+    if (mounted) {
+      setState(() => _activeModelId = modelId);
+    }
+    await _persistDefaultModel(modelId);
+  }
+
+  Future<void> _persistDefaultModel(String modelId) async {
+    if (_configuredModels.isEmpty) return;
+    final currentDefault = _configuredModels.firstWhere(
+      (config) => config.isDefault,
+      orElse: () => _configuredModels.first,
+    );
+    final updated =
+        currentDefault.copyWith(defaultModel: modelId, isDefault: true);
+    try {
+      final saved = await _llmConfigService.save(updated);
+      if (!mounted) return;
+      setState(() {
+        _configuredModels = _configuredModels
+            .map(
+              (cfg) =>
+                  cfg.id == saved.id ? saved : cfg.copyWith(isDefault: false),
+            )
+            .toList();
+      });
+    } catch (_) {
+      // Ignore persistence failures; in-session model still applies immediately.
+    }
   }
 
   PreferredSizeWidget _buildActiveAgentsIndicator() {
@@ -459,6 +548,13 @@ class _ChatScreenState extends State<ChatScreen> {
               ),
           ],
         ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.tune),
+            tooltip: 'Session settings',
+            onPressed: _openSessionSettings,
+          ),
+        ],
         bottom: _buildActiveAgentsIndicator(),
       ),
       body: Column(

--- a/apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
@@ -124,13 +124,6 @@ class _ComposerBarState extends State<ComposerBar>
     _hideMentions();
   }
 
-  void _handleVoiceInput() {
-    // TODO(chat): Implement voice input (placeholder for future).
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Voice input coming soon')),
-    );
-  }
-
   @override
   void dispose() {
     _spinController.dispose();
@@ -153,13 +146,6 @@ class _ComposerBarState extends State<ComposerBar>
           children: [
             Row(
               children: [
-                // Voice input button.
-                IconButton(
-                  onPressed: widget.isStreaming ? null : _handleVoiceInput,
-                  icon: const Icon(Icons.mic_outlined),
-                  tooltip: 'Voice input',
-                ),
-                const SizedBox(width: BricksSpacing.xs),
                 Expanded(
                   child: TextField(
                     controller: _controller,

--- a/apps/mobile_chat_app/lib/features/session/session_settings_page.dart
+++ b/apps/mobile_chat_app/lib/features/session/session_settings_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:agent_sdk_contract/agent_sdk_contract.dart';
 import 'package:design_system/design_system.dart';
@@ -11,19 +13,52 @@ class SessionSettingsPage extends StatefulWidget {
   const SessionSettingsPage({
     super.key,
     required this.coordinator,
+    required this.currentModel,
+    required this.availableModels,
+    this.onModelSelected,
   });
 
   /// The coordinator that owns the session's participant list.
   final SessionCoordinator coordinator;
+  final String currentModel;
+  final List<String> availableModels;
+  final Future<void> Function(String modelId)? onModelSelected;
 
   @override
   State<SessionSettingsPage> createState() => _SessionSettingsPageState();
 }
 
 class _SessionSettingsPageState extends State<SessionSettingsPage> {
+  late String _selectedModelId;
+  bool _savingModel = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedModelId = widget.currentModel;
+  }
+
   /// Returns a mutable snapshot of current participants.
   List<AgentParticipant> get _participants =>
       widget.coordinator.participants.participants.toList();
+
+  Future<void> _selectModel(String modelId) async {
+    if (_savingModel || modelId == _selectedModelId) return;
+    setState(() {
+      _selectedModelId = modelId;
+      _savingModel = true;
+    });
+    try {
+      await widget.onModelSelected?.call(modelId);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Model switched to $modelId')),
+      );
+    } finally {
+      if (!mounted) return;
+      setState(() => _savingModel = false);
+    }
+  }
 
   void _toggle(String agentId, bool enabled) {
     widget.coordinator.setEnabled(agentId, enabled);
@@ -41,33 +76,70 @@ class _SessionSettingsPageState extends State<SessionSettingsPage> {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Session Settings')),
-      body: participants.isEmpty
-          ? Center(
-              child: Padding(
-                padding: const EdgeInsets.all(BricksSpacing.xl),
-                child: Text(
-                  'No agents in this session.\nAdd agents to enable proactive participation.',
-                  textAlign: TextAlign.center,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.outline,
-                      ),
-                ),
+      body: ListView(
+        padding: const EdgeInsets.all(BricksSpacing.md),
+        children: [
+          Text(
+            'Model Selection',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: BricksSpacing.xs),
+          RadioGroup<String>(
+            groupValue: _selectedModelId,
+            onChanged: (value) {
+              if (_savingModel || value == null) return;
+              unawaited(_selectModel(value));
+            },
+            child: Column(
+              children: widget.availableModels
+                  .map(
+                    (modelId) => RadioListTile<String>(
+                      value: modelId,
+                      title: Text(modelId),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ),
+          if (_savingModel)
+            const Padding(
+              padding: EdgeInsets.only(bottom: BricksSpacing.md),
+              child: LinearProgressIndicator(),
+            ),
+          const SizedBox(height: BricksSpacing.sm),
+          Text(
+            'Agent Participation',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: BricksSpacing.xs),
+          if (participants.isEmpty)
+            Padding(
+              padding: const EdgeInsets.all(BricksSpacing.xl),
+              child: Text(
+                'No agents in this session.\nAdd agents to enable proactive participation.',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
               ),
             )
-          : ListView.separated(
-              padding: const EdgeInsets.all(BricksSpacing.md),
-              itemCount: participants.length,
-              separatorBuilder: (_, __) => const Divider(height: 1),
-              itemBuilder: (context, index) {
-                final p = participants[index];
-                return AgentParticipantTile(
-                  participant: p,
-                  onToggle: (enabled) => _toggle(p.agentId, enabled),
-                  onProbabilityChanged: (value) =>
-                      _setProbability(p.agentId, value),
-                );
-              },
-            ),
+          else
+            ...List.generate(participants.length, (index) {
+              final p = participants[index];
+              return Column(
+                children: [
+                  AgentParticipantTile(
+                    participant: p,
+                    onToggle: (enabled) => _toggle(p.agentId, enabled),
+                    onProbabilityChanged: (value) =>
+                        _setProbability(p.agentId, value),
+                  ),
+                  if (index < participants.length - 1) const Divider(height: 1),
+                ],
+              );
+            }),
+        ],
+      ),
     );
   }
 }

--- a/apps/mobile_chat_app/test/composer_bar_test.dart
+++ b/apps/mobile_chat_app/test/composer_bar_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_chat_app/features/chat/widgets/composer_bar.dart';
+
+void main() {
+  testWidgets('does not show add or microphone buttons', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: ComposerBar(
+            agents: [],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.add), findsNothing);
+    expect(find.byIcon(Icons.mic_outlined), findsNothing);
+  });
+
+  testWidgets('submits typed message when send is tapped', (tester) async {
+    String? sentText;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ComposerBar(
+            agents: const [],
+            onSend: (text) => sentText = text,
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'hello');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+
+    expect(sentText, equals('hello'));
+  });
+}

--- a/apps/mobile_chat_app/test/session_settings_test.dart
+++ b/apps/mobile_chat_app/test/session_settings_test.dart
@@ -11,7 +11,16 @@ void main() {
       final coordinator = ParticipantManager();
 
       await tester.pumpWidget(
-        MaterialApp(home: SessionSettingsPage(coordinator: coordinator)),
+        MaterialApp(
+          home: SessionSettingsPage(
+            coordinator: coordinator,
+            currentModel: 'claude-sonnet-4-5',
+            availableModels: const [
+              'claude-sonnet-4-5',
+              'gemini-3-flash-preview'
+            ],
+          ),
+        ),
       );
 
       expect(find.text('Session Settings'), findsOneWidget);
@@ -29,7 +38,16 @@ void main() {
         ));
 
       await tester.pumpWidget(
-        MaterialApp(home: SessionSettingsPage(coordinator: coordinator)),
+        MaterialApp(
+          home: SessionSettingsPage(
+            coordinator: coordinator,
+            currentModel: 'claude-sonnet-4-5',
+            availableModels: const [
+              'claude-sonnet-4-5',
+              'gemini-3-flash-preview'
+            ],
+          ),
+        ),
       );
 
       expect(find.text('Analyst'), findsOneWidget);
@@ -50,7 +68,16 @@ void main() {
         ));
 
       await tester.pumpWidget(
-        MaterialApp(home: SessionSettingsPage(coordinator: coordinator)),
+        MaterialApp(
+          home: SessionSettingsPage(
+            coordinator: coordinator,
+            currentModel: 'claude-sonnet-4-5',
+            availableModels: const [
+              'claude-sonnet-4-5',
+              'gemini-3-flash-preview'
+            ],
+          ),
+        ),
       );
 
       // Uncheck the checkbox.
@@ -75,12 +102,47 @@ void main() {
         ));
 
       await tester.pumpWidget(
-        MaterialApp(home: SessionSettingsPage(coordinator: coordinator)),
+        MaterialApp(
+          home: SessionSettingsPage(
+            coordinator: coordinator,
+            currentModel: 'claude-sonnet-4-5',
+            availableModels: const [
+              'claude-sonnet-4-5',
+              'gemini-3-flash-preview'
+            ],
+          ),
+        ),
       );
 
       expect(find.text('Analyst'), findsOneWidget);
       expect(find.text('Critic'), findsOneWidget);
       expect(find.byType(Slider), findsNWidgets(2));
+    });
+
+    testWidgets('selecting a model calls onModelSelected', (tester) async {
+      final coordinator = ParticipantManager();
+      String? selected;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SessionSettingsPage(
+            coordinator: coordinator,
+            currentModel: 'claude-sonnet-4-5',
+            availableModels: const [
+              'claude-sonnet-4-5',
+              'gemini-3-flash-preview'
+            ],
+            onModelSelected: (modelId) async {
+              selected = modelId;
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('gemini-3-flash-preview'));
+      await tester.pump();
+
+      expect(selected, equals('gemini-3-flash-preview'));
     });
   });
 

--- a/docs/plans/2026-04-01-11-11-UTC-chat-model-picker-fix.md
+++ b/docs/plans/2026-04-01-11-11-UTC-chat-model-picker-fix.md
@@ -1,0 +1,33 @@
+# Background
+The chat composer currently shows a placeholder voice button and does not provide a direct in-chat model switcher. Users also reported that sending a message can appear to stall with no visible model request/response behavior.
+
+# Goals
+1. Ensure message sending always uses a resolved default model when no explicit agent model is chosen.
+2. Replace the voice button in the composer with a plus button that opens model selection.
+3. Populate the model selection list from configured LLM configs and make selection apply to the current session and persisted default model.
+4. Keep behavior aligned with existing settings persistence semantics.
+
+# Implementation Plan (phased)
+## Phase 1: Model resolution and session behavior
+- Introduce chat-level state for current model and configured model options.
+- Load default model from `LlmConfigService.fetchDefault()` at startup and on settings return.
+- Update session creation keying so sessions are keyed by agent and model to avoid stale session settings.
+- Ensure `_settingsForAgent` prefers active in-chat selected model and falls back to configured default.
+
+## Phase 2: Composer UI and interaction
+- Replace microphone icon button with a plus icon button.
+- Add callback plumbing from `ComposerBar` to `ChatScreen` for opening model selection.
+- Show a popup menu from the plus button with all configured model IDs.
+- On selection, update in-memory active model for current chat and persist the same model as default via `LlmConfigService.save` on the currently default config.
+
+## Phase 3: Tests and regressions
+- Add/update widget tests for `ComposerBar` plus button behavior and callback execution.
+- Add/update chat screen tests for model selection fallback and persistence trigger behavior where feasible.
+- Run repository bootstrap then targeted Flutter tests and static checks.
+
+# Acceptance Criteria
+- Sending a message without explicit per-agent model selection uses a valid default model and starts a request flow.
+- The composer left icon is `+` (add) instead of voice/microphone.
+- Tapping `+` presents all configured model IDs.
+- Selecting a model applies immediately to current chat messages and updates default model persistence consistently with settings default model behavior.
+- Existing chat composer send/stop behavior remains functional.

--- a/docs/plans/2026-04-01-12-37-UTC-session-settings-model-picker.md
+++ b/docs/plans/2026-04-01-12-37-UTC-session-settings-model-picker.md
@@ -1,0 +1,30 @@
+# Background
+The previous implementation added model selection inside the chat composer. Product direction has changed: model selection should live in Session Settings, and Session Settings access should be promoted to a top-right chat action instead of sidebar navigation.
+
+# Goals
+1. Move model selection UI from composer/chat input area into Session Settings.
+2. Add a dedicated Session Settings button in Chat page top-right app bar actions.
+3. Remove Session Settings entry from the sidebar navigation page.
+4. Keep model selection behavior: apply to current session and persist as default model.
+
+# Implementation Plan (phased)
+## Phase 1: Chat layout and navigation
+- Remove composer model-picker callback wiring and related UI trigger.
+- Add AppBar action button in `ChatScreen` to open Session Settings directly.
+- Remove `sessionSettings` option from `ChatNavigationPage` enum and tile.
+
+## Phase 2: Session Settings model section
+- Extend `SessionSettingsPage` to accept current model and callbacks.
+- Load configured models from `LlmConfigService` and render selectable options in Session Settings.
+- On selection, notify chat screen to update in-memory current model and persist default model through existing save flow.
+
+## Phase 3: Validation and tests
+- Update/replace widget tests to cover new Session Settings model picker section.
+- Run bootstrap + targeted Flutter tests and analyzer checks.
+
+# Acceptance Criteria
+- Chat page has a top-right Session Settings icon/button that opens Session Settings.
+- Sidebar navigation no longer contains Session Settings entry.
+- Session Settings page displays configured model options.
+- Selecting a model in Session Settings updates current chat model and persists default model.
+- Message sending continues working with the selected/default model.


### PR DESCRIPTION
### Motivation
- Move model selection out of the composer into Session Settings and expose Session Settings from the chat app bar for easier access.
- Ensure chat sessions and requests always use a resolved default model and avoid stale sessions by scoping sessions to agent+model.
- Remove the placeholder voice input in the composer and centralize model persistence so in-session model changes apply immediately and can be saved as the default.

### Description
- Removed `ChatNavigationAction.sessionSettings` and the sidebar "Session Settings" tile, and added a top-right AppBar action in `ChatScreen` that opens session settings via `_openSessionSettings`.
- Introduced `LlmConfigService` usage in `ChatScreen` with `_loadModelPreferences`, `_configuredModels`, `_activeModelId`, `_availableModelIds`, `_onModelSelectedFromSessionSettings`, and `_persistDefaultModel` to load, present, and persist model selections.
- Keyed sessions by agent name plus resolved model id in `_sessionForAgent` and updated `_settingsForAgent` to prefer the active in-chat model, including model resolution logic in `_resolveModelId` and `_providerForModel`.
- Extended `SessionSettingsPage` API to accept `currentModel`, `availableModels`, and `onModelSelected`, and updated its UI to show a model selection radio group and the agent participation list; removed the microphone button from `ComposerBar` and adjusted related UI.

### Testing
- Ran Flutter widget tests for the chat UI, including the new `composer_bar_test.dart` and the updated `session_settings_test.dart`, which exercise absence of voice/add icons, message submission, agent tiles, and model selection, and they passed.
- Executed the updated test suite that touched `SessionSettingsPage` interactions and persistence callbacks, and those widget tests passed.
- Static analysis and existing widget tests were run locally and did not report regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccfd351bc8832d965dc9b196802cae)