### PR TITLE
Fix mobile chat layout overflow and add assistant typing indicator

### DIFF
--- a/apps/web_chat_app/src/__tests__/app.test.tsx
+++ b/apps/web_chat_app/src/__tests__/app.test.tsx
@@ -130,21 +130,29 @@ test('mobile drawer matches navigation groups with agents and channels', async (
 test('shows typing indicator while waiting for assistant reply', async () => {
   const user = userEvent.setup();
   let resolveReply: ((value: Response) => void) | undefined;
-  let callIndex = 0;
-  vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
-    callIndex += 1;
-    if (callIndex === 1) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+
+    if (url.includes('/api/chat/respond')) {
+      return await new Promise<Response>((resolve) => {
+        resolveReply = resolve;
+      });
+    }
+
+    if (url.includes('/api/config?category=')) {
       return {
         ok: true,
-        json: async () => ({
-          user: { id: 'u1', email: 'demo@example.com', created_at: '2024-01-01', updated_at: '2024-01-01' },
-          oauth_connections: [],
-        }),
+        json: async () => [],
       } as Response;
     }
-    return await new Promise<Response>((resolve) => {
-      resolveReply = resolve;
-    });
+
+    return {
+      ok: true,
+      json: async () => ({
+        user: { id: 'u1', email: 'demo@example.com', created_at: '2024-01-01', updated_at: '2024-01-01' },
+        oauth_connections: [],
+      }),
+    } as Response;
   });
 
   render(
@@ -160,7 +168,9 @@ test('shows typing indicator while waiting for assistant reply', async () => {
   await user.type(screen.getByPlaceholderText('Ask Bricks to create something...'), 'Hi');
   await user.click(screen.getByRole('button', { name: 'Send message' }));
 
-  expect(screen.getByLabelText('AI is replying')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
 
   resolveReply?.({
     ok: true,
@@ -170,5 +180,5 @@ test('shows typing indicator while waiting for assistant reply', async () => {
   await waitFor(() => {
     expect(screen.getByText('Delayed reply')).toBeInTheDocument();
   });
-  expect(screen.queryByLabelText('AI is replying')).not.toBeInTheDocument();
+  expect(screen.queryByRole('status')).not.toBeInTheDocument();
 });

--- a/apps/web_chat_app/src/__tests__/app.test.tsx
+++ b/apps/web_chat_app/src/__tests__/app.test.tsx
@@ -126,3 +126,49 @@ test('mobile drawer matches navigation groups with agents and channels', async (
   expect(screen.getByRole('button', { name: 'Channels section' })).toBeInTheDocument();
   expect(screen.getByText('默认频道')).toBeInTheDocument();
 });
+
+test('shows typing indicator while waiting for assistant reply', async () => {
+  const user = userEvent.setup();
+  let resolveReply: ((value: Response) => void) | undefined;
+  let callIndex = 0;
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+    callIndex += 1;
+    if (callIndex === 1) {
+      return {
+        ok: true,
+        json: async () => ({
+          user: { id: 'u1', email: 'demo@example.com', created_at: '2024-01-01', updated_at: '2024-01-01' },
+          oauth_connections: [],
+        }),
+      } as Response;
+    }
+    return await new Promise<Response>((resolve) => {
+      resolveReply = resolve;
+    });
+  });
+
+  render(
+    <MemoryRouter initialEntries={['/chat']}>
+      <App />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByPlaceholderText('Ask Bricks to create something...')).toBeInTheDocument();
+  });
+
+  await user.type(screen.getByPlaceholderText('Ask Bricks to create something...'), 'Hi');
+  await user.click(screen.getByRole('button', { name: 'Send message' }));
+
+  expect(screen.getByLabelText('AI is replying')).toBeInTheDocument();
+
+  resolveReply?.({
+    ok: true,
+    json: async () => ({ text: 'Delayed reply' }),
+  } as Response);
+
+  await waitFor(() => {
+    expect(screen.getByText('Delayed reply')).toBeInTheDocument();
+  });
+  expect(screen.queryByLabelText('AI is replying')).not.toBeInTheDocument();
+});

--- a/apps/web_chat_app/src/__tests__/app.test.tsx
+++ b/apps/web_chat_app/src/__tests__/app.test.tsx
@@ -131,7 +131,14 @@ test('shows typing indicator while waiting for assistant reply', async () => {
   const user = userEvent.setup();
   let resolveReply: ((value: Response) => void) | undefined;
   vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
-    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+    let url: string;
+    if (typeof input === 'string') {
+      url = input;
+    } else if (input instanceof URL) {
+      url = input.toString();
+    } else {
+      url = (input as Request).url;
+    }
 
     if (url.includes('/api/chat/respond')) {
       return await new Promise<Response>((resolve) => {

--- a/apps/web_chat_app/src/pages/ChatPage.tsx
+++ b/apps/web_chat_app/src/pages/ChatPage.tsx
@@ -155,7 +155,6 @@ export function ChatPage() {
         </button>
       </header>
 
-      <div className="chat-meta">🧰 ask</div>
       <article className="chat-message-card" aria-label="message-list">
         {messages.length === 0 ? (
           <p className="chat-empty">No messages yet.</p>
@@ -168,6 +167,15 @@ export function ChatPage() {
               {message.content}
             </div>
           ))
+        )}
+        {loading && (
+          <div className="chat-bubble chat-bubble--assistant chat-bubble--typing" aria-live="polite">
+            <span className="typing-indicator" aria-label="AI is replying">
+              <span />
+              <span />
+              <span />
+            </span>
+          </div>
         )}
       </article>
 

--- a/apps/web_chat_app/src/pages/ChatPage.tsx
+++ b/apps/web_chat_app/src/pages/ChatPage.tsx
@@ -169,11 +169,17 @@ export function ChatPage() {
           ))
         )}
         {loading && (
-          <div className="chat-bubble chat-bubble--assistant chat-bubble--typing" aria-live="polite">
-            <span className="typing-indicator" aria-label="AI is replying">
-              <span />
-              <span />
-              <span />
+          <div
+            className="chat-bubble chat-bubble--assistant chat-bubble--typing"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            <span className="sr-only">AI is replying…</span>
+            <span className="typing-indicator" aria-hidden="true">
+              <span aria-hidden="true" />
+              <span aria-hidden="true" />
+              <span aria-hidden="true" />
             </span>
           </div>
         )}

--- a/apps/web_chat_app/src/styles.css
+++ b/apps/web_chat_app/src/styles.css
@@ -105,7 +105,6 @@ body {
   line-height: 1.5;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
-  word-break: break-word;
   box-sizing: border-box;
   max-width: 100%;
 }

--- a/apps/web_chat_app/src/styles.css
+++ b/apps/web_chat_app/src/styles.css
@@ -34,7 +34,8 @@ body {
 }
 
 .chat-mobile-page {
-  height: 100vh;
+  min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   position: relative;
@@ -78,18 +79,12 @@ body {
   cursor: pointer;
 }
 
-.chat-meta {
-  color: #285f96;
-  font-size: 40px;
-  font-size: clamp(18px, 4.6vw, 40px);
-  margin: 16px 16px 8px;
-}
-
 .chat-message-card {
   margin: 0 16px;
   flex: 1;
   min-height: 0;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   border-radius: 14px;
   padding: 12px 0;
   line-height: 1.45;
@@ -109,6 +104,8 @@ body {
   font-size: clamp(15px, 4vw, 20px);
   line-height: 1.5;
   white-space: pre-wrap;
+  box-sizing: border-box;
+  max-width: 100%;
 }
 
 .chat-bubble--user {
@@ -120,7 +117,6 @@ body {
 
 .chat-bubble--assistant {
   align-self: stretch;
-  width: 100%;
   background: #f4f6fb;
   color: #263041;
 }
@@ -131,9 +127,8 @@ body {
   border-radius: 22px;
   background: #e4e6ec;
   padding: 16px 16px 12px;
-  position: sticky;
-  bottom: 0;
   z-index: 5;
+  padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
 }
 
 .composer-mobile input {
@@ -162,6 +157,48 @@ body {
 
 .send-btn:disabled {
   opacity: 0.45;
+}
+
+.chat-bubble--typing {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+}
+
+.typing-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.typing-indicator span {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #7d8798;
+  opacity: 0.35;
+  animation: typing-dot 1.1s infinite ease-in-out;
+}
+
+.typing-indicator span:nth-child(2) {
+  animation-delay: 0.18s;
+}
+
+.typing-indicator span:nth-child(3) {
+  animation-delay: 0.36s;
+}
+
+@keyframes typing-dot {
+  0%,
+  80%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.35;
+  }
+  40% {
+    transform: translateY(-3px);
+    opacity: 1;
+  }
 }
 
 .drawer-overlay {

--- a/apps/web_chat_app/src/styles.css
+++ b/apps/web_chat_app/src/styles.css
@@ -104,6 +104,8 @@ body {
   font-size: clamp(15px, 4vw, 20px);
   line-height: 1.5;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   box-sizing: border-box;
   max-width: 100%;
 }
@@ -199,6 +201,25 @@ body {
     transform: translateY(-3px);
     opacity: 1;
   }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .typing-indicator span {
+    animation: none;
+    opacity: 0.6;
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .drawer-overlay {

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: feature_map
 owner: bricks
-last_updated: 2026-04-09
+last_updated: 2026-04-10
 purpose: >
   为人类测试员和 AI 测试员提供产品功能清单与进入路径，作为回归测试与变更影响评估的入口索引。
 
@@ -36,9 +36,10 @@ products:
           - route: /api/chat/respond
             route_hint: apps/node_backend/src/routes/chat.ts
         smoke_checks:
-          - 在 Chat 页面发送一条消息后可看到 user 与 assistant 分样式气泡，assistant 气泡占满消息区宽度。
+          - 在 Chat 页面发送一条消息后可看到 user 与 assistant 分样式气泡，assistant 气泡宽度受消息区约束且不触发横向滚动。
+          - 用户发送消息后、assistant 响应返回前，消息区可见三点加载动画提示“AI 正在回复”。
           - API 失败时出现可见错误反馈消息。
-          - 顶部主区菜单可读取后端 section 配置并切换 channelId。
+          - 顶部主区菜单可读取后端 section 配置并切换 channelId，消息区顶部不显示额外 ask 元信息行。
 
       - feature_id: mobile_navigation_shell
         name: 移动端导航壳层
@@ -53,6 +54,7 @@ products:
           - 点击左上按钮打开侧边栏抽屉，显示 Navigation 头部、Current Chat、Agents 与频道分组。
           - Agents 分组可展开显示“在设置中新建 Agents”占位提示，频道分组可展示默认频道与“新建频道”操作。
           - 输入框左下角按钮打开独立 composer 菜单且定位在底部左侧。
+          - iOS/移动端视口下输入框容器贴合底部安全区，不被浏览器底部区域遮挡。
           - 设置页展示 Model Settings / Manage Agents / Sign Out 条目。
 
   - product_id: node_backend

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: logic_map
 owner: bricks
-last_updated: 2026-04-09
+last_updated: 2026-04-10
 purpose: >
   为人类测试员、AI 测试员与 AI 工程师提供“功能 -> 代码/文档/关键词”映射，
   用于影响面分析、回归测试设计与遗留逻辑清理。
@@ -53,6 +53,8 @@ index:
     change_risks:
       - 请求体字段缺失将触发后端 400 并导致发送失败。
       - 前端会话 ID 策略变动可能影响后端历史聚合。
+      - 消息气泡宽度与容器 overflow 配置变动可能再次引入横向滚动条。
+      - 加载态动画若与请求状态不同步，可能出现常驻“正在回复”或无提示闪烁。
 
   - feature_id: mobile_navigation_shell
     capability: 移动端导航与设置入口
@@ -82,6 +84,7 @@ index:
       - 浮层定位与层级错误会导致菜单遮挡或不可点击。
       - 主区数据读取失败会导致 channelId 退化为默认值并影响会话隔离。
       - 顶部导航按钮文案或可访问名称变更会破坏自动化测试选择器。
+      - 底部 composer 的安全区 padding 若被覆盖，在 iOS Safari 可能再次出现输入框遮挡。
 
   - feature_id: backend_auth
     capability: 后端 GitHub OAuth 认证

--- a/docs/plans/2026-04-10-01-00-chat-ui-layout-loading-fixes.md
+++ b/docs/plans/2026-04-10-01-00-chat-ui-layout-loading-fixes.md
@@ -1,0 +1,30 @@
+# Background
+The mobile web chat UI currently has multiple regressions: the composer is not pinned to the bottom on iOS, the message region shows an unnecessary horizontal scrollbar, an unintended red "ask" label appears above messages, and there is no visible loading animation while waiting for assistant replies.
+
+# Goals
+1. Pin the message input/composer area to the bottom viewport/safe area.
+2. Remove horizontal overflow/scrollbar from the message region.
+3. Remove the unintended red "ask" marker from the chat body.
+4. Show a clear in-thread loading animation while waiting for AI response.
+
+# Implementation Plan (phased)
+## Phase 1: Locate and patch chat layout/rendering
+- Inspect chat container, message list, and composer layout styles/components.
+- Update CSS/layout constraints to prevent horizontal overflow and ensure bottom anchoring with safe-area support.
+- Remove the source for the stray "ask" label in message rendering.
+
+## Phase 2: Add waiting-state animation
+- Identify assistant pending state in message pipeline.
+- Render a visible typing/loading indicator bubble during pending assistant response.
+- Ensure the indicator is removed when response content arrives.
+
+## Phase 3: Validate and document
+- Run targeted checks (lint/type-check/tests or package-specific checks as available).
+- Update code maps if feature/logic index changed.
+
+# Acceptance Criteria
+- On mobile viewport, the composer visually sits against the bottom safe area and remains reachable while scrolling.
+- No horizontal scrollbar appears in message list under normal chat content.
+- The unintended red "ask" label is absent from chat message area.
+- After a user sends a message and before assistant reply arrives, a loading animation is visible in the conversation.
+- Validation command(s) complete successfully: at minimum run project-appropriate checks for the touched app (e.g., `npm run lint`, `npm run type-check`, or relevant package test command).


### PR DESCRIPTION
### Motivation
- Resolve multiple mobile web chat regressions: input composer being obscured on iOS, horizontal scrollbar in the message list, an unintended top meta row in the chat, and lack of a visible in-thread loading indicator while awaiting assistant replies.
- Make the chat UX clearer during pending assistant responses by showing a typing animation in the message stream.

### Description
- Remove the stray meta row and render an in-thread assistant typing indicator when `loading` is true in `apps/web_chat_app/src/pages/ChatPage.tsx`.
- Harden layout and sizing in `apps/web_chat_app/src/styles.css` by using `100dvh`-aware page height, constraining bubble sizing with `box-sizing` and `max-width: 100%`, preventing horizontal overflow with `overflow-x: hidden`, and adding safe-area bottom padding for the composer.
- Add a unit/interaction test that verifies the typing indicator appears while a reply is pending and is removed after the reply arrives in `apps/web_chat_app/src/__tests__/app.test.tsx`.
- Update repository artifacts and documentation: add a persisted implementation plan in `docs/plans/2026-04-10-01-00-chat-ui-layout-loading-fixes.md` and update `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` to reflect the UI change and associated smoke checks/risks.

### Testing
- Ran dependency install with `cd apps/web_chat_app && npm ci`, which completed successfully.
- Ran the test suite with `cd apps/web_chat_app && npm test`, and all tests passed (5 tests total; suite succeeded).
- Built the production bundle with `cd apps/web_chat_app && npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84b95b68c832d8b33813644f4c395)