### PR TITLE
Add OpenClaw plugin-first plans and OpenSpec proposal/design/tasks for Bricks integration

### DIFF
--- a/docs/plans/2026-04-03-04-12-UTC-bricks-openclaw-collab-docs.md
+++ b/docs/plans/2026-04-03-04-12-UTC-bricks-openclaw-collab-docs.md
@@ -1,0 +1,33 @@
+# Bricks × OpenClaw 协同文档计划
+
+## Background
+
+用户需要调用 openspec propose 流程，基于既有四份参考资料形成一份可执行的协同架构文档，并至少覆盖总体设计、后端设计、OpenClaw plugin 设计、客户端设计四个部分。
+
+## Goals
+
+1. 在 OpenSpec 变更目录中生成 proposal/design/tasks 三份核心工件。
+2. 文档内容完整覆盖四个必需设计部分。
+3. 输出内容可作为后续实现与跨团队评审的统一依据。
+
+## Implementation Plan (phased)
+
+### Phase 1: 变更骨架
+- 创建 `openspec/changes/bricks-openclaw-collab-docs/`。
+- 建立 `.openspec.yaml` 与三份文档骨架。
+
+### Phase 2: 内容编排
+- 在 `proposal.md` 固化目标、范围、关键决策。
+- 在 `design.md` 分四部分写入设计细节。
+- 在 `tasks.md` 输出交付清单与验收标准。
+
+### Phase 3: 校验与交付
+- 检查文档是否满足四部分约束与核心原则。
+- 完成 Git 提交并准备 PR 说明。
+
+## Acceptance Criteria
+
+- `openspec/changes/bricks-openclaw-collab-docs/` 下存在 `proposal.md`、`design.md`、`tasks.md`。
+- `design.md` 明确包含四个一级部分：总体设计、后端设计、openclaw plugin 设计、客户端设计。
+- `tasks.md` 包含可核查的交付项与验收项。
+- 计划文件保存于 `docs/plans/` 且名称含 `YYYY-MM-DD-HH-mm` 前缀。

--- a/docs/plans/2026-04-03-04-12-UTC-bricks-openclaw-collab-docs.md
+++ b/docs/plans/2026-04-03-04-12-UTC-bricks-openclaw-collab-docs.md
@@ -1,13 +1,13 @@
-# Bricks × OpenClaw 协同文档计划
+# Bricks × OpenClaw 协同文档计划（插件优先）
 
 ## Background
 
-用户需要调用 openspec propose 流程，基于既有四份参考资料形成一份可执行的协同架构文档，并至少覆盖总体设计、后端设计、OpenClaw plugin 设计、客户端设计四个部分。
+本计划聚焦第一阶段：通过 OpenClaw Channel Plugin 打通最小可行消息闭环，验证插件边界与收发路径后再扩展后端/客户端能力。阶段一不要求覆盖完整系统分层。
 
 ## Goals
 
 1. 在 OpenSpec 变更目录中生成 proposal/design/tasks 三份核心工件。
-2. 文档内容完整覆盖四个必需设计部分。
+2. 文档内容聚焦插件优先闭环：消息流时序、Plugin Bridge 接口、可靠性与安全最小集。
 3. 输出内容可作为后续实现与跨团队评审的统一依据。
 
 ## Implementation Plan (phased)
@@ -17,17 +17,17 @@
 - 建立 `.openspec.yaml` 与三份文档骨架。
 
 ### Phase 2: 内容编排
-- 在 `proposal.md` 固化目标、范围、关键决策。
-- 在 `design.md` 分四部分写入设计细节。
+- 在 `proposal.md` 固化插件优先目标、范围、关键决策。
+- 在 `design.md` 完成最小闭环时序、接口草案、可靠性/安全第一阶段规范。
 - 在 `tasks.md` 输出交付清单与验收标准。
 
 ### Phase 3: 校验与交付
-- 检查文档是否满足四部分约束与核心原则。
+- 检查文档是否满足插件闭环约束与核心原则。
 - 完成 Git 提交并准备 PR 说明。
 
 ## Acceptance Criteria
 
 - `openspec/changes/bricks-openclaw-collab-docs/` 下存在 `proposal.md`、`design.md`、`tasks.md`。
-- `design.md` 明确包含四个一级部分：总体设计、后端设计、openclaw plugin 设计、客户端设计。
+- `design.md` 包含最小闭环时序、Plugin Bridge 与 Callback 接口草案、可靠性/安全规范，以及第一阶段验收标准。
 - `tasks.md` 包含可核查的交付项与验收项。
 - 计划文件保存于 `docs/plans/` 且名称含 `YYYY-MM-DD-HH-mm` 前缀。

--- a/docs/plans/2026-04-03-05-01-UTC-openclaw-plugin-first-loop.md
+++ b/docs/plans/2026-04-03-05-01-UTC-openclaw-plugin-first-loop.md
@@ -1,0 +1,31 @@
+# OpenClaw 插件优先闭环计划
+
+## Background
+
+上一版文档覆盖面过大。当前需求调整为“先只看插件设计”，优先打通网页消息经服务器到 OpenClaw，再由插件回传服务器并同步客户端的最小闭环。
+
+## Goals
+
+1. 将 OpenSpec 文档聚焦到插件职责与消息双向流。
+2. 基于官方文档补齐插件能力调研结论。
+3. 给出可执行的接口草案与 Phase 1 验收标准。
+
+## Implementation Plan (phased)
+
+### Phase 1: 调研
+- 查阅 OpenClaw 官方插件文档（channel/plugin architecture）。
+- 提炼可直接用于“服务器-插件-服务器”闭环的能力。
+
+### Phase 2: 文档收敛
+- 重写 proposal/design/tasks 为“插件优先”版本。
+- 删除或下沉暂不需要的系统广域内容。
+
+### Phase 3: 验收标准
+- 增加最小闭环验收条目（dispatch/callback/cursor recovery）。
+- 输出下一步 PoC 任务清单。
+
+## Acceptance Criteria
+
+- `design.md` 的主线是插件闭环，不再以全系统展开为主。
+- 文档明确说明插件如何接收服务器消息、如何回传服务器。
+- `tasks.md` 包含可执行的 PoC 任务与可观测验收项。

--- a/openspec/changes/bricks-openclaw-collab-docs/.openspec.yaml
+++ b/openspec/changes/bricks-openclaw-collab-docs/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+change: bricks-openclaw-collab-docs
+issue: null

--- a/openspec/changes/bricks-openclaw-collab-docs/.openspec.yaml
+++ b/openspec/changes/bricks-openclaw-collab-docs/.openspec.yaml
@@ -1,3 +1,2 @@
 schema: spec-driven
 change: bricks-openclaw-collab-docs
-issue: null

--- a/openspec/changes/bricks-openclaw-collab-docs/design.md
+++ b/openspec/changes/bricks-openclaw-collab-docs/design.md
@@ -1,0 +1,145 @@
+# Design: Bricks × OpenClaw（插件优先最小闭环）
+
+## 0. 范围声明
+
+本版本只解决一个问题：
+**Bricks 服务器如何通过 OpenClaw 插件完成“发给 Claude 与收回回复”的可靠闭环。**
+
+不展开 OpenClaw 内部推理与多 Agent 编排。
+
+---
+
+## 1) 最小消息闭环（唯一主线）
+
+```text
+Web Client -> Bricks API -> DB(持久化)
+                         -> Plugin Bridge -> OpenClaw/Claude
+OpenClaw/Claude -> Channel Plugin outbound/inbound hook
+                -> Bricks Callback API -> DB(持久化)
+                -> Client Sync API (cursor pull; optional push)
+```
+
+### 1.1 客户端到服务器
+
+- 客户端 `POST /messages`（含 channel/thread/session 标识与消息体）。
+- Bricks 先落库，再返回 `200 + message_id + task_id`。
+- 随后异步触发“投递到 OpenClaw 插件”的后台任务。
+
+### 1.2 服务器到 OpenClaw（通过插件）
+
+- Bricks 不直接耦合模型细节，只调用“插件桥接接口”（Plugin Bridge）。
+- 插件桥接接口负责把 Bricks 消息转换为 OpenClaw 侧可处理事件。
+- 失败重试采用幂等键：`task_id + attempt`。
+
+### 1.3 OpenClaw 回复回传服务器
+
+- 当 Claude 完成回复后，插件通过回调 API（例如 `POST /callbacks/openclaw/messages`）把结果回传 Bricks。
+- Bricks 校验签名/令牌，落库为 assistant message，并更新 task 状态。
+
+### 1.4 服务器同步给客户端
+
+- 客户端以 cursor pull 获取 `seq > last_seq` 的增量消息作为一致性来源。
+- 可选 websocket/push 仅用于降低延迟，不作为一致性依据。
+
+---
+
+## 2) OpenClaw 插件能力调研结论（2026-04-03）
+
+> 结论来源于 OpenClaw 官方插件文档（见文末“调研来源”）。
+
+### 2.1 适合本场景的能力
+
+- `defineChannelPluginEntry`：定义 channel 插件入口。
+- `createChatChannelPlugin`：用声明式方式组合 security/pairing/threading/outbound。
+- `registerFull(api)`：注册运行时能力（包括 HTTP 路由/webhook）。
+- `outbound` 适配器：负责发送消息，并可返回 `messageId` 等结果元数据。
+
+### 2.2 “如何从服务器获取消息”
+
+官方示例偏向“平台 webhook 入站 -> 插件转发到 OpenClaw”。
+对 Bricks 场景建议两种实现：
+
+1. **Push 模式（推荐起步）**：Bricks 主动调用插件桥接接口投递消息；
+2. **Pull 模式（后续）**：插件定时向 Bricks 拉取待处理消息（需租约锁）。
+
+第一阶段先实现 Push 模式，路径短、问题可观测。
+
+### 2.3 “结束后如何告诉服务器”
+
+利用插件运行时/出站流程，在 Claude 产出后执行 Bricks 回调：
+
+- 回调最少字段：`task_id`, `channel_id`, `thread_id`, `role`, `content`, `provider_message_id`, `finished_at`。
+- 回调必须带签名（HMAC）与重放保护（timestamp + nonce）。
+- Bricks 按 `task_id` 幂等写入，避免重复回调造成脏数据。
+
+---
+
+## 3) 插件接口草案（先定协议，不绑实现）
+
+### 3.1 Bricks -> Plugin Bridge
+
+`POST /plugin-bridge/openclaw/dispatch`
+
+```json
+{
+  "task_id": "t_123",
+  "message_id": "m_123",
+  "channel_id": "c_1",
+  "thread_id": "th_9",
+  "user_id": "u_7",
+  "content": "请帮我总结这段文本",
+  "context": {"history_window": 20}
+}
+```
+
+返回：`202 Accepted` + `dispatch_id`。
+
+### 3.2 Plugin -> Bricks Callback
+
+`POST /callbacks/openclaw/messages`
+
+```json
+{
+  "task_id": "t_123",
+  "dispatch_id": "d_888",
+  "channel_id": "c_1",
+  "thread_id": "th_9",
+  "role": "assistant",
+  "content": "这是总结结果...",
+  "provider_message_id": "oc_msg_456",
+  "status": "completed",
+  "finished_at": "2026-04-03T05:00:00Z"
+}
+```
+
+---
+
+## 4) 可靠性与安全（第一阶段最小集）
+
+- 鉴权：Bricks -> Plugin 使用服务间 token；Plugin -> Bricks callback 使用 HMAC。
+- 幂等：`task_id` 全链路唯一；callback 以 `task_id + provider_message_id` 去重。
+- 可观测：记录 `dispatch_id`, provider latency, callback code, retry count。
+- 失败恢复：
+  - dispatch 失败进入重试队列；
+  - callback 失败由插件重试并指数退避；
+  - 客户端始终可通过 cursor pull 补齐结果。
+
+---
+
+## 5) 第一阶段验收标准（仅插件闭环）
+
+1. 网页发送消息后，Bricks 能立即返回已受理。
+2. 该消息可被成功投递到 OpenClaw 插件侧。
+3. Claude 回复后，插件可回调 Bricks 并落库。
+4. 客户端在断线重连后，仍可通过 cursor 拉到这条回复。
+
+---
+
+## 调研来源
+
+- OpenClaw 官方：Building Channel Plugins
+  https://docs.openclaw.ai/plugins/sdk-channel-plugins
+- OpenClaw 官方：Building Plugins
+  https://docs.openclaw.ai/plugins/building-plugins
+- OpenClaw 官方：Plugin Architecture
+  https://docs.openclaw.ai/plugins/architecture

--- a/openspec/changes/bricks-openclaw-collab-docs/design.md
+++ b/openspec/changes/bricks-openclaw-collab-docs/design.md
@@ -29,7 +29,7 @@ OpenClaw/Claude -> Channel Plugin outbound/inbound hook
 
 - Bricks 不直接耦合模型细节，只调用“插件桥接接口”（Plugin Bridge）。
 - 插件桥接接口负责把 Bricks 消息转换为 OpenClaw 侧可处理事件。
-- 失败重试采用幂等键：`task_id + attempt`。
+- 失败重试采用稳定的幂等键：`task_id`（或单独生成且在整个逻辑投递周期内保持不变的 `dispatch_id`）；`attempt` 仅作为日志、指标与链路追踪元数据，不参与幂等键计算。
 
 ### 1.3 OpenClaw 回复回传服务器
 

--- a/openspec/changes/bricks-openclaw-collab-docs/proposal.md
+++ b/openspec/changes/bricks-openclaw-collab-docs/proposal.md
@@ -1,39 +1,59 @@
-# Proposal: Bricks × OpenClaw 第一阶段（仅插件设计）
+# Proposal: Bricks × OpenClaw Phase 1 / 第一阶段（Plugin Design Only / 仅插件设计）
 
 ## What
 
 将原先较宽泛的 Bricks × OpenClaw 协同文档收敛为**第一阶段：仅聚焦 OpenClaw Channel Plugin 设计**，目标是打通最小可行消息闭环：
+Narrow the previously broad Bricks × OpenClaw collaboration document into **Phase 1: focused only on OpenClaw Channel Plugin design**, with the goal of establishing the smallest viable end-to-end message loop:
 
 1. 网页客户端发送消息到 Bricks 服务器并落库；
+   The web client sends a message to the Bricks server, where it is persisted.
 2. 服务器通过 OpenClaw 插件能力把消息交给 Claude/OpenClaw 处理；
+   The server passes the message to Claude/OpenClaw for processing through the OpenClaw plugin capability.
 3. Claude 产生回复后，通过插件回传到 Bricks 服务器；
+   After Claude generates a reply, the plugin sends it back to the Bricks server.
 4. 服务器再把回复同步给客户端（优先拉取一致性，可选推送优化）。
+   The server then synchronizes the reply back to the client, prioritizing pull-based consistency with optional push optimization.
 
 ## Why
 
-当前最紧迫问题不是完整系统分层，而是验证“**消息如何经由插件完成双向流转**”。
+当前最紧迫问题不是完整系统分层，而是验证"**消息如何经由插件完成双向流转**"。
+The most urgent issue is not full system layering, but validating **how messages complete bidirectional flow through the plugin**.
 如果插件边界不清晰，后续后端/客户端方案会反复返工。
+If the plugin boundary remains unclear, subsequent backend and client work will likely be reworked repeatedly.
 
-因此本次提案采用“先打通链路、再扩展能力”的简化策略：
+因此本次提案采用"先打通链路、再扩展能力"的简化策略：
+Therefore, this proposal adopts a simplified strategy of "connect the flow first, then expand capabilities":
 
 - 暂缓复杂多 Agent 编排细节；
+  Defer complex multi-agent orchestration details.
 - 暂缓完整客户端组件体系；
+  Defer the full client component system.
 - 先完成 OpenClaw 插件职责、生命周期、收发路径与回执机制定义。
+  First define the OpenClaw plugin responsibilities, lifecycle, send/receive paths, and acknowledgment mechanism.
 
 ## Non-goals
 
 - 不在本提案内实现完整业务代码；
+  Implementing complete production business code in this proposal.
 - 不设计 OpenClaw/Claude 内部推理细节；
+  Designing OpenClaw/Claude internal reasoning details.
 - 不扩展到完整权限系统矩阵与全量 UI 组件。
+  Expanding to the full permission matrix and the complete set of UI components.
 
 ## Key Decisions
 
 - 以官方 Channel Plugin 能力为准绳：`defineChannelPluginEntry` + `createChatChannelPlugin`。
+  Use the official Channel Plugin capabilities as the baseline: `defineChannelPluginEntry` + `createChatChannelPlugin`.
 - 入站（平台 -> OpenClaw）由插件在 `registerFull` 注册 HTTP route/webhook 后转发处理。
+  For inbound traffic (platform -> OpenClaw), the plugin registers an HTTP route/webhook in `registerFull` and forwards the request for processing.
 - 出站（OpenClaw -> 平台/Bricks）由插件 `outbound` 适配器负责发送，并返回 message metadata。
-- Bricks 与插件通信建议采用“事件投递 + 状态查询”双通道，保证离线可恢复。
+  For outbound traffic (OpenClaw -> platform/Bricks), the plugin `outbound` adapter is responsible for sending and returning message metadata.
+- Bricks 与插件通信建议采用"事件投递 + 状态查询"双通道，保证离线可恢复。
+  Communication between Bricks and the plugin should use a dual-channel approach of "event delivery + status query" to ensure offline recovery.
 
 ## Deliverables
 
 - `design.md`：仅保留插件导向的最小闭环设计与时序。
+  `design.md`: retain only the plugin-oriented minimal closed-loop design and sequence flow.
 - `tasks.md`：插件能力调研、接口定义、PoC 验证任务。
+  `tasks.md`: plugin capability research, interface definition, and PoC validation tasks.

--- a/openspec/changes/bricks-openclaw-collab-docs/proposal.md
+++ b/openspec/changes/bricks-openclaw-collab-docs/proposal.md
@@ -1,0 +1,39 @@
+# Proposal: Bricks × OpenClaw 第一阶段（仅插件设计）
+
+## What
+
+将原先较宽泛的 Bricks × OpenClaw 协同文档收敛为**第一阶段：仅聚焦 OpenClaw Channel Plugin 设计**，目标是打通最小可行消息闭环：
+
+1. 网页客户端发送消息到 Bricks 服务器并落库；
+2. 服务器通过 OpenClaw 插件能力把消息交给 Claude/OpenClaw 处理；
+3. Claude 产生回复后，通过插件回传到 Bricks 服务器；
+4. 服务器再把回复同步给客户端（优先拉取一致性，可选推送优化）。
+
+## Why
+
+当前最紧迫问题不是完整系统分层，而是验证“**消息如何经由插件完成双向流转**”。
+如果插件边界不清晰，后续后端/客户端方案会反复返工。
+
+因此本次提案采用“先打通链路、再扩展能力”的简化策略：
+
+- 暂缓复杂多 Agent 编排细节；
+- 暂缓完整客户端组件体系；
+- 先完成 OpenClaw 插件职责、生命周期、收发路径与回执机制定义。
+
+## Non-goals
+
+- 不在本提案内实现完整业务代码；
+- 不设计 OpenClaw/Claude 内部推理细节；
+- 不扩展到完整权限系统矩阵与全量 UI 组件。
+
+## Key Decisions
+
+- 以官方 Channel Plugin 能力为准绳：`defineChannelPluginEntry` + `createChatChannelPlugin`。
+- 入站（平台 -> OpenClaw）由插件在 `registerFull` 注册 HTTP route/webhook 后转发处理。
+- 出站（OpenClaw -> 平台/Bricks）由插件 `outbound` 适配器负责发送，并返回 message metadata。
+- Bricks 与插件通信建议采用“事件投递 + 状态查询”双通道，保证离线可恢复。
+
+## Deliverables
+
+- `design.md`：仅保留插件导向的最小闭环设计与时序。
+- `tasks.md`：插件能力调研、接口定义、PoC 验证任务。

--- a/openspec/changes/bricks-openclaw-collab-docs/tasks.md
+++ b/openspec/changes/bricks-openclaw-collab-docs/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: 插件优先闭环（Phase 1）
+
+## A. 调研与接口冻结
+
+- [x] 基于 OpenClaw 官方文档确认 Channel Plugin 核心能力与入口形式
+- [x] 明确 inbound/outbound 在本方案中的职责分工
+- [x] 输出 Bricks -> Plugin 与 Plugin -> Bricks 最小接口草案
+
+## B. PoC 任务（仅闭环）
+
+- [ ] 在 Bricks 增加 `POST /plugin-bridge/openclaw/dispatch`（或等价服务间入口）
+- [ ] 在插件侧实现 dispatch 接收与 OpenClaw 调用链路
+- [ ] 在插件侧实现 `POST /callbacks/openclaw/messages` 回调至 Bricks
+- [ ] 在 Bricks 端完成 callback 验签、幂等落库、任务状态推进
+- [ ] 在客户端验证 cursor 重连可见性（断网后恢复）
+
+## C. 验收
+
+- [ ] 单条消息从网页发出后，可在 Bricks 与插件日志中追踪同一 `task_id`
+- [ ] Claude 回复可在 1 次或多次重试后可靠回传并最终落库
+- [ ] 客户端不依赖 websocket 也能拉到完整回复


### PR DESCRIPTION
- [x] Review all PR comments and identify changes needed
- [x] Fix `.openspec.yaml`: remove `issue: null` (field omitted when tracking issue unknown)
- [x] Fix `design.md:32`: change idempotency key from `task_id + attempt` to stable `task_id`/`dispatch_id`; `attempt` is metadata-only
- [x] Update `docs/plans/2026-04-03-04-12-UTC-bricks-openclaw-collab-docs.md`: align goals/acceptance criteria with plugin-first scope (remove conflicting 4-section requirement)
- [x] Make `proposal.md` bilingual (Chinese + English inline) for cross-team reviewability
- [x] Code review completed