### PR TITLE
Fix chat mobile menus/layout and remove legacy route entries

### DIFF
--- a/apps/web_chat_app/src/App.tsx
+++ b/apps/web_chat_app/src/App.tsx
@@ -54,8 +54,6 @@ export function App() {
     <main className="mobile-shell">
       <Routes>
         <Route path="/chat" element={<ChatPage />} />
-        <Route path="/workspace" element={<Navigate to="/chat" replace />} />
-        <Route path="/resources" element={<Navigate to="/chat" replace />} />
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/settings/model" element={<ModelSettingsPage />} />
         <Route path="*" element={<Navigate to="/chat" replace />} />

--- a/apps/web_chat_app/src/__tests__/app.test.tsx
+++ b/apps/web_chat_app/src/__tests__/app.test.tsx
@@ -40,7 +40,7 @@ test('shows login entry when user is not authenticated', async () => {
   });
 });
 
-test('renders mobile chat shell after auth and routes to chat', async () => {
+test('renders mobile chat shell after auth on /chat', async () => {
   const fetchSpy = mockFetch([
     {
       ok: true,
@@ -51,7 +51,7 @@ test('renders mobile chat shell after auth and routes to chat', async () => {
     },
   ]);
   render(
-    <MemoryRouter initialEntries={['/workspace']}>
+    <MemoryRouter initialEntries={['/chat']}>
       <App />
     </MemoryRouter>,
   );

--- a/apps/web_chat_app/src/pages/ChatPage.tsx
+++ b/apps/web_chat_app/src/pages/ChatPage.tsx
@@ -1,17 +1,84 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { apiPost } from '../lib/api';
+import { apiGet, apiPost } from '../lib/api';
 
 type ChatMessage = { role: 'user' | 'assistant'; content: string };
 
-type MenuState = 'none' | 'main' | 'section';
+type ChatSectionConfig = {
+  id: string;
+  category: string;
+  provider: string;
+  config?: {
+    section_id?: string;
+    section_name?: string;
+    created_at?: string;
+  };
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+const SECTION_CATEGORY = 'chat_section';
+
+function toSectionSlug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '') || `sub-${Date.now()}`;
+}
 
 export function ChatPage() {
   const navigate = useNavigate();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
-  const [menuState, setMenuState] = useState<MenuState>('none');
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [composerMenuOpen, setComposerMenuOpen] = useState(false);
+  const [sectionMenuOpen, setSectionMenuOpen] = useState(false);
+  const [sections, setSections] = useState<ChatSectionConfig[]>([]);
+  const [activeSectionId, setActiveSectionId] = useState('main');
+
+  useEffect(() => {
+    void loadSections();
+  }, []);
+
+  async function loadSections() {
+    try {
+      const data = await apiGet<ChatSectionConfig[]>(`/api/config?category=${SECTION_CATEGORY}`);
+      const sorted = [...data].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+      setSections(sorted);
+      if (sorted.length > 0 && activeSectionId === 'main') {
+        setActiveSectionId(sorted[0].id);
+      }
+    } catch {
+      setSections([]);
+    }
+  }
+
+  async function createSubsection() {
+    const defaultName = `sub-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}`;
+    const name = prompt('Subsection name', defaultName)?.trim();
+    if (!name) return;
+
+    try {
+      const created = await apiPost<ChatSectionConfig>('/api/config', {
+        category: SECTION_CATEGORY,
+        provider: 'workspace',
+        is_default: false,
+        config: {
+          section_id: toSectionSlug(name),
+          section_name: name,
+          created_at: new Date().toISOString(),
+        },
+      });
+      setSections((prev) => [created, ...prev]);
+      setActiveSectionId(created.id);
+      setSectionMenuOpen(false);
+    } catch {
+      alert('Failed to create subsection. Please retry.');
+    }
+  }
 
   async function onSubmit(event: FormEvent) {
     event.preventDefault();
@@ -30,7 +97,7 @@ export function ChatPage() {
       const response = await apiPost<{ text: string }>('/api/chat/respond', {
         taskId,
         idempotencyKey: taskId,
-        channelId: 'chat',
+        channelId: activeSectionId,
         sessionId,
         userMessageId,
         assistantMessageId,
@@ -47,6 +114,9 @@ export function ChatPage() {
     }
   }
 
+  const activeSectionName =
+    sections.find((section) => section.id === activeSectionId)?.config?.section_name ?? '主区';
+
   return (
     <section className="chat-mobile-page">
       <header className="mobile-topbar">
@@ -54,7 +124,11 @@ export function ChatPage() {
           type="button"
           className="icon-btn"
           aria-label="Open navigation menu"
-          onClick={() => setMenuState((prev) => (prev === 'main' ? 'none' : 'main'))}
+          onClick={() => {
+            setDrawerOpen((prev) => !prev);
+            setComposerMenuOpen(false);
+            setSectionMenuOpen(false);
+          }}
         >
           ☰
         </button>
@@ -62,22 +136,28 @@ export function ChatPage() {
         <button
           type="button"
           className="section-btn"
-          onClick={() => setMenuState((prev) => (prev === 'section' ? 'none' : 'section'))}
+          onClick={() => {
+            setSectionMenuOpen((prev) => !prev);
+            setComposerMenuOpen(false);
+            setDrawerOpen(false);
+          }}
         >
-          主区 ▾
+          {activeSectionName} ▾
         </button>
       </header>
 
       <div className="chat-meta">🧰 ask</div>
       <article className="chat-message-card" aria-label="message-list">
         {messages.length === 0 ? (
-          <p>No messages yet.</p>
+          <p className="chat-empty">No messages yet.</p>
         ) : (
-          messages.map((m, index) => (
-            <p key={`${m.role}-${index}`}>
-              <strong>{m.role === 'user' ? 'You' : 'Assistant'}：</strong>
-              {m.content}
-            </p>
+          messages.map((message, index) => (
+            <div
+              key={`${message.role}-${index}`}
+              className={`chat-bubble chat-bubble--${message.role}`}
+            >
+              {message.content}
+            </div>
           ))
         )}
       </article>
@@ -92,8 +172,12 @@ export function ChatPage() {
           <button
             type="button"
             className="icon-btn"
-            aria-label="Context menu"
-            onClick={() => setMenuState((prev) => (prev === 'main' ? 'none' : 'main'))}
+            aria-label="Composer options"
+            onClick={() => {
+              setComposerMenuOpen((prev) => !prev);
+              setDrawerOpen(false);
+              setSectionMenuOpen(false);
+            }}
           >
             ☷
           </button>
@@ -108,38 +192,104 @@ export function ChatPage() {
         </div>
       </form>
 
-      {menuState === 'main' && (
-        <div className="floating-menu floating-menu--left" role="menu" aria-label="Main menu">
+      {drawerOpen && (
+        <>
+          <button
+            className="drawer-overlay"
+            type="button"
+            aria-label="Close navigation menu"
+            onClick={() => setDrawerOpen(false)}
+          />
+          <aside className="sidebar-drawer" aria-label="Navigation drawer">
+            <button
+              type="button"
+              className="icon-btn drawer-close"
+              aria-label="Close drawer"
+              onClick={() => setDrawerOpen(false)}
+            >
+              ✕
+            </button>
+            <button
+              type="button"
+              className="drawer-item"
+              onClick={() => {
+                setMessages([]);
+                setDrawerOpen(false);
+              }}
+            >
+              New context
+            </button>
+            <button
+              type="button"
+              className="drawer-item"
+              onClick={() => {
+                navigate('/settings/model');
+                setDrawerOpen(false);
+              }}
+            >
+              Model
+            </button>
+            <Link to="/settings" className="drawer-item" onClick={() => setDrawerOpen(false)}>
+              Settings
+            </Link>
+          </aside>
+        </>
+      )}
+
+      {composerMenuOpen && (
+        <div className="floating-menu floating-menu--composer" role="menu" aria-label="Composer menu">
           <button
             type="button"
             role="menuitem"
-            onClick={() => { setMessages([]); setMenuState('none'); }}
+            onClick={() => {
+              setMessages([]);
+              setComposerMenuOpen(false);
+            }}
           >
-            New context
+            Clear messages
           </button>
           <button
             type="button"
             role="menuitem"
-            onClick={() => { navigate('/settings/model'); setMenuState('none'); }}
+            onClick={() => {
+              navigate('/settings/model');
+              setComposerMenuOpen(false);
+            }}
           >
             Model
           </button>
-          <button type="button" role="menuitem" disabled>
-            Agents (coming soon)
-          </button>
-          <Link to="/settings" role="menuitem" onClick={() => setMenuState('none')}>
-            Settings
-          </Link>
         </div>
       )}
 
-      {menuState === 'section' && (
+      {sectionMenuOpen && (
         <div className="floating-menu floating-menu--right" role="menu" aria-label="Section menu">
-          <button type="button" role="menuitem" onClick={() => setMenuState('none')}>Back to main</button>
-          <button type="button" role="menuitem" disabled>New subsection (coming soon)</button>
-          <button type="button" role="menuitem" className="muted-item">
-            sub-2026-04-09-21-31-16-844
+          <button type="button" role="menuitem" onClick={() => void createSubsection()}>
+            新建子区
           </button>
+          {sections.length === 0 ? (
+            <button type="button" role="menuitem" className="muted-item" disabled>
+              暂无子区
+            </button>
+          ) : (
+            sections.map((section) => {
+              const selected = section.id === activeSectionId;
+              return (
+                <button
+                  key={section.id}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={selected}
+                  className={selected ? 'menu-item-selected' : undefined}
+                  onClick={() => {
+                    setActiveSectionId(section.id);
+                    setSectionMenuOpen(false);
+                  }}
+                >
+                  {section.config?.section_name ?? section.config?.section_id ?? section.id}
+                </button>
+              );
+            })
+          )}
         </div>
       )}
     </section>

--- a/apps/web_chat_app/src/pages/ModelSettingsPage.tsx
+++ b/apps/web_chat_app/src/pages/ModelSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { apiGet, apiPost, apiPut, apiDelete } from '../lib/api';
 
 type Provider = 'anthropic' | 'google_ai_studio';
@@ -37,14 +38,17 @@ const PROVIDER_DEFAULTS: Record<Provider, { baseUrl: string; model: string }> = 
 };
 
 function toSlotId(model: string): string {
-  return model
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '') || `slot-${Date.now()}`;
+  return (
+    model
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '') || `slot-${Date.now()}`
+  );
 }
 
 export function ModelSettingsPage() {
+  const navigate = useNavigate();
   const [configs, setConfigs] = useState<ApiConfig[]>([]);
   const [activeIdx, setActiveIdx] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -92,9 +96,7 @@ export function ModelSettingsPage() {
     setProvider(p);
     setBaseUrl(config.config?.endpoint ?? PROVIDER_DEFAULTS[p].baseUrl);
     setApiKey('');
-    setDefaultModel(
-      config.config?.model_preferences?.default_model ?? PROVIDER_DEFAULTS[p].model,
-    );
+    setDefaultModel(config.config?.model_preferences?.default_model ?? PROVIDER_DEFAULTS[p].model);
   }
 
   function resetFormToDefaults(p: Provider) {
@@ -184,8 +186,16 @@ export function ModelSettingsPage() {
 
   if (loading) {
     return (
-      <section className="page-panel">
-        <p>Loading...</p>
+      <section className="settings-mobile-page">
+        <header className="settings-mobile-header model-settings-topbar">
+          <button type="button" className="icon-btn" aria-label="Back" onClick={() => navigate('/settings')}>
+            ←
+          </button>
+          <h1>Model Settings</h1>
+        </header>
+        <section className="page-panel">
+          <p>Loading...</p>
+        </section>
       </section>
     );
   }
@@ -193,110 +203,118 @@ export function ModelSettingsPage() {
   const hasExisting = configs.length > 0 && !!configs[activeIdx]?.id;
 
   return (
-    <section className="page-panel">
-      <h2>Model Settings</h2>
-      <p className="page-subtitle">Configure your LLM provider, API key, and default model.</p>
+    <section className="settings-mobile-page">
+      <header className="settings-mobile-header model-settings-topbar">
+        <button type="button" className="icon-btn" aria-label="Back" onClick={() => navigate('/settings')}>
+          ←
+        </button>
+        <h1>Model Settings</h1>
+      </header>
 
-      {configs.length > 1 && (
-        <div className="form-row">
-          <label htmlFor="config-select">Configuration</label>
-          <select
-            id="config-select"
-            value={activeIdx}
-            onChange={(e) => {
-              const idx = Number(e.target.value);
-              setActiveIdx(idx);
-              hydrateForm(configs[idx]);
-              setError(null);
-              setSuccess(null);
-            }}
-          >
-            {configs.map((c, i) => (
-              <option key={c.id || i} value={i}>
-                {c.config?.model_preferences?.default_model ?? `Config ${i + 1}`}
-                {c.is_default ? ' (default)' : ''}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
+      <section className="page-panel">
+        <p className="page-subtitle">Configure your LLM provider, API key, and default model.</p>
 
-      <form className="settings-form" onSubmit={(e) => void handleSave(e)}>
-        <div className="form-row">
-          <label htmlFor="provider">Provider</label>
-          <select
-            id="provider"
-            value={provider}
-            onChange={(e) => handleProviderChange(e.target.value as Provider)}
-          >
-            <option value="anthropic">Anthropic</option>
-            <option value="google_ai_studio">Google AI Studio</option>
-          </select>
-        </div>
-
-        <div className="form-row">
-          <label htmlFor="base-url">Base URL</label>
-          <input
-            id="base-url"
-            type="url"
-            value={baseUrl}
-            onChange={(e) => setBaseUrl(e.target.value)}
-            required
-          />
-        </div>
-
-        <div className="form-row">
-          <label htmlFor="api-key">API Key</label>
-          <div className="input-group">
-            <input
-              id="api-key"
-              type={showKey ? 'text' : 'password'}
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-              placeholder={hasExisting ? '(unchanged – enter to update)' : 'Enter API key'}
-              autoComplete="off"
-            />
-            <button
-              type="button"
-              className="toggle-btn"
-              onClick={() => setShowKey((v) => !v)}
-              aria-label={showKey ? 'Hide API key' : 'Show API key'}
+        {configs.length > 1 && (
+          <div className="form-row">
+            <label htmlFor="config-select">Configuration</label>
+            <select
+              id="config-select"
+              value={activeIdx}
+              onChange={(e) => {
+                const idx = Number(e.target.value);
+                setActiveIdx(idx);
+                hydrateForm(configs[idx]);
+                setError(null);
+                setSuccess(null);
+              }}
             >
-              {showKey ? 'Hide' : 'Show'}
-            </button>
+              {configs.map((c, i) => (
+                <option key={c.id || i} value={i}>
+                  {c.config?.model_preferences?.default_model ?? `Config ${i + 1}`}
+                  {c.is_default ? ' (default)' : ''}
+                </option>
+              ))}
+            </select>
           </div>
-        </div>
+        )}
 
-        <div className="form-row">
-          <label htmlFor="default-model">Default Model</label>
-          <input
-            id="default-model"
-            type="text"
-            value={defaultModel}
-            onChange={(e) => setDefaultModel(e.target.value)}
-            required
-          />
-        </div>
-
-        {error && <p className="form-feedback form-feedback--error">{error}</p>}
-        {success && <p className="form-feedback form-feedback--success">{success}</p>}
-
-        <div className="form-actions">
-          <button type="submit" disabled={saving}>
-            {saving ? 'Saving…' : 'Save'}
-          </button>
-          {hasExisting && (
-            <button
-              type="button"
-              className="danger-btn"
-              disabled={deleting}
-              onClick={() => void handleDelete()}
+        <form className="settings-form" onSubmit={(e) => void handleSave(e)}>
+          <div className="form-row">
+            <label htmlFor="provider">Provider</label>
+            <select
+              id="provider"
+              value={provider}
+              onChange={(e) => handleProviderChange(e.target.value as Provider)}
             >
-              {deleting ? 'Deleting…' : 'Delete'}
+              <option value="anthropic">Anthropic</option>
+              <option value="google_ai_studio">Google AI Studio</option>
+            </select>
+          </div>
+
+          <div className="form-row">
+            <label htmlFor="base-url">Base URL</label>
+            <input
+              id="base-url"
+              type="url"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="form-row">
+            <label htmlFor="api-key">API Key</label>
+            <div className="input-group">
+              <input
+                id="api-key"
+                type={showKey ? 'text' : 'password'}
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={hasExisting ? '(unchanged – enter to update)' : 'Enter API key'}
+                autoComplete="off"
+              />
+              <button
+                type="button"
+                className="toggle-btn"
+                onClick={() => setShowKey((v) => !v)}
+                aria-label={showKey ? 'Hide API key' : 'Show API key'}
+              >
+                {showKey ? 'Hide' : 'Show'}
+              </button>
+            </div>
+          </div>
+
+          <div className="form-row">
+            <label htmlFor="default-model">Default Model</label>
+            <input
+              id="default-model"
+              type="text"
+              value={defaultModel}
+              onChange={(e) => setDefaultModel(e.target.value)}
+              required
+            />
+          </div>
+
+          {error && <p className="form-feedback form-feedback--error">{error}</p>}
+          {success && <p className="form-feedback form-feedback--success">{success}</p>}
+
+          <div className="form-actions">
+            <button type="submit" disabled={saving}>
+              {saving ? 'Saving…' : 'Save'}
             </button>
-          )}
-        </div>
-      </form>
+            {hasExisting && (
+              <button
+                type="button"
+                className="danger-btn"
+                disabled={deleting}
+                onClick={() => void handleDelete()}
+              >
+                {deleting ? 'Deleting…' : 'Delete'}
+              </button>
+            )}
+          </div>
+        </form>
+      </section>
     </section>
   );
 }

--- a/apps/web_chat_app/src/styles.css
+++ b/apps/web_chat_app/src/styles.css
@@ -35,7 +35,8 @@ body {
 
 .chat-mobile-page {
   min-height: 100vh;
-  padding-bottom: 22px;
+  display: flex;
+  flex-direction: column;
   position: relative;
 }
 
@@ -85,19 +86,46 @@ body {
 
 .chat-message-card {
   margin: 0 16px;
-  min-height: 340px;
-  max-height: calc(100vh - 360px);
+  flex: 1;
   overflow: auto;
   background: #d2d5de;
   border-radius: 14px;
   padding: 16px;
   line-height: 1.45;
-  font-size: 38px;
-  font-size: clamp(18px, 4.5vw, 38px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chat-empty {
+  margin: auto 0;
+  color: #515763;
+}
+
+.chat-bubble {
+  border-radius: 14px;
+  padding: 10px 12px;
+  font-size: clamp(15px, 4vw, 20px);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.chat-bubble--user {
+  align-self: flex-end;
+  max-width: 85%;
+  background: #3b82f6;
+  color: #fff;
+}
+
+.chat-bubble--assistant {
+  align-self: stretch;
+  width: 100%;
+  background: #f4f6fb;
+  color: #263041;
 }
 
 .composer-mobile {
-  margin: 12px 16px 0;
+  margin: 12px 16px 12px;
   border: 2px solid #808592;
   border-radius: 22px;
   background: #e4e6ec;
@@ -109,8 +137,7 @@ body {
   background: transparent;
   border: 0;
   color: #3c414a;
-  font-size: 46px;
-  font-size: clamp(18px, 5.2vw, 46px);
+  font-size: clamp(16px, 4.5vw, 24px);
   outline: none;
 }
 
@@ -133,6 +160,53 @@ body {
   opacity: 0.45;
 }
 
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  border: 0;
+  background: rgba(22, 28, 39, 0.3);
+  z-index: 24;
+}
+
+.sidebar-drawer {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: min(280px, 78vw);
+  height: 100%;
+  background: #eceef5;
+  border-right: 1px solid #c1c6d1;
+  box-shadow: 8px 0 24px rgba(20, 24, 34, 0.2);
+  z-index: 25;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px 10px;
+}
+
+.drawer-close {
+  align-self: flex-end;
+  font-size: 24px;
+  margin-bottom: 8px;
+}
+
+.drawer-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  font-size: 18px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: #1f232c;
+  padding: 12px 14px;
+  text-decoration: none;
+}
+
+.drawer-item:hover {
+  background: #dce0ea;
+}
+
 .floating-menu {
   position: absolute;
   background: #d9dce5;
@@ -143,16 +217,16 @@ body {
   z-index: 20;
 }
 
-.floating-menu--left {
-  left: 8px;
-  bottom: 132px;
+.floating-menu--composer {
+  left: 16px;
+  bottom: 112px;
   width: 220px;
 }
 
 .floating-menu--right {
   right: 16px;
   top: 74px;
-  width: 220px;
+  width: 240px;
 }
 
 .floating-menu button,
@@ -160,11 +234,11 @@ body {
   display: block;
   width: 100%;
   text-align: left;
-  font-size: 18px;
+  font-size: 16px;
   border: 0;
   background: transparent;
   color: #1f232c;
-  padding: 14px 16px;
+  padding: 12px 14px;
   text-decoration: none;
   border-top: 1px solid #c1c6d1;
 }
@@ -175,7 +249,11 @@ body {
 }
 
 .floating-menu .muted-item {
-  color: #373d47;
+  color: #737d90;
+}
+
+.menu-item-selected {
+  background: #c6d4ef !important;
 }
 
 .settings-mobile-page {
@@ -196,6 +274,11 @@ body {
   margin-right: 44px;
   font-size: 24px;
   font-weight: 500;
+}
+
+.model-settings-topbar {
+  border-bottom: 1px solid #c4c9d3;
+  background: #d6dae3;
 }
 
 .settings-mobile-list {

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -35,12 +35,13 @@ products:
           - route: /api/chat/respond
             route_hint: apps/node_backend/src/routes/chat.ts
         smoke_checks:
-          - 在 Chat 页面发送一条消息后可看到 user 与 assistant 消息。
+          - 在 Chat 页面发送一条消息后可看到 user 与 assistant 分样式气泡，assistant 气泡占满消息区宽度。
           - API 失败时出现可见错误反馈消息。
+          - 顶部主区菜单可读取后端 section 配置并切换 channelId。
 
       - feature_id: mobile_navigation_shell
         name: 移动端导航壳层
-        user_value: 用户可通过顶部按钮打开主菜单、区段菜单并进入设置页。
+        user_value: 用户可通过顶部按钮打开侧边栏、区段菜单并进入设置页。
         entry_paths:
           - shell: MobileTopbar
             route_hint: apps/web_chat_app/src/pages/ChatPage.tsx
@@ -48,7 +49,8 @@ products:
             route_hint: apps/web_chat_app/src/pages/SettingsPage.tsx
         smoke_checks:
           - 顶部栏展示 Bricks 标题、左侧菜单按钮与右侧主区按钮。
-          - 点击左侧菜单出现浮层项，新上下文/模型/Agents/信息可见。
+          - 点击左上按钮打开侧边栏抽屉，显示 New context / Model / Settings。
+          - 输入框左下角按钮打开独立 composer 菜单且定位在底部左侧。
           - 设置页展示 Model Settings / Manage Agents / Sign Out 条目。
 
   - product_id: node_backend

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -56,6 +56,7 @@ index:
       - apps/web_chat_app/src/App.tsx
       - apps/web_chat_app/src/pages/ChatPage.tsx
       - apps/web_chat_app/src/pages/SettingsPage.tsx
+      - apps/web_chat_app/src/pages/ModelSettingsPage.tsx
       - apps/web_chat_app/src/styles.css
     doc_index:
       - docs/architecture.md
@@ -67,9 +68,13 @@ index:
       - topbar
       - menu
       - settings
+      - drawer
       - overlay
+      - subsection
     change_risks:
+      - 抽屉菜单与 composer/section 菜单状态耦合时，可能出现误触发错误菜单。
       - 浮层定位与层级错误会导致菜单遮挡或不可点击。
+      - 主区数据读取失败会导致 channelId 退化为默认值并影响会话隔离。
       - 顶部导航按钮文案或可访问名称变更会破坏自动化测试选择器。
 
   - feature_id: backend_auth

--- a/docs/plans/2026-04-09-16-02-UTC-chat-ui-routing-fixes.md
+++ b/docs/plans/2026-04-09-16-02-UTC-chat-ui-routing-fixes.md
@@ -1,0 +1,40 @@
+# Background
+The current React chat UI still exposes legacy `/workspace` and `/resources` paths and has multiple mobile interaction regressions in the chat screen and model settings screen. The user reported incorrect menu behavior, misplaced composer/menu layout, and incomplete section data handling.
+
+# Goals
+- Remove `/workspace` and `/resources` route entry points.
+- Fix chat page interactions/layout:
+  - top-left button opens a sidebar/drawer instead of the wrong menu,
+  - composer config menu anchors to the lower-left composer button,
+  - composer is pinned at the bottom,
+  - messages render as role-specific bubbles with assistant bubbles full width,
+  - top-right section menu uses fetched data and supports creating subsections.
+- Add a top back header row to model settings page.
+
+# Implementation Plan (phased)
+## Phase 1: Routing and page structure
+1. Update app routes to remove workspace/resources entries and ensure fallback goes to `/chat`.
+2. Update tests that currently rely on `/workspace` redirect behavior.
+
+## Phase 2: Chat page UX and data flow
+1. Split chat menu state into separate states for drawer, composer menu, and section menu.
+2. Implement section config fetch from backend (`/api/config?category=chat_section`) and map to menu options.
+3. Implement subsection creation via POST to `/api/config` and refresh list.
+4. Apply chat layout changes for bottom-pinned composer and message bubble variants.
+
+## Phase 3: Model settings header and styling
+1. Add back button header row to model settings page.
+2. Extend CSS for drawer, anchored menus, bubbles, and model settings top bar.
+
+## Phase 4: Validation and maps
+1. Run web chat app tests.
+2. Update code maps for changed entry/menu behavior and regression focus.
+
+# Acceptance Criteria
+- App no longer registers `/workspace` or `/resources` routes.
+- Top-left chat button opens sidebar drawer; composer config button opens a separate lower-left anchored menu.
+- Composer appears at the bottom of chat viewport.
+- User and assistant messages render with distinct bubble styles; assistant bubble spans full message width.
+- Section menu data is fetched from backend and includes working “new subsection” action.
+- Model settings page has a visible top back row and title row.
+- `npm test` for `apps/web_chat_app` passes.


### PR DESCRIPTION
### Motivation
- Remove legacy `/workspace` and `/resources` route entry points and make `/chat` the primary chat entry. 
- Fix multiple mobile chat UX regressions: top-left should open a sidebar drawer, composer options should open a bottom-left anchored menu, composer should sit at the bottom, messages should display role-specific bubbles with assistant bubbles full-width, and the top-right section menu should use real backend data. 
- Ensure model settings has a visible top back row for navigation. 

### Description
- Remove legacy routes from `App.tsx` and keep `/chat`, `/settings`, and `/settings/model` with fallback to `/chat` (file: `apps/web_chat_app/src/App.tsx`).
- Refactor `ChatPage` to separate menu state into `drawerOpen`, `composerMenuOpen`, and `sectionMenuOpen`; implement a sidebar drawer, composer-anchored floating menu, and a section menu that fetches real data from the backend at `GET /api/config?category=chat_section` and can create subsections via `POST /api/config` (file: `apps/web_chat_app/src/pages/ChatPage.tsx`).
- Change message rendering to role-specific bubbles and update CSS so assistant bubbles stretch full width and the composer is visually pinned to the bottom (files: `apps/web_chat_app/src/pages/ChatPage.tsx`, `apps/web_chat_app/src/styles.css`).
- Add a top back header (Back + title) to `ModelSettingsPage` for both loading and normal states and wire navigation with `useNavigate` (file: `apps/web_chat_app/src/pages/ModelSettingsPage.tsx`).
- Update tests and repository maps: changed the web test to start at `/chat`, created an implementation plan under `docs/plans/`, and updated `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` to reflect the UI/entry changes; modified feature IDs: `chat_session` and `mobile_navigation_shell` (updated smoke checks and change risks). Recommended smoke checks: verify left drawer opens and contains New context/Model/Settings, composer options open anchored at bottom-left, section menu loads backend sections and supports “new subsection”, messages render with user/assistant bubbles and assistant spans full width, and model settings shows the top back header.

### Testing
- Ran `cd apps/web_chat_app && npm install` and `cd apps/web_chat_app && npm run build`, and the production build completed successfully after a small compatibility fix (`replaceAll` -> `replace`); build succeeded. 
- Ran unit tests with `cd apps/web_chat_app && npm test` (Vitest): all tests passed (1 test file, 3 tests passed). 
- Validated code map YAMLs with `npx js-yaml docs/code_maps/feature_map.yaml` and `npx js-yaml docs/code_maps/logic_map.yaml`: validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cd486890832d9011dae3a21e4f8f)