### PR TITLE
Chat mobile: align sidebar header, fix message/composer layout, and restructure section menu

### DIFF
--- a/apps/web_chat_app/src/pages/ChatPage.tsx
+++ b/apps/web_chat_app/src/pages/ChatPage.tsx
@@ -116,10 +116,11 @@ export function ChatPage() {
     }
   }
 
+  const activeSection = sections.find((section) => section.id === activeSectionId);
   const activeSectionName =
     activeSectionId === 'main'
       ? '主区'
-      : sections.find((section) => section.id === activeSectionId)?.config?.section_name ?? '主区';
+      : activeSection?.config?.section_name ?? activeSection?.config?.section_id ?? activeSection?.id ?? '主区';
 
   function createDrawerChannel() {
     void createSubsection().finally(() => setDrawerOpen(false));
@@ -370,7 +371,7 @@ export function ChatPage() {
 
       {sectionMenuOpen && (
         <div className="floating-menu floating-menu--right" role="menu" aria-label="Section menu">
-          <div className="menu-group">
+          <div className="menu-group" role="none">
             <button
               type="button"
               role="menuitemradio"

--- a/apps/web_chat_app/src/pages/ChatPage.tsx
+++ b/apps/web_chat_app/src/pages/ChatPage.tsx
@@ -117,7 +117,9 @@ export function ChatPage() {
   }
 
   const activeSectionName =
-    sections.find((section) => section.id === activeSectionId)?.config?.section_name ?? '主区';
+    activeSectionId === 'main'
+      ? '主区'
+      : sections.find((section) => section.id === activeSectionId)?.config?.section_name ?? '主区';
 
   function createDrawerChannel() {
     void createSubsection().finally(() => setDrawerOpen(false));
@@ -328,7 +330,7 @@ export function ChatPage() {
                             <strong>
                               {section.config?.section_name ?? section.config?.section_id ?? section.id}
                             </strong>
-                            <small>Default channel</small>
+                            <small>子区</small>
                           </span>
                         </button>
                       );
@@ -368,9 +370,23 @@ export function ChatPage() {
 
       {sectionMenuOpen && (
         <div className="floating-menu floating-menu--right" role="menu" aria-label="Section menu">
-          <button type="button" role="menuitem" onClick={() => void createSubsection()}>
-            新建子区
-          </button>
+          <div className="menu-group">
+            <button
+              type="button"
+              role="menuitemradio"
+              aria-checked={activeSectionId === 'main'}
+              className={activeSectionId === 'main' ? 'menu-item-selected' : undefined}
+              onClick={() => {
+                setActiveSectionId('main');
+                setSectionMenuOpen(false);
+              }}
+            >
+              主区
+            </button>
+            <button type="button" role="menuitem" onClick={() => void createSubsection()}>
+              新建子区
+            </button>
+          </div>
           {sections.length === 0 ? (
             <button type="button" role="menuitem" className="muted-item" disabled>
               暂无子区

--- a/apps/web_chat_app/src/styles.css
+++ b/apps/web_chat_app/src/styles.css
@@ -34,10 +34,11 @@ body {
 }
 
 .chat-mobile-page {
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   position: relative;
+  overflow: hidden;
 }
 
 .mobile-topbar {
@@ -87,10 +88,10 @@ body {
 .chat-message-card {
   margin: 0 16px;
   flex: 1;
+  min-height: 0;
   overflow: auto;
-  background: #d2d5de;
   border-radius: 14px;
-  padding: 16px;
+  padding: 12px 0;
   line-height: 1.45;
   display: flex;
   flex-direction: column;
@@ -125,11 +126,14 @@ body {
 }
 
 .composer-mobile {
-  margin: 12px 16px 12px;
+  margin: 10px 16px 12px;
   border: 2px solid #808592;
   border-radius: 22px;
   background: #e4e6ec;
   padding: 16px 16px 12px;
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
 }
 
 .composer-mobile input {
@@ -184,22 +188,24 @@ body {
 }
 
 .drawer-header {
-  height: 92px;
-  padding: 0 14px;
+  height: 74px;
+  padding: 0 16px;
   border-bottom: 1px solid #cfd5df;
   display: grid;
-  grid-template-columns: 42px 1fr 42px;
+  grid-template-columns: 44px 1fr 44px;
   align-items: center;
+  column-gap: 12px;
 }
 
 .drawer-header h2 {
   margin: 0;
-  font-size: 22px;
+  text-align: center;
+  font-size: 24px;
   font-weight: 500;
 }
 
 .drawer-back {
-  font-size: 34px;
+  font-size: 28px;
 }
 
 .drawer-settings-link {
@@ -345,6 +351,14 @@ body {
 .floating-menu button:first-child,
 .floating-menu a:first-child {
   border-top: 0;
+}
+
+.menu-group {
+  border-bottom: 1px solid #c1c6d1;
+}
+
+.menu-group button + button {
+  border-top: 1px solid #c1c6d1;
 }
 
 .floating-menu .muted-item {

--- a/apps/web_chat_app/src/styles.css
+++ b/apps/web_chat_app/src/styles.css
@@ -357,8 +357,16 @@ body {
   border-bottom: 1px solid #c1c6d1;
 }
 
+.menu-group button:first-child {
+  border-top: 0;
+}
+
 .menu-group button + button {
   border-top: 1px solid #c1c6d1;
+}
+
+.floating-menu .menu-group + * {
+  border-top: 0;
 }
 
 .floating-menu .muted-item {

--- a/docs/plans/2026-04-09-16-37-UTC-chat-sidebar-header-and-section-menu-fixes.md
+++ b/docs/plans/2026-04-09-16-37-UTC-chat-sidebar-header-and-section-menu-fixes.md
@@ -1,0 +1,35 @@
+# Background
+The chat mobile UI has multiple parity and usability issues: sidebar header height/layout does not align with the chat top header, the message pane uses an undesired gray background, the composer can be pushed off-screen by message growth, and the top-right section menu ordering/grouping does not match the expected IA. There is also confusion around subsection default labeling, where newly created subsections appear as default.
+
+# Goals
+1. Align sidebar drawer header height and left-button/title layout with the chat page top header.
+2. Remove gray background styling from the message area.
+3. Keep the composer/input area fixed to the bottom of the viewport while messages scroll.
+4. Update the section menu to show a grouped block containing "主区" and "新建子区", followed by the subsection list.
+5. Ensure only one main section representation is shown as default in UI labels, and avoid labeling each subsection as default.
+
+# Implementation Plan (phased)
+## Phase 1: Chat layout and header alignment
+- Update `apps/web_chat_app/src/styles.css` to normalize top header and drawer header heights and grid alignment.
+- Adjust drawer header internals (button/title/right action spacing) so the back button and title align with the chat header controls.
+- Remove the message container gray background style while preserving bubble contrast.
+- Make message list area properly scrollable (`min-height: 0`) and pin composer to bottom (`position: sticky; bottom: 0`) so it remains visible.
+
+## Phase 2: Section menu grouping and default semantics in UI
+- Update `apps/web_chat_app/src/pages/ChatPage.tsx` section menu render logic:
+  - Add grouped block with `主区` and `新建子区` at top.
+  - Render subsection list below the group.
+- Ensure `主区` is always selectable and shown explicitly.
+- Remove per-subsection "Default channel" copy and only mark main section as default in labels.
+
+## Phase 3: Validation
+- Run web frontend tests for `apps/web_chat_app`.
+- Run a production build to verify TypeScript and style integrity.
+
+# Acceptance Criteria
+1. Sidebar drawer header and chat top header have matching height and visually aligned left control + title layout.
+2. Message list container no longer has a gray background panel.
+3. Composer remains visible at the bottom while long message history scrolls independently.
+4. Section dropdown first shows grouped actions (`主区`, `新建子区`) and then subsection list items.
+5. UI shows only main section as default; subsection items are not labeled as default.
+6. `cd apps/web_chat_app && npm test -- --run` and `cd apps/web_chat_app && npm run build` succeed.


### PR DESCRIPTION
### Motivation
- Fix visual/layout parity between the chat page top header and the navigation drawer header so buttons and titles align.
- Prevent the message area from appearing as a gray panel and keep the composer input pinned to the bottom so it is not pushed off-screen.
- Make the top-right section menu IA clearer by grouping `主区` and `新建子区` before listing subsections and avoid labeling every subsection as the default.

### Description
- Updated layout and spacing in `apps/web_chat_app/src/styles.css` to unify header heights, adjust drawer header grid, remove the message-pane background, ensure the message list can scroll (`min-height: 0; overflow: auto`), and pin the composer with `position: sticky; bottom: 0`.
- Adjusted section/menu rendering in `apps/web_chat_app/src/pages/ChatPage.tsx` to explicitly show `主区` in the section menu, add a grouped block containing `主区` + `新建子区`, render subsections below, and show subsections as `子区` rather than marking each as default.
- Added an implementation plan file at `docs/plans/2026-04-09-16-37-UTC-chat-sidebar-header-and-section-menu-fixes.md` describing background, goals, implementation steps, and acceptance criteria.

### Testing
- Ran frontend unit tests with `cd apps/web_chat_app && npm test -- --run`, and the test suite passed (`1 file, 4 tests` succeeded).
- Performed a production build with `cd apps/web_chat_app && npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d58aed9c832d8e5ad1326bd92607)