### PR TITLE
refactor: modernize smoke tests workflow for Node/React stack

### DIFF
--- a/.github/workflows/ai_provider_smoke_test.yml
+++ b/.github/workflows/ai_provider_smoke_test.yml
@@ -1,55 +1,71 @@
-name: AI Provider Smoke Tests
+name: Smoke Tests
 
 on:
   pull_request:
     paths:
-      - 'packages/bricks_ai_smoke_test/**'
+      - 'apps/node_backend/**'
+      - 'apps/web_chat_app/**'
       - '.github/workflows/ai_provider_smoke_test.yml'
   workflow_dispatch:
-  # Optional: Run on a schedule (every day at 2 AM UTC)
-  # schedule:
-  #   - cron: '0 2 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: smoke-tests-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
-  smoke-test:
+  backend-smoke:
+    name: Backend smoke checks
     runs-on: ubuntu-latest
-    env:
-      HAS_ANTHROPIC_KEY: ${{ secrets.TEST_ANTHROPIC_API_KEY != '' }}
-      HAS_GEMINI_KEY: ${{ secrets.TEST_GEMINI_API_KEY != '' }}
+    defaults:
+      run:
+        working-directory: apps/node_backend
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          channel: stable
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: apps/node_backend/package-lock.json
 
-      - name: Install Melos
-        run: |
-          dart pub global activate melos
-          echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Bootstrap dependencies
-        run: melos bootstrap
+      - name: Run backend type-check
+        run: npm run type-check
 
-      - name: Run smoke tests (unit tests only, no real API calls)
-        working-directory: packages/bricks_ai_smoke_test
-        run: dart test --exclude-tags=integration
+      - name: Run backend tests
+        run: npm test
 
-      - name: Run integration tests with real APIs
-        if: ${{ env.HAS_ANTHROPIC_KEY == 'true' || env.HAS_GEMINI_KEY == 'true' }}
-        working-directory: packages/bricks_ai_smoke_test
-        env:
-          TEST_ANTHROPIC_BASE_URL: ${{ vars.TEST_ANTHROPIC_BASE_URL }}
-          TEST_ANTHROPIC_API_KEY: ${{ secrets.TEST_ANTHROPIC_API_KEY }}
-          TEST_GEMINI_BASE_URL: ${{ vars.TEST_GEMINI_BASE_URL }}
-          TEST_GEMINI_API_KEY: ${{ secrets.TEST_GEMINI_API_KEY }}
-        run: dart test --tags=integration
+  frontend-smoke:
+    name: Frontend smoke checks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web_chat_app
 
-      - name: Log test results
-        if: always()
-        run: |
-          echo "Smoke tests completed"
-          echo "Check test output above for results"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: apps/web_chat_app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run frontend tests
+        run: npm test
+
+      - name: Build frontend
+        run: npm run build

--- a/docs/plans/2026-04-09-16-40-UTC-smoke-tests-workflow-refactor.md
+++ b/docs/plans/2026-04-09-16-40-UTC-smoke-tests-workflow-refactor.md
@@ -1,0 +1,25 @@
+# Smoke Tests Workflow Refactor Plan
+
+## Background
+The existing smoke test GitHub Actions workflow (`.github/workflows/ai_provider_smoke_test.yml`) is still tied to the removed Flutter/Dart smoke test package (`packages/bricks_ai_smoke_test`) and Melos bootstrap flow. After the frontend stack migration to React + Node.js, this workflow no longer reflects the active code paths and creates maintenance risk.
+
+## Goals
+1. Refactor the smoke test workflow to validate the current runnable stack (Node backend + React frontend).
+2. Keep smoke checks fast and deterministic for pull requests.
+3. Preserve manual dispatch support for on-demand verification.
+
+## Implementation Plan (phased)
+1. **Workflow scope and trigger update**
+   - Replace obsolete Flutter/Dart package path filters with active paths under `apps/node_backend`, `apps/web_chat_app`, and the workflow file itself.
+2. **Job topology refactor**
+   - Replace legacy Melos-based single job with two explicit jobs:
+     - backend smoke checks (Node install + type-check + tests)
+     - frontend smoke checks (Node install + tests + build)
+   - Add least-privilege workflow permissions and concurrency cancellation.
+3. **Validation**
+   - Validate workflow YAML syntax locally and ensure only intended workflow/plan files changed.
+
+## Acceptance Criteria
+1. `.github/workflows/ai_provider_smoke_test.yml` no longer depends on Flutter, Dart, Melos, or removed package directories.
+2. Pull requests touching backend/frontend source paths trigger smoke checks for the corresponding Node/React stack.
+3. The workflow remains manually runnable via `workflow_dispatch`.


### PR DESCRIPTION
### Motivation
- Replace the legacy Flutter/Dart/Melos smoke test workflow that referenced removed packages and no longer matched the repository's runtime stack. 
- Provide fast, deterministic smoke checks for pull requests that touch the active Node backend and React frontend while preserving manual `workflow_dispatch` runs.

### Description
- Update `.github/workflows/ai_provider_smoke_test.yml` to trigger on `apps/node_backend/**`, `apps/web_chat_app/**`, and the workflow file itself, and keep `workflow_dispatch` for manual runs. 
- Add least-privilege workflow `permissions` (`contents: read`) and a `concurrency` group to cancel in-progress duplicate runs. 
- Replace the single Melos/Flutter job with two explicit jobs: `backend-smoke` and `frontend-smoke`, each using Node setup and `npm` flows; the backend job runs `npm ci`, `npm run type-check`, and `npm test`, and the frontend job runs `npm ci`, `npm test`, and `npm run build`; removed all Flutter/Dart/Melos steps and real-API conditional logic. 
- Add a persisted implementation plan at `docs/plans/2026-04-09-16-40-UTC-smoke-tests-workflow-refactor.md`, and do not update code maps because this change is CI/workflow-only and does not alter feature entry points or application runtime logic.

### Testing
- Validated workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ai_provider_smoke_test.yml')"`, which succeeded. 
- Backend smoke run: `npm ci`, `npm run type-check`, and `npm test` (Vitest) all succeeded (backend tests: 4 files, 51 tests passed). 
- Frontend smoke run: `npm ci`, `npm test` (Vitest) and `npm run build` all succeeded (frontend tests: 1 file, 3 tests passed and production build emitted `dist/`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d06f5850832db9a7f282fdb0abb3)