### PR TITLE
fix(web_chat_app): restore mobile drawer agents/channels navigation

### DIFF
--- a/apps/web_chat_app/src/__tests__/app.test.tsx
+++ b/apps/web_chat_app/src/__tests__/app.test.tsx
@@ -95,3 +95,34 @@ test('sends chat message and displays assistant reply', async () => {
     expect(screen.getByText(/Hello from assistant/)).toBeInTheDocument();
   });
 });
+
+test('mobile drawer matches navigation groups with agents and channels', async () => {
+  const user = userEvent.setup();
+  mockFetch([
+    {
+      ok: true,
+      json: {
+        user: { id: 'u1', email: 'demo@example.com', created_at: '2024-01-01', updated_at: '2024-01-01' },
+        oauth_connections: [],
+      },
+    },
+    { ok: true, json: [] },
+  ]);
+  render(
+    <MemoryRouter initialEntries={['/chat']}>
+      <App />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Open navigation menu' })).toBeInTheDocument();
+  });
+
+  await user.click(screen.getByRole('button', { name: 'Open navigation menu' }));
+
+  expect(screen.getByRole('heading', { name: 'Navigation' })).toBeInTheDocument();
+  expect(screen.getByText('Current Chat')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Agents section' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Channels section' })).toBeInTheDocument();
+  expect(screen.getByText('默认频道')).toBeInTheDocument();
+});

--- a/apps/web_chat_app/src/pages/ChatPage.tsx
+++ b/apps/web_chat_app/src/pages/ChatPage.tsx
@@ -36,6 +36,8 @@ export function ChatPage() {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [composerMenuOpen, setComposerMenuOpen] = useState(false);
   const [sectionMenuOpen, setSectionMenuOpen] = useState(false);
+  const [agentsExpanded, setAgentsExpanded] = useState(true);
+  const [channelsExpanded, setChannelsExpanded] = useState(true);
   const [sections, setSections] = useState<ChatSectionConfig[]>([]);
   const [activeSectionId, setActiveSectionId] = useState('main');
 
@@ -116,6 +118,10 @@ export function ChatPage() {
 
   const activeSectionName =
     sections.find((section) => section.id === activeSectionId)?.config?.section_name ?? '主区';
+
+  function createDrawerChannel() {
+    void createSubsection().finally(() => setDrawerOpen(false));
+  }
 
   return (
     <section className="chat-mobile-page">
@@ -201,37 +207,136 @@ export function ChatPage() {
             onClick={() => setDrawerOpen(false)}
           />
           <aside className="sidebar-drawer" aria-label="Navigation drawer">
+            <header className="drawer-header">
+              <button
+                type="button"
+                className="icon-btn drawer-back"
+                aria-label="Close navigation menu"
+                onClick={() => setDrawerOpen(false)}
+              >
+                ←
+              </button>
+              <h2>Navigation</h2>
+              <Link
+                to="/settings"
+                className="icon-btn drawer-settings-link"
+                aria-label="Open settings"
+                onClick={() => setDrawerOpen(false)}
+              >
+                ⚙
+              </Link>
+            </header>
+
             <button
               type="button"
-              className="icon-btn drawer-close"
-              aria-label="Close drawer"
-              onClick={() => setDrawerOpen(false)}
-            >
-              ✕
-            </button>
-            <button
-              type="button"
-              className="drawer-item"
+              className="drawer-current-chat"
               onClick={() => {
                 setMessages([]);
                 setDrawerOpen(false);
               }}
             >
-              New context
+              <span className="drawer-current-icon" aria-hidden="true">
+                💬
+              </span>
+              <span>
+                <strong>Current Chat</strong>
+                <small>You are here</small>
+              </span>
             </button>
-            <button
-              type="button"
-              className="drawer-item"
-              onClick={() => {
-                navigate('/settings/model');
-                setDrawerOpen(false);
-              }}
-            >
-              Model
-            </button>
-            <Link to="/settings" className="drawer-item" onClick={() => setDrawerOpen(false)}>
-              Settings
-            </Link>
+
+            <section className="drawer-group">
+              <div className="drawer-group-header">
+                <button
+                  type="button"
+                  className="drawer-group-toggle"
+                  aria-label="Agents section"
+                  aria-expanded={agentsExpanded}
+                  onClick={() => setAgentsExpanded((prev) => !prev)}
+                >
+                  <span>{agentsExpanded ? '⌄' : '›'} Agents</span>
+                </button>
+                <button
+                  type="button"
+                  className="drawer-group-action"
+                  onClick={() => {
+                    alert('未开发的功能');
+                  }}
+                >
+                  ⚙ 配置
+                </button>
+              </div>
+              {agentsExpanded && (
+                <p className="drawer-empty-hint" role="status">
+                  在设置中新建 Agents
+                </p>
+              )}
+            </section>
+
+            <section className="drawer-group">
+              <div className="drawer-group-header">
+                <button
+                  type="button"
+                  className="drawer-group-toggle"
+                  aria-label="Channels section"
+                  aria-expanded={channelsExpanded}
+                  onClick={() => setChannelsExpanded((prev) => !prev)}
+                >
+                  <span>{channelsExpanded ? '⌄' : '›'} 频道</span>
+                </button>
+                <button
+                  type="button"
+                  className="drawer-group-action"
+                  onClick={() => {
+                    createDrawerChannel();
+                  }}
+                >
+                  ⊕ 新建频道
+                </button>
+              </div>
+              {channelsExpanded && (
+                <div className="drawer-channel-list">
+                  {sections.length === 0 ? (
+                    <button
+                      type="button"
+                      className={`drawer-channel-item ${activeSectionId === 'main' ? 'selected' : ''}`}
+                      onClick={() => {
+                        setActiveSectionId('main');
+                        setDrawerOpen(false);
+                      }}
+                    >
+                      <span className="drawer-channel-icon">⌂</span>
+                      <span>
+                        <strong>默认频道</strong>
+                        <small>Default channel</small>
+                      </span>
+                    </button>
+                  ) : (
+                    sections.map((section) => {
+                      const selected = section.id === activeSectionId;
+                      return (
+                        <button
+                          key={section.id}
+                          type="button"
+                          className={`drawer-channel-item ${selected ? 'selected' : ''}`}
+                          onClick={() => {
+                            setActiveSectionId(section.id);
+                            setDrawerOpen(false);
+                          }}
+                        >
+                          <span className="drawer-channel-icon">⌂</span>
+                          <span>
+                            <strong>
+                              {section.config?.section_name ?? section.config?.section_id ?? section.id}
+                            </strong>
+                            <small>Default channel</small>
+                          </span>
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+              )}
+            </section>
           </aside>
         </>
       )}

--- a/apps/web_chat_app/src/styles.css
+++ b/apps/web_chat_app/src/styles.css
@@ -172,39 +172,138 @@ body {
   position: absolute;
   left: 0;
   top: 0;
-  width: min(280px, 78vw);
+  width: min(420px, 100vw);
   height: 100%;
-  background: #eceef5;
-  border-right: 1px solid #c1c6d1;
+  background: #e7e9f0;
+  border-right: 1px solid #ced3df;
   box-shadow: 8px 0 24px rgba(20, 24, 34, 0.2);
   z-index: 25;
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 16px 10px;
+  padding: 0;
 }
 
-.drawer-close {
-  align-self: flex-end;
-  font-size: 24px;
-  margin-bottom: 8px;
+.drawer-header {
+  height: 92px;
+  padding: 0 14px;
+  border-bottom: 1px solid #cfd5df;
+  display: grid;
+  grid-template-columns: 42px 1fr 42px;
+  align-items: center;
 }
 
-.drawer-item {
-  display: block;
-  width: 100%;
-  text-align: left;
-  font-size: 18px;
-  border: 0;
-  border-radius: 10px;
-  background: transparent;
-  color: #1f232c;
-  padding: 12px 14px;
+.drawer-header h2 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 500;
+}
+
+.drawer-back {
+  font-size: 34px;
+}
+
+.drawer-settings-link {
+  color: #4b5260;
+  font-size: 28px;
   text-decoration: none;
 }
 
-.drawer-item:hover {
-  background: #dce0ea;
+.drawer-current-chat {
+  margin: 18px 16px 10px;
+  border: 0;
+  border-radius: 12px;
+  padding: 12px;
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 10px;
+  align-items: start;
+  text-align: left;
+  background: transparent;
+  color: #1f232c;
+  cursor: pointer;
+}
+
+.drawer-current-icon {
+  font-size: 25px;
+}
+
+.drawer-current-chat strong,
+.drawer-channel-item strong {
+  display: block;
+  font-size: 20px;
+  font-weight: 500;
+}
+
+.drawer-current-chat small,
+.drawer-channel-item small {
+  display: block;
+  margin-top: 2px;
+  color: #3f6f9f;
+  font-size: 18px;
+}
+
+.drawer-group {
+  padding: 4px 16px;
+  border-top: 1px solid #cfd5df;
+}
+
+.drawer-group-header {
+  height: 52px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.drawer-group-toggle,
+.drawer-group-action {
+  border: 0;
+  background: transparent;
+  color: #1f232c;
+  padding: 0;
+  cursor: pointer;
+}
+
+.drawer-group-toggle {
+  font-size: 18px;
+}
+
+.drawer-group-action {
+  color: #2f6194;
+  font-size: 18px;
+}
+
+.drawer-empty-hint {
+  margin: 8px 0 18px;
+  color: #1f232c;
+  font-size: 20px;
+}
+
+.drawer-channel-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+
+.drawer-channel-item {
+  border: 0;
+  background: transparent;
+  border-radius: 10px;
+  padding: 12px 10px;
+  text-align: left;
+  display: grid;
+  grid-template-columns: 26px 1fr;
+  gap: 8px;
+  color: #1f232c;
+}
+
+.drawer-channel-item.selected {
+  background: #dde2ee;
+}
+
+.drawer-channel-icon {
+  font-size: 22px;
+  color: #2f6194;
 }
 
 .floating-menu {

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -49,7 +49,8 @@ products:
             route_hint: apps/web_chat_app/src/pages/SettingsPage.tsx
         smoke_checks:
           - 顶部栏展示 Bricks 标题、左侧菜单按钮与右侧主区按钮。
-          - 点击左上按钮打开侧边栏抽屉，显示 New context / Model / Settings。
+          - 点击左上按钮打开侧边栏抽屉，显示 Navigation 头部、Current Chat、Agents 与频道分组。
+          - Agents 分组可展开显示“在设置中新建 Agents”占位提示，频道分组可展示默认频道与“新建频道”操作。
           - 输入框左下角按钮打开独立 composer 菜单且定位在底部左侧。
           - 设置页展示 Model Settings / Manage Agents / Sign Out 条目。
 

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -67,6 +67,8 @@ index:
       - mobile
       - topbar
       - menu
+      - agents
+      - channels
       - settings
       - drawer
       - overlay

--- a/docs/plans/2026-04-09-16-20-UTC-nav-refactor-fix.md
+++ b/docs/plans/2026-04-09-16-20-UTC-nav-refactor-fix.md
@@ -1,0 +1,20 @@
+# Background
+Refactor branch navigation drawer on mobile differs from main branch behavior/UI: it shows a simple three-item list with a close button, while main branch includes current chat context, agents section, and channels section.
+
+# Goals
+- Compare current refactor implementation against main branch intended behavior.
+- Restore layout, functionality, and logic parity with main-branch navigation (agents + channels structure).
+- Validate with targeted checks.
+
+# Implementation Plan (phased)
+1. Identify navigation drawer component(s) and related state/actions in current branch.
+2. Compare with main-branch expected structure (agents/channels/current-chat) and locate regressions from refactor.
+3. Implement fixes to align component layout and behaviors with main branch.
+4. Run relevant lint/tests and sanity checks for touched package(s).
+5. Update code map files if entry/logic/test/doc index changed; otherwise document why no update is needed.
+
+# Acceptance Criteria
+- Mobile navigation drawer renders current chat, agents section, and channels section rather than a flat three-item menu.
+- Interaction handlers for agent/channel actions work consistently with main branch.
+- No regressions introduced in touched module checks.
+- If code maps are unchanged, final report explains why no code map update is required.


### PR DESCRIPTION
### Motivation
- The refactor branch replaced the mobile navigation drawer with a flat three-item menu and a close button, diverging from the main-branch UX that shows `Current Chat`, an `Agents` group, and a `频道` (channels) group. 
- The change aims to restore layout, interactions, and logic parity so the drawer exposes agents and channels and reuses existing section/channel logic.

### Description
- Replaced the simple drawer UI with a grouped navigation panel in `apps/web_chat_app/src/pages/ChatPage.tsx`, adding `Agents` and `频道` collapsible sections, a `Current Chat` row, section toggles and a drawer header with settings link, and wired channel selection to existing `sections` state. 
- Added local state and helper `createDrawerChannel` to reuse the existing `createSubsection` flow for new channels. 
- Adjusted drawer styling in `apps/web_chat_app/src/styles.css` to match the mobile layout (width, header, group visuals, channel item styles). 
- Added a regression test `mobile drawer matches navigation groups with agents and channels` in `apps/web_chat_app/src/__tests__/app.test.tsx` to assert drawer content and accessibility names. 
- Updated repository metadata: changed `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` to reflect the drawer structure and keywords, and added an implementation plan at `docs/plans/2026-04-09-16-20-UTC-nav-refactor-fix.md`.

### Testing
- Ran the Web app unit tests with `cd apps/web_chat_app && npm test -- --run`, and all tests passed (4 tests). 
- Built the web app with `cd apps/web_chat_app && npm run build`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d1c78048832d84d17fb7d69b7b31)