### PR TITLE
Add OpenClaw pull-only integration doc and settings copy actions

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
@@ -22,10 +22,14 @@ class ChatRespondResult {
   const ChatRespondResult({
     required this.text,
     required this.lastSeqId,
+    required this.isAsync,
+    this.taskState,
   });
 
   final String text;
   final int lastSeqId;
+  final bool isAsync;
+  final ChatTaskState? taskState;
 }
 
 class ChatPersistedScope {
@@ -58,8 +62,8 @@ class ChatAcceptedTask {
 
 class ChatHistoryApiService {
   ChatHistoryApiService({http.Client? httpClient})
-      : _httpClient = httpClient ?? http.Client(),
-        _ownsHttpClient = httpClient == null;
+    : _httpClient = httpClient ?? http.Client(),
+      _ownsHttpClient = httpClient == null;
 
   final http.Client _httpClient;
   final bool _ownsHttpClient;
@@ -86,19 +90,28 @@ class ChatHistoryApiService {
   String get _base => LlmConfigService.resolveBaseUrl();
 
   Uri _historyUri(String sessionId, {required int limit}) => Uri.parse(
-      '$_base/api/chat/history/${Uri.encodeComponent(sessionId)}?limit=$limit');
+    '$_base/api/chat/history/${Uri.encodeComponent(sessionId)}?limit=$limit',
+  );
 
   Uri _syncUri(String sessionId, {required int afterSeq}) => Uri.parse(
-      '$_base/api/chat/sync/${Uri.encodeComponent(sessionId)}?afterSeq=$afterSeq');
+    '$_base/api/chat/sync/${Uri.encodeComponent(sessionId)}?afterSeq=$afterSeq',
+  );
 
   Uri get _acceptTaskUri => Uri.parse('$_base/api/chat/tasks/accept');
 
   Uri get _batchMessagesUri => Uri.parse('$_base/api/chat/messages/batch');
   Uri get _scopesUri => Uri.parse('$_base/api/chat/scopes');
+  Uri get _scopeSettingsUri => Uri.parse('$_base/api/chat/scope-settings');
 
-  Future<List<ChatPersistedScope>> loadScopes({
-    required String token,
-  }) async {
+  ChatTaskState? _parseTaskState(Object? value) {
+    if (value is! String || value.isEmpty) return null;
+    for (final state in ChatTaskState.values) {
+      if (state.name == value) return state;
+    }
+    return null;
+  }
+
+  Future<List<ChatPersistedScope>> loadScopes({required String token}) async {
     final response = await _client.get(
       _scopesUri,
       headers: {'Authorization': 'Bearer $token'},
@@ -112,15 +125,53 @@ class ChatHistoryApiService {
     return ((map['scopes'] as List?) ?? const [])
         .whereType<Map>()
         .map((item) => Map<String, dynamic>.from(item))
-        .map((item) => ChatPersistedScope(
-              channelId: (item['channelId'] as String?) ?? 'default',
-              threadId: (item['threadId'] as String?) ?? 'main',
-              sessionId: (item['sessionId'] as String?) ?? '',
-              lastActivityAt: item['lastActivityAt'] is String
-                  ? DateTime.tryParse(item['lastActivityAt'] as String)
-                  : null,
-            ))
+        .map(
+          (item) => ChatPersistedScope(
+            channelId: (item['channelId'] as String?) ?? 'default',
+            threadId: (item['threadId'] as String?) ?? 'main',
+            sessionId: (item['sessionId'] as String?) ?? '',
+            lastActivityAt: item['lastActivityAt'] is String
+                ? DateTime.tryParse(item['lastActivityAt'] as String)
+                : null,
+          ),
+        )
         .where((scope) => scope.sessionId.isNotEmpty)
+        .toList(growable: false);
+  }
+
+  Future<List<ChatScopeSetting>> loadScopeSettings({
+    required String token,
+  }) async {
+    final response = await _client.get(
+      _scopeSettingsUri,
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    if (response.statusCode != 200) {
+      throw Exception(
+        'Failed to load chat scope settings (${response.statusCode})',
+      );
+    }
+    final raw = jsonDecode(response.body);
+    if (raw is! Map) return const [];
+    final map = Map<String, dynamic>.from(raw);
+    return ((map['settings'] as List?) ?? const [])
+        .whereType<Map>()
+        .map((item) => Map<String, dynamic>.from(item))
+        .map((item) {
+          final scopeType = chatScopeTypeFromApi(item['scopeType'] as String?);
+          if (scopeType == null) {
+            throw const FormatException('Invalid scopeType');
+          }
+          return ChatScopeSetting(
+            scopeType: scopeType,
+            channelId: (item['channelId'] as String?) ?? 'default',
+            threadId: item['threadId'] as String?,
+            router: chatRouterFromApi(item['router'] as String?),
+            updatedAt: item['updatedAt'] is String
+                ? DateTime.tryParse(item['updatedAt'] as String)
+                : null,
+          );
+        })
         .toList(growable: false);
   }
 
@@ -229,12 +280,42 @@ class ChatHistoryApiService {
     }
 
     final raw = jsonDecode(response.body);
-    final map =
-        raw is Map ? Map<String, dynamic>.from(raw) : const <String, dynamic>{};
+    final map = raw is Map
+        ? Map<String, dynamic>.from(raw)
+        : const <String, dynamic>{};
     return ChatRespondResult(
       text: (map['text'] as String?) ?? '',
       lastSeqId: (map['lastSeqId'] as num?)?.toInt() ?? 0,
+      isAsync: (map['mode'] as String?) == 'async',
+      taskState: _parseTaskState(map['state']),
     );
+  }
+
+  Future<void> saveScopeSetting({
+    required String token,
+    required ChatScopeType scopeType,
+    required String channelId,
+    String? threadId,
+    required ChatRouter? router,
+  }) async {
+    final response = await _client.put(
+      _scopeSettingsUri,
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({
+        'scopeType': scopeType.apiValue,
+        'channelId': channelId,
+        if (threadId != null) 'threadId': threadId,
+        'router': router?.apiValue,
+      }),
+    );
+    if (response.statusCode != 200) {
+      throw Exception(
+        'Failed to save chat scope setting (${response.statusCode})',
+      );
+    }
   }
 
   Future<ChatAcceptedTask> acceptTask({
@@ -266,8 +347,9 @@ class ChatHistoryApiService {
     }
 
     final raw = jsonDecode(response.body);
-    final map =
-        raw is Map ? Map<String, dynamic>.from(raw) : const <String, dynamic>{};
+    final map = raw is Map
+        ? Map<String, dynamic>.from(raw)
+        : const <String, dynamic>{};
     return ChatAcceptedTask(
       taskId: (map['taskId'] as String?) ?? taskId,
       sessionId: (map['sessionId'] as String?) ?? scope.sessionId,
@@ -282,9 +364,12 @@ class ChatHistoryApiService {
     // still streaming; otherwise refresh can show an empty bubble with no
     // meaningful content.
     return messages
-        .where((message) => !(message.role == 'assistant' &&
-            message.isStreaming &&
-            message.content.trim().isEmpty))
+        .where(
+          (message) =>
+              !(message.role == 'assistant' &&
+                  message.isStreaming &&
+                  message.content.trim().isEmpty),
+        )
         .toList(growable: false);
   }
 

--- a/apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
@@ -193,7 +193,7 @@ class ChatHistoryApiService {
       return const ChatHistorySnapshot(messages: [], lastSeqId: 0);
     }
 
-    final map = Map<String, dynamic>.from(raw as Map);
+    final map = Map<String, dynamic>.from(raw);
     final messages = ((map['messages'] as List?) ?? const [])
         .whereType<Map>()
         .map((item) => Map<String, Object?>.from(item))
@@ -223,7 +223,7 @@ class ChatHistoryApiService {
     if (raw is! Map) {
       return ChatHistorySnapshot(messages: const [], lastSeqId: afterSeq);
     }
-    final map = Map<String, dynamic>.from(raw as Map);
+    final map = Map<String, dynamic>.from(raw);
     final messages = ((map['messages'] as List?) ?? const [])
         .whereType<Map>()
         .map((item) => Map<String, Object?>.from(item))

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -943,10 +943,13 @@ class _ChatScreenState extends State<ChatScreen> {
       _syncTimer = null;
       return;
     }
+    final shouldTriggerImmediately =
+        triggerNow && _syncTimer == null && !_syncInFlight;
     _syncTimer ??= Timer.periodic(const Duration(seconds: 2), (_) {
+      if (_syncInFlight) return;
       unawaited(_syncActiveScope());
     });
-    if (triggerNow) {
+    if (shouldTriggerImmediately) {
       unawaited(_syncActiveScope());
     }
   }

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -9,7 +9,6 @@ import 'package:workspace_fs/workspace_fs.dart';
 
 import 'chat_history_api_service.dart';
 
-import '../agents/agents_screen.dart';
 import '../auth/auth_service.dart';
 import '../settings/llm_config_service.dart';
 import '../settings/settings_screen.dart';
@@ -1428,17 +1427,6 @@ class _ChatScreenState extends State<ChatScreen> {
       }
     } catch (e) {
       _updateMessageContent(index, 'Error: $e', isStreaming: false);
-    }
-  }
-
-  Future<void> _openAgentsScreen() async {
-    final updated = await Navigator.push<AgentDefinition?>(
-      context,
-      MaterialPageRoute<AgentDefinition?>(builder: (_) => const AgentsScreen()),
-    );
-    await _reloadAgents();
-    if (updated != null) {
-      _selectAgent(updated);
     }
   }
 

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -55,7 +55,6 @@ class _ChatScreenState extends State<ChatScreen> {
   final ChatTopologyResolver _topologyResolver = const ChatTopologyResolver();
   final Map<String, AgentSession> _sessions = {};
   StreamSubscription<AgentSessionEvent>? _currentSubscription;
-  AgentsRepository? _agentsRepository;
   List<AgentDefinition> _agents = [];
   AgentDefinition? _activeAgent;
   final LlmConfigService _llmConfigService = const LlmConfigService();
@@ -152,7 +151,6 @@ class _ChatScreenState extends State<ChatScreen> {
               ),
       );
       if (!mounted) return;
-      _agentsRepository = repo;
       _syncParticipants(definitions);
       final restoredChannels = _hydrateChannelsFromScopes(persistedScopes);
       final restoredSubSections = _hydrateSubSectionsFromScopes(

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -49,8 +49,9 @@ class _ChatScreenState extends State<ChatScreen> {
 
   final AgentClient _client = AgentCoreClient();
   final ChatBotRegistry _botRegistry = ChatBotRegistry();
-  late final ChatArbitrationEngine _arbitrationEngine =
-      ChatArbitrationEngine(registry: _botRegistry);
+  late final ChatArbitrationEngine _arbitrationEngine = ChatArbitrationEngine(
+    registry: _botRegistry,
+  );
   final ChatTaskProtocol _taskProtocol = ChatTaskProtocol();
   final ChatTopologyResolver _topologyResolver = const ChatTopologyResolver();
   final Map<String, AgentSession> _sessions = {};
@@ -68,7 +69,7 @@ class _ChatScreenState extends State<ChatScreen> {
   ];
   String _activeChannelId = 'default';
   final Map<String, List<ChatSubSection>> _channelSubSections = {
-    'default': <ChatSubSection>[]
+    'default': <ChatSubSection>[],
   };
   final Map<String, DateTime> _subSectionLastMessageAt = {};
   String _activeSubSection = 'main';
@@ -80,6 +81,10 @@ class _ChatScreenState extends State<ChatScreen> {
   int _lastSyncedSeq = 0;
   final ChatHistoryApiService _chatHistoryApiService = ChatHistoryApiService();
   Timer? _persistDebounce;
+  Timer? _syncTimer;
+  bool _syncInFlight = false;
+  final Map<String, ChatRouter> _channelRouters = {};
+  final Map<String, ChatRouter> _threadRouters = {};
   int _respondGeneration = 0;
 
   @override
@@ -91,6 +96,7 @@ class _ChatScreenState extends State<ChatScreen> {
   @override
   void dispose() {
     _persistDebounce?.cancel();
+    _syncTimer?.cancel();
     _doPersistActiveScopeMessages();
     Timer(const Duration(seconds: 5), _chatHistoryApiService.dispose);
     _currentSubscription?.cancel();
@@ -111,14 +117,27 @@ class _ChatScreenState extends State<ChatScreen> {
       final authToken = await tokenFuture;
       final definitions = await _readAgentDefinitions(repo);
       List<ChatPersistedScope> persistedScopes = const [];
+      List<ChatScopeSetting> scopeSettings = const [];
       if (authToken != null && authToken.isNotEmpty) {
         try {
-          persistedScopes =
-              await _chatHistoryApiService.loadScopes(token: authToken);
+          persistedScopes = await _chatHistoryApiService.loadScopes(
+            token: authToken,
+          );
         } catch (e) {
           // Scope hydration is best-effort; a backend failure (e.g. 404 during
           // rollout or transient error) must not block the rest of chat setup.
-          debugPrint('loadScopes failed, continuing without scope hydration: $e');
+          debugPrint(
+            'loadScopes failed, continuing without scope hydration: $e',
+          );
+        }
+        try {
+          scopeSettings = await _chatHistoryApiService.loadScopeSettings(
+            token: authToken,
+          );
+        } catch (e) {
+          debugPrint(
+            'loadScopeSettings failed, continuing without router hydration: $e',
+          );
         }
       }
       final defaultConfig = llmConfigs.firstWhere(
@@ -137,10 +156,13 @@ class _ChatScreenState extends State<ChatScreen> {
       _agentsRepository = repo;
       _syncParticipants(definitions);
       final restoredChannels = _hydrateChannelsFromScopes(persistedScopes);
-      final restoredSubSections =
-          _hydrateSubSectionsFromScopes(persistedScopes);
+      final restoredSubSections = _hydrateSubSectionsFromScopes(
+        persistedScopes,
+      );
       final restoredLastSubSectionByChannel =
           _hydrateLastActiveSubSectionByChannel(persistedScopes);
+      final restoredChannelRouters = _hydrateChannelRouters(scopeSettings);
+      final restoredThreadRouters = _hydrateThreadRouters(scopeSettings);
       final resolvedActiveChannel = _topologyResolver.resolveChannelId(
         channels: restoredChannels,
         requestedChannelId: _activeChannelId,
@@ -152,10 +174,12 @@ class _ChatScreenState extends State<ChatScreen> {
         _activeAgent ??= definitions.isNotEmpty ? definitions.first : null;
         _loadingAgents = false;
         _llmConfigs = llmConfigs;
-        _sessionConfigSlotId ??=
-            llmConfigs.isNotEmpty ? defaultConfig.slotId : null;
-        _sessionModelOverride ??=
-            llmConfigs.isNotEmpty ? defaultConfig.defaultModel : null;
+        _sessionConfigSlotId ??= llmConfigs.isNotEmpty
+            ? defaultConfig.slotId
+            : null;
+        _sessionModelOverride ??= llmConfigs.isNotEmpty
+            ? defaultConfig.defaultModel
+            : null;
         _loadingLlmConfigs = false;
         _authToken = authToken;
         _channels
@@ -167,6 +191,12 @@ class _ChatScreenState extends State<ChatScreen> {
         _lastActiveSubSectionByChannel
           ..clear()
           ..addAll(restoredLastSubSectionByChannel);
+        _channelRouters
+          ..clear()
+          ..addAll(restoredChannelRouters);
+        _threadRouters
+          ..clear()
+          ..addAll(restoredThreadRouters);
         _activeChannelId = resolvedActiveChannel;
         _activeSubSection = restoredActiveSubSection;
       });
@@ -231,9 +261,9 @@ class _ChatScreenState extends State<ChatScreen> {
 
   void _selectAgent(AgentDefinition agent) {
     setState(() => _activeAgent = agent);
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Responding as @${agent.name}')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Responding as @${agent.name}')));
   }
 
   LlmConfig? get _activeLlmConfig {
@@ -247,7 +277,8 @@ class _ChatScreenState extends State<ChatScreen> {
 
   AgentSettings _settingsForAgent(AgentDefinition? agent) {
     final selectedConfig = _activeLlmConfig;
-    final selectedModel = _sessionModelOverride ??
+    final selectedModel =
+        _sessionModelOverride ??
         selectedConfig?.defaultModel ??
         _resolveModelId(agent?.model);
     return AgentSettings(
@@ -295,12 +326,14 @@ class _ChatScreenState extends State<ChatScreen> {
       return;
     }
 
-    var selectedSlot = _sessionConfigSlotId ??
+    var selectedSlot =
+        _sessionConfigSlotId ??
         _llmConfigs
             .firstWhere((c) => c.isDefault, orElse: () => _llmConfigs.first)
             .slotId;
-    var selectedConfig =
-        _llmConfigs.firstWhere((cfg) => cfg.slotId == selectedSlot);
+    var selectedConfig = _llmConfigs.firstWhere(
+      (cfg) => cfg.slotId == selectedSlot,
+    );
     var selectedModel = _sessionModelOverride ?? selectedConfig.defaultModel;
 
     final applied = await showDialog<bool>(
@@ -325,8 +358,9 @@ class _ChatScreenState extends State<ChatScreen> {
                 children: [
                   DropdownButtonFormField<String>(
                     initialValue: selectedSlot,
-                    decoration:
-                        const InputDecoration(labelText: 'Configuration'),
+                    decoration: const InputDecoration(
+                      labelText: 'Configuration',
+                    ),
                     items: _llmConfigs
                         .map(
                           (cfg) => DropdownMenuItem<String>(
@@ -395,9 +429,9 @@ class _ChatScreenState extends State<ChatScreen> {
       _isSending = false;
       _isStreaming = false;
     });
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Session now uses $selectedModel')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Session now uses $selectedModel')));
   }
 
   String _resolveModelId(String? model) {
@@ -441,10 +475,14 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   List<ChatChannel> _hydrateChannelsFromScopes(
-      List<ChatPersistedScope> scopes) {
+    List<ChatPersistedScope> scopes,
+  ) {
     final channelsById = <String, ChatChannel>{
-      'default':
-          const ChatChannel(id: 'default', name: '默认频道', isDefault: true),
+      'default': const ChatChannel(
+        id: 'default',
+        name: '默认频道',
+        isDefault: true,
+      ),
     };
     for (final scope in scopes) {
       if (scope.channelId == 'default') continue;
@@ -467,8 +505,10 @@ class _ChatScreenState extends State<ChatScreen> {
       'default': <ChatSubSection>[],
     };
     for (final scope in scopes) {
-      final channelSections =
-          subSections.putIfAbsent(scope.channelId, () => <ChatSubSection>[]);
+      final channelSections = subSections.putIfAbsent(
+        scope.channelId,
+        () => <ChatSubSection>[],
+      );
       if (scope.threadId == 'main' ||
           channelSections.any((item) => item.id == scope.threadId)) {
         continue;
@@ -493,7 +533,8 @@ class _ChatScreenState extends State<ChatScreen> {
       final current = byChannel[scope.channelId];
       final currentAt = current?.lastActivityAt;
       final nextAt = scope.lastActivityAt;
-      final shouldReplace = current == null ||
+      final shouldReplace =
+          current == null ||
           (nextAt != null && (currentAt == null || nextAt.isAfter(currentAt)));
       if (shouldReplace) byChannel[scope.channelId] = scope;
     }
@@ -503,10 +544,39 @@ class _ChatScreenState extends State<ChatScreen> {
     });
   }
 
+  Map<String, ChatRouter> _hydrateChannelRouters(
+    List<ChatScopeSetting> settings,
+  ) {
+    final routers = <String, ChatRouter>{};
+    for (final setting in settings) {
+      if (setting.scopeType != ChatScopeType.channel) continue;
+      routers[setting.channelId] = setting.router;
+    }
+    return routers;
+  }
+
+  Map<String, ChatRouter> _hydrateThreadRouters(
+    List<ChatScopeSetting> settings,
+  ) {
+    final routers = <String, ChatRouter>{};
+    for (final setting in settings) {
+      if (setting.scopeType != ChatScopeType.thread ||
+          setting.threadId == null) {
+        continue;
+      }
+      routers[_subSectionKey(setting.channelId, setting.threadId!)] =
+          setting.router;
+    }
+    return routers;
+  }
+
   void _createChannel() {
     final id = _newId('channel');
-    final channel =
-        ChatChannel(id: id, name: _timestampName(), isDefault: false);
+    final channel = ChatChannel(
+      id: id,
+      name: _timestampName(),
+      isDefault: false,
+    );
     setState(() {
       _channels.add(channel);
       _channelSubSections[id] = <ChatSubSection>[];
@@ -517,6 +587,7 @@ class _ChatScreenState extends State<ChatScreen> {
       _lastSyncedSeq = 0;
     });
     _persistActiveScopeMessages();
+    _configureActiveScopeSync();
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text('已创建频道：${channel.name}')));
@@ -524,7 +595,9 @@ class _ChatScreenState extends State<ChatScreen> {
 
   void _switchChannel(String channelId) {
     final resolvedChannelId = _topologyResolver.resolveChannelId(
-        channels: _channels, requestedChannelId: channelId);
+      channels: _channels,
+      requestedChannelId: channelId,
+    );
     if (_activeChannelId == resolvedChannelId) {
       // Drawer closing is handled by ChatNavigationPage; avoid an extra pop
       // here, which can dismiss the chat route itself.
@@ -538,11 +611,16 @@ class _ChatScreenState extends State<ChatScreen> {
     final sections = _channelSubSections[resolvedChannelId] ?? const [];
     final restoredSubSection =
         (remembered != null && sections.any((s) => s.id == remembered))
-            ? remembered
-            : 'main';
+        ? remembered
+        : 'main';
+    _syncTimer?.cancel();
+    _syncTimer = null;
     setState(() {
       _activeChannelId = resolvedChannelId;
       _activeSubSection = restoredSubSection;
+      _messages.clear();
+      _latestCheckpointCursor = null;
+      _lastSyncedSeq = 0;
     });
     unawaited(_loadMessagesForActiveScope());
   }
@@ -571,9 +649,9 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   ChatSessionScope get _activeScope => ChatSessionScope(
-        channelId: _activeChannelId,
-        threadId: _activeSubSection,
-      );
+    channelId: _activeChannelId,
+    threadId: _activeSubSection,
+  );
 
   String get _sessionIdForScope => _activeScope.sessionId;
 
@@ -586,6 +664,7 @@ class _ChatScreenState extends State<ChatScreen> {
         _latestCheckpointCursor = null;
         _lastSyncedSeq = 0;
       });
+      _configureActiveScopeSync();
       return;
     }
 
@@ -596,6 +675,8 @@ class _ChatScreenState extends State<ChatScreen> {
     final capturedChannelId = _activeChannelId;
     final capturedSubSection = _activeSubSection;
     final capturedSessionId = _sessionIdForScope;
+    _syncTimer?.cancel();
+    _syncTimer = null;
 
     bool _isScopeStale() => _sessionIdForScope != capturedSessionId;
 
@@ -616,6 +697,7 @@ class _ChatScreenState extends State<ChatScreen> {
         channelId: capturedChannelId,
         subSection: capturedSubSection,
       );
+      _configureActiveScopeSync();
     } catch (_) {
       if (!mounted || _isScopeStale()) return;
       setState(() {
@@ -623,11 +705,175 @@ class _ChatScreenState extends State<ChatScreen> {
         _latestCheckpointCursor = null;
         _lastSyncedSeq = 0;
       });
+      _configureActiveScopeSync();
     }
   }
 
   String _subSectionKey(String channelId, String sectionId) =>
       '$channelId::$sectionId';
+
+  ChatRouter? _explicitThreadRouter({String? channelId, String? threadId}) {
+    final resolvedChannelId = channelId ?? _activeChannelId;
+    final resolvedThreadId = threadId ?? _activeSubSection;
+    return _threadRouters[_subSectionKey(resolvedChannelId, resolvedThreadId)];
+  }
+
+  ChatRouter _effectiveRouterForScope({String? channelId, String? threadId}) {
+    final resolvedChannelId = channelId ?? _activeChannelId;
+    final resolvedThreadId = threadId ?? _activeSubSection;
+    return _explicitThreadRouter(
+          channelId: resolvedChannelId,
+          threadId: resolvedThreadId,
+        ) ??
+        _channelRouters[resolvedChannelId] ??
+        ChatRouter.defaultRoute;
+  }
+
+  String _routerLabel(ChatRouter router) {
+    switch (router) {
+      case ChatRouter.defaultRoute:
+        return 'Bricks Default';
+      case ChatRouter.openclaw:
+        return 'OpenClaw';
+    }
+  }
+
+  String _threadRouterMenuLabel(ChatRouter? router) {
+    if (router == null) return 'Follow channel';
+    return _routerLabel(router);
+  }
+
+  String _activeRouterSummary() {
+    final effective = _routerLabel(_effectiveRouterForScope());
+    final channel = _routerLabel(
+      _channelRouters[_activeChannelId] ?? ChatRouter.defaultRoute,
+    );
+    final thread = _threadRouterMenuLabel(_explicitThreadRouter());
+    return 'Router: $effective · Channel $channel · Thread $thread';
+  }
+
+  Future<void> _saveChannelRouter(ChatRouter router) async {
+    final token = _authToken;
+    if (token == null || token.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Missing auth token')));
+      return;
+    }
+
+    final channelId = _activeChannelId;
+    final previous = _channelRouters[channelId];
+    setState(() {
+      if (router == ChatRouter.defaultRoute) {
+        _channelRouters.remove(channelId);
+      } else {
+        _channelRouters[channelId] = router;
+      }
+    });
+    _configureActiveScopeSync();
+
+    try {
+      await _chatHistoryApiService.saveScopeSetting(
+        token: token,
+        scopeType: ChatScopeType.channel,
+        channelId: channelId,
+        router: router == ChatRouter.defaultRoute ? null : router,
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Channel router set to ${_routerLabel(router)}'),
+        ),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        if (previous == null) {
+          _channelRouters.remove(channelId);
+        } else {
+          _channelRouters[channelId] = previous;
+        }
+      });
+      _configureActiveScopeSync();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to save channel router: $error')),
+      );
+    }
+  }
+
+  Future<void> _saveThreadRouter(ChatRouter? router) async {
+    final token = _authToken;
+    if (token == null || token.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Missing auth token')));
+      return;
+    }
+
+    final channelId = _activeChannelId;
+    final threadId = _activeSubSection;
+    final key = _subSectionKey(channelId, threadId);
+    final previous = _threadRouters[key];
+    setState(() {
+      if (router == null) {
+        _threadRouters.remove(key);
+      } else {
+        _threadRouters[key] = router;
+      }
+    });
+    _configureActiveScopeSync();
+
+    try {
+      await _chatHistoryApiService.saveScopeSetting(
+        token: token,
+        scopeType: ChatScopeType.thread,
+        channelId: channelId,
+        threadId: threadId,
+        router: router,
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Thread router set to ${_threadRouterMenuLabel(router)}',
+          ),
+        ),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        if (previous == null) {
+          _threadRouters.remove(key);
+        } else {
+          _threadRouters[key] = previous;
+        }
+      });
+      _configureActiveScopeSync();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to save thread router: $error')),
+      );
+    }
+  }
+
+  void _handleRouterMenuSelection(String value) {
+    switch (value) {
+      case 'channel:default':
+        unawaited(_saveChannelRouter(ChatRouter.defaultRoute));
+        return;
+      case 'channel:openclaw':
+        unawaited(_saveChannelRouter(ChatRouter.openclaw));
+        return;
+      case 'thread:inherit':
+        unawaited(_saveThreadRouter(null));
+        return;
+      case 'thread:default':
+        unawaited(_saveThreadRouter(ChatRouter.defaultRoute));
+        return;
+      case 'thread:openclaw':
+        unawaited(_saveThreadRouter(ChatRouter.openclaw));
+        return;
+    }
+  }
 
   void _updateSubSectionLastMessageAtFromMessages({
     String? channelId,
@@ -643,8 +889,11 @@ class _ChatScreenState extends State<ChatScreen> {
     });
     if (latest == null) return;
     setState(() {
-      _subSectionLastMessageAt[
-          _subSectionKey(resolvedChannelId, resolvedSubSection)] = latest;
+      _subSectionLastMessageAt[_subSectionKey(
+            resolvedChannelId,
+            resolvedSubSection,
+          )] =
+          latest;
     });
   }
 
@@ -677,13 +926,168 @@ class _ChatScreenState extends State<ChatScreen> {
       _chatHistoryApiService
           .upsertMessages(token: token, messages: _messages)
           .then((lastSeq) {
-        if (!mounted || lastSeq <= 0) return;
-        // Only advance the cursor, never move it backwards.
-        setState(() {
-          if (lastSeq > _lastSyncedSeq) _lastSyncedSeq = lastSeq;
-        });
-      }).catchError((_) {}),
+            if (!mounted || lastSeq <= 0) return;
+            // Only advance the cursor, never move it backwards.
+            setState(() {
+              if (lastSeq > _lastSyncedSeq) _lastSyncedSeq = lastSeq;
+            });
+          })
+          .catchError((_) {}),
     );
+  }
+
+  bool _hasPendingAssistantTasks() {
+    return _messages.any(
+      (message) =>
+          message.role == 'assistant' &&
+          (message.taskState == ChatTaskState.accepted ||
+              message.taskState == ChatTaskState.dispatched),
+    );
+  }
+
+  bool _shouldSyncActiveScope() {
+    final token = _authToken;
+    if (token == null || token.isEmpty) return false;
+    if (_effectiveRouterForScope() == ChatRouter.openclaw) return true;
+    return _hasPendingAssistantTasks();
+  }
+
+  void _configureActiveScopeSync({bool triggerNow = true}) {
+    if (!_shouldSyncActiveScope()) {
+      _syncTimer?.cancel();
+      _syncTimer = null;
+      return;
+    }
+    _syncTimer ??= Timer.periodic(const Duration(seconds: 2), (_) {
+      unawaited(_syncActiveScope());
+    });
+    if (triggerNow) {
+      unawaited(_syncActiveScope());
+    }
+  }
+
+  ChatTaskState? _normalizedServerTaskState(
+    ChatMessage message, {
+    ChatTaskState? fallback,
+  }) {
+    if (message.taskState != null) return message.taskState;
+    if (message.role == 'assistant' && message.content.trim().isNotEmpty) {
+      return ChatTaskState.completed;
+    }
+    return fallback;
+  }
+
+  ChatMessage _mergeServerMessage(ChatMessage current, ChatMessage incoming) {
+    return incoming.copyWith(
+      agentId: incoming.agentId ?? current.agentId,
+      agentName: incoming.agentName ?? current.agentName,
+      idempotencyKey: current.idempotencyKey,
+      acknowledgedAt: incoming.acknowledgedAt ?? current.acknowledgedAt,
+      checkpointCursor: incoming.checkpointCursor ?? current.checkpointCursor,
+      resolvedBotId: incoming.resolvedBotId ?? current.resolvedBotId,
+      resolvedSkillId: incoming.resolvedSkillId ?? current.resolvedSkillId,
+      arbitrationMode: current.arbitrationMode,
+      fallbackToDefaultBot: current.fallbackToDefaultBot,
+      decisionReason: current.decisionReason,
+      traceId: current.traceId,
+      tieDetected: current.tieDetected,
+      tieBotIds: current.tieBotIds,
+      selectedScore: current.selectedScore,
+      candidateScoreSummary: current.candidateScoreSummary,
+      isStreaming: false,
+      taskState: _normalizedServerTaskState(
+        incoming,
+        fallback: current.taskState,
+      ),
+    );
+  }
+
+  int _compareChatMessages(ChatMessage a, ChatMessage b) {
+    final aTime = a.createdAt ?? a.timestamp;
+    final bTime = b.createdAt ?? b.timestamp;
+    final byTime = aTime.compareTo(bTime);
+    if (byTime != 0) return byTime;
+    if (a.role != b.role) {
+      if (a.role == 'user') return -1;
+      if (b.role == 'user') return 1;
+    }
+    return (a.messageId ?? '').compareTo(b.messageId ?? '');
+  }
+
+  List<ChatMessage> _mergeSyncedMessages(
+    List<ChatMessage> current,
+    List<ChatMessage> incoming,
+  ) {
+    final merged = [...current];
+    final byId = <String, int>{};
+    for (var i = 0; i < merged.length; i++) {
+      final messageId = merged[i].messageId;
+      if (messageId != null && messageId.isNotEmpty) {
+        byId[messageId] = i;
+      }
+    }
+
+    for (final message in incoming) {
+      final normalized = message.copyWith(
+        isStreaming: false,
+        taskState: _normalizedServerTaskState(message),
+      );
+      final messageId = normalized.messageId;
+      if (messageId != null && byId.containsKey(messageId)) {
+        final index = byId[messageId]!;
+        merged[index] = _mergeServerMessage(merged[index], normalized);
+        continue;
+      }
+      merged.add(normalized);
+      if (messageId != null && messageId.isNotEmpty) {
+        byId[messageId] = merged.length - 1;
+      }
+    }
+
+    merged.sort(_compareChatMessages);
+    return merged;
+  }
+
+  Future<void> _syncActiveScope() async {
+    if (_syncInFlight) return;
+    final token = _authToken;
+    if (token == null || token.isEmpty) return;
+
+    final capturedSessionId = _sessionIdForScope;
+    final capturedChannelId = _activeChannelId;
+    final capturedSubSection = _activeSubSection;
+    _syncInFlight = true;
+    try {
+      final snapshot = await _chatHistoryApiService.sync(
+        token: token,
+        sessionId: capturedSessionId,
+        afterSeq: _lastSyncedSeq,
+      );
+      if (!mounted || _sessionIdForScope != capturedSessionId) return;
+      if (snapshot.messages.isEmpty && snapshot.lastSeqId <= _lastSyncedSeq) {
+        return;
+      }
+      final merged = _mergeSyncedMessages(_messages, snapshot.messages);
+      setState(() {
+        _messages
+          ..clear()
+          ..addAll(merged);
+        if (snapshot.lastSeqId > _lastSyncedSeq) {
+          _lastSyncedSeq = snapshot.lastSeqId;
+        }
+      });
+      _updateSubSectionLastMessageAtFromMessages(
+        channelId: capturedChannelId,
+        subSection: capturedSubSection,
+      );
+    } catch (error) {
+      debugPrint('chat scope sync failed: $error');
+    } finally {
+      _syncInFlight = false;
+      if (mounted) {
+        _configureActiveScopeSync(triggerNow: false);
+      }
+    }
   }
 
   void _createSubSection() {
@@ -697,7 +1101,9 @@ class _ChatScreenState extends State<ChatScreen> {
     );
     setState(() {
       final items = _channelSubSections.putIfAbsent(
-          _activeChannelId, () => <ChatSubSection>[]);
+        _activeChannelId,
+        () => <ChatSubSection>[],
+      );
       items.add(section);
       _activeSubSection = id;
       _messages.clear();
@@ -705,6 +1111,7 @@ class _ChatScreenState extends State<ChatScreen> {
       _lastSyncedSeq = 0;
     });
     _persistActiveScopeMessages();
+    _configureActiveScopeSync();
   }
 
   Future<AgentSession> _sessionForAgent(AgentDefinition? agent) async {
@@ -736,16 +1143,18 @@ class _ChatScreenState extends State<ChatScreen> {
       messageId: message.messageId ?? _newId('msg'),
       channelId: message.channelId ?? _activeScope.channelId,
       sessionId: message.sessionId ?? _activeScope.sessionId,
-      threadId: message.threadId ??
+      threadId:
+          message.threadId ??
           (_activeScope.threadId == 'main' ? null : _activeScope.threadId),
     );
     final messageTime = normalized.createdAt ?? normalized.timestamp;
     setState(() {
       _messages.add(normalized);
       _subSectionLastMessageAt[_subSectionKey(
-        _activeScope.channelId,
-        _activeScope.threadId,
-      )] = messageTime;
+            _activeScope.channelId,
+            _activeScope.threadId,
+          )] =
+          messageTime;
     });
     final shouldPersistImmediately =
         normalized.role == 'user' || (!normalized.isStreaming);
@@ -758,8 +1167,9 @@ class _ChatScreenState extends State<ChatScreen> {
 
     final agent = _activeAgent;
     final activeParticipants = _participantManager.participants.active;
-    final positiveCandidates =
-        activeParticipants.where((item) => item.probability > 1e-9).toList();
+    final positiveCandidates = activeParticipants
+        .where((item) => item.probability > 1e-9)
+        .toList();
     final arbitrationMode = positiveCandidates.length > 1;
     final arbitration = _arbitrationEngine.resolve(
       candidates: positiveCandidates
@@ -870,57 +1280,72 @@ class _ChatScreenState extends State<ChatScreen> {
     final generation = ++_respondGeneration;
     _chatHistoryApiService
         .respond(
-      token: token,
-      taskId: taskId,
-      idempotencyKey: idempotencyKey,
-      scope: _activeScope,
-      userMessageId: _messages[agentMessageIndex - 1].messageId!,
-      assistantMessageId: _messages[agentMessageIndex].messageId!,
-      userMessage: text,
-      resolvedBotId: resolvedBotId,
-      resolvedSkillId: resolvedSkillId,
-      provider: runtimeSettings.provider,
-      model: runtimeSettings.model,
-      configId: runtimeSettings.configId,
-      createdAt: envelope.createdAt,
-    )
+          token: token,
+          taskId: taskId,
+          idempotencyKey: idempotencyKey,
+          scope: _activeScope,
+          userMessageId: _messages[agentMessageIndex - 1].messageId!,
+          assistantMessageId: _messages[agentMessageIndex].messageId!,
+          userMessage: text,
+          resolvedBotId: resolvedBotId,
+          resolvedSkillId: resolvedSkillId,
+          provider: runtimeSettings.provider,
+          model: runtimeSettings.model,
+          configId: runtimeSettings.configId,
+          createdAt: envelope.createdAt,
+        )
         .then((result) async {
-      if (!mounted || agentMessageIndex >= _messages.length) return;
-      // Ignore stale completions if stop was pressed after this request started.
-      if (generation != _respondGeneration) return;
-      setState(() {
-        _messages[agentMessageIndex] = _messages[agentMessageIndex].copyWith(
-          content: result.text,
-          isStreaming: false,
-          taskState: ChatTaskState.completed,
-        );
-        if (result.lastSeqId > _lastSyncedSeq) {
-          _lastSyncedSeq = result.lastSeqId;
-        }
-      });
-      // Backend already persisted both messages; skip redundant client-side
-      // upsert to avoid overwriting backend-only metadata (provider/model/source).
-      if (mounted) {
-        await _handleProactiveResponses(text);
-        setState(() {
-          _isSending = false;
-          _isStreaming = false;
+          if (!mounted || agentMessageIndex >= _messages.length) return;
+          // Ignore stale completions if stop was pressed after this request started.
+          if (generation != _respondGeneration) return;
+          setState(() {
+            _messages[agentMessageIndex] = _messages[agentMessageIndex]
+                .copyWith(
+                  content: result.text,
+                  isStreaming: false,
+                  taskState:
+                      result.taskState ??
+                      (result.isAsync
+                          ? ChatTaskState.dispatched
+                          : ChatTaskState.completed),
+                );
+            if (result.lastSeqId > _lastSyncedSeq) {
+              _lastSyncedSeq = result.lastSeqId;
+            }
+            if (result.isAsync) {
+              _isSending = false;
+              _isStreaming = false;
+            }
+          });
+          if (result.isAsync) {
+            _configureActiveScopeSync();
+            return;
+          }
+          // Backend already persisted both messages; skip redundant client-side
+          // upsert to avoid overwriting backend-only metadata (provider/model/source).
+          if (mounted) {
+            await _handleProactiveResponses(text);
+            setState(() {
+              _isSending = false;
+              _isStreaming = false;
+            });
+          }
+        })
+        .catchError((error) {
+          if (!mounted || agentMessageIndex >= _messages.length) return;
+          if (generation != _respondGeneration) return;
+          setState(() {
+            _messages[agentMessageIndex] = _messages[agentMessageIndex]
+                .copyWith(
+                  content: 'Error: $error',
+                  isStreaming: false,
+                  taskState: ChatTaskState.failed,
+                );
+            _isSending = false;
+            _isStreaming = false;
+          });
+          _persistActiveScopeMessages(immediate: true);
         });
-      }
-    }).catchError((error) {
-      if (!mounted || agentMessageIndex >= _messages.length) return;
-      if (generation != _respondGeneration) return;
-      setState(() {
-        _messages[agentMessageIndex] = _messages[agentMessageIndex].copyWith(
-          content: 'Error: $error',
-          isStreaming: false,
-          taskState: ChatTaskState.failed,
-        );
-        _isSending = false;
-        _isStreaming = false;
-      });
-      _persistActiveScopeMessages(immediate: true);
-    });
   }
 
   void _stopStreaming() {
@@ -1107,9 +1532,7 @@ class _ChatScreenState extends State<ChatScreen> {
   @override
   Widget build(BuildContext context) {
     if (_loadingAgents || _loadingLlmConfigs) {
-      return const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
-      );
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
 
     final activeAgentName = _activeAgent?.name;
@@ -1169,9 +1592,54 @@ class _ChatScreenState extends State<ChatScreen> {
                   'Responding as @$activeAgentName',
                   style: Theme.of(context).textTheme.labelSmall,
                 ),
+              Text(
+                _activeRouterSummary(),
+                style: Theme.of(context).textTheme.labelSmall,
+              ),
             ],
           ),
           actions: [
+            PopupMenuButton<String>(
+              popUpAnimationStyle: BricksTheme.menuPopupAnimationStyle,
+              tooltip: 'Router settings',
+              onSelected: _handleRouterMenuSelection,
+              itemBuilder: (context) => [
+                PopupMenuItem<String>(
+                  enabled: false,
+                  child: Text(
+                    'Channel router · ${_routerLabel(_channelRouters[_activeChannelId] ?? ChatRouter.defaultRoute)}',
+                  ),
+                ),
+                const PopupMenuItem<String>(
+                  value: 'channel:default',
+                  child: Text('Bricks Default'),
+                ),
+                const PopupMenuItem<String>(
+                  value: 'channel:openclaw',
+                  child: Text('OpenClaw'),
+                ),
+                const PopupMenuDivider(),
+                PopupMenuItem<String>(
+                  enabled: false,
+                  child: Text(
+                    'Thread router · ${_threadRouterMenuLabel(_explicitThreadRouter())}',
+                  ),
+                ),
+                const PopupMenuItem<String>(
+                  value: 'thread:inherit',
+                  child: Text('Follow channel'),
+                ),
+                const PopupMenuItem<String>(
+                  value: 'thread:default',
+                  child: Text('Bricks Default'),
+                ),
+                const PopupMenuItem<String>(
+                  value: 'thread:openclaw',
+                  child: Text('OpenClaw'),
+                ),
+              ],
+              icon: const Icon(Icons.alt_route),
+            ),
             PopupMenuButton<String>(
               popUpAnimationStyle: BricksTheme.menuPopupAnimationStyle,
               tooltip: 'Sub sections',
@@ -1180,17 +1648,19 @@ class _ChatScreenState extends State<ChatScreen> {
                   _createSubSection();
                   unawaited(_loadMessagesForActiveScope());
                 } else {
+                  _syncTimer?.cancel();
+                  _syncTimer = null;
                   setState(() {
                     _activeSubSection = value;
+                    _messages.clear();
+                    _latestCheckpointCursor = null;
+                    _lastSyncedSeq = 0;
                   });
                   unawaited(_loadMessagesForActiveScope());
                 }
               },
               itemBuilder: (context) => [
-                const PopupMenuItem<String>(
-                  value: 'main',
-                  child: Text('回到主区'),
-                ),
+                const PopupMenuItem<String>(value: 'main', child: Text('回到主区')),
                 const PopupMenuItem<String>(
                   value: '__new__',
                   child: Text('新建子区'),
@@ -1204,16 +1674,19 @@ class _ChatScreenState extends State<ChatScreen> {
                 ),
               ],
               child: Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: BricksSpacing.md),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: BricksSpacing.md,
+                ),
                 child: Row(
                   children: [
                     const Icon(Icons.splitscreen_outlined),
                     const SizedBox(width: BricksSpacing.xs),
-                    Text(_activeSubSection == 'main'
-                        ? '主区'
-                        : (_subSectionNameById(_activeSubSection) ??
-                            _activeSubSection)),
+                    Text(
+                      _activeSubSection == 'main'
+                          ? '主区'
+                          : (_subSectionNameById(_activeSubSection) ??
+                                _activeSubSection),
+                    ),
                     const Icon(Icons.arrow_drop_down),
                   ],
                 ),

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -213,18 +213,6 @@ class _ChatScreenState extends State<ChatScreen> {
     }
   }
 
-  Future<void> _reloadAgents() async {
-    final repo = _agentsRepository ?? await createAgentsRepository();
-    final definitions = await _readAgentDefinitions(repo);
-    if (!mounted) return;
-    _syncParticipants(definitions);
-    setState(() {
-      _agentsRepository = repo;
-      _agents = definitions;
-      _activeAgent ??= definitions.isNotEmpty ? definitions.first : null;
-    });
-  }
-
   Future<List<AgentDefinition>> _readAgentDefinitions(
     AgentsRepository repository,
   ) async {

--- a/apps/mobile_chat_app/lib/features/chat/chat_topology.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_topology.dart
@@ -1,3 +1,50 @@
+enum ChatRouter { defaultRoute, openclaw }
+
+enum ChatScopeType { channel, thread }
+
+extension ChatRouterApi on ChatRouter {
+  String get apiValue {
+    switch (this) {
+      case ChatRouter.defaultRoute:
+        return 'default';
+      case ChatRouter.openclaw:
+        return 'openclaw';
+    }
+  }
+}
+
+extension ChatScopeTypeApi on ChatScopeType {
+  String get apiValue {
+    switch (this) {
+      case ChatScopeType.channel:
+        return 'channel';
+      case ChatScopeType.thread:
+        return 'thread';
+    }
+  }
+}
+
+ChatRouter chatRouterFromApi(String? value) {
+  switch (value) {
+    case 'openclaw':
+      return ChatRouter.openclaw;
+    case 'default':
+    default:
+      return ChatRouter.defaultRoute;
+  }
+}
+
+ChatScopeType? chatScopeTypeFromApi(String? value) {
+  switch (value) {
+    case 'channel':
+      return ChatScopeType.channel;
+    case 'thread':
+      return ChatScopeType.thread;
+    default:
+      return null;
+  }
+}
+
 class ChatChannel {
   const ChatChannel({
     required this.id,
@@ -39,10 +86,7 @@ class ChatSubSection {
 }
 
 class ChatSessionScope {
-  const ChatSessionScope({
-    required this.channelId,
-    required this.threadId,
-  });
+  const ChatSessionScope({required this.channelId, required this.threadId});
 
   final String channelId;
   final String threadId;
@@ -50,13 +94,31 @@ class ChatSessionScope {
   String get sessionId => 'session:$channelId:$threadId';
 }
 
+class ChatScopeSetting {
+  const ChatScopeSetting({
+    required this.scopeType,
+    required this.channelId,
+    required this.router,
+    this.threadId,
+    this.updatedAt,
+  });
+
+  final ChatScopeType scopeType;
+  final String channelId;
+  final String? threadId;
+  final ChatRouter router;
+  final DateTime? updatedAt;
+}
+
 class ChatTopologyResolver {
   const ChatTopologyResolver({this.defaultChannelId = 'default'});
 
   final String defaultChannelId;
 
-  String resolveChannelId(
-      {required List<ChatChannel> channels, String? requestedChannelId}) {
+  String resolveChannelId({
+    required List<ChatChannel> channels,
+    String? requestedChannelId,
+  }) {
     final requested = requestedChannelId;
     if (requested != null &&
         channels.any((channel) => channel.id == requested)) {

--- a/apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
+++ b/apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
@@ -205,6 +205,49 @@ class LlmConfigService {
     }
   }
 
+  Future<PlatformTokenBundle> fetchPlatformToken({
+    String pluginId = 'plugin_local_main',
+  }) async {
+    final token = await AuthService.getToken();
+    if (token == null || token.isEmpty) {
+      throw Exception('Not authenticated');
+    }
+
+    final response = await http.get(
+      _buildUri('/api/config/platform-token', {'pluginId': pluginId}),
+      headers: {
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception(
+          'Failed to fetch platform token (${response.statusCode})');
+    }
+
+    final decoded = jsonDecode(response.body);
+    if (decoded is! Map) {
+      throw Exception('Invalid platform token payload');
+    }
+    final map = Map<String, dynamic>.from(decoded);
+    final scopesRaw = map['scopes'];
+    final scopes = scopesRaw is List
+        ? scopesRaw
+            .whereType<String>()
+            .map((s) => s.trim())
+            .where((s) => s.isNotEmpty)
+            .toList()
+        : const <String>[];
+
+    return PlatformTokenBundle(
+      token: (map['token'] as String?) ?? '',
+      pluginId: (map['pluginId'] as String?) ?? pluginId,
+      baseUrl: (map['baseUrl'] as String?) ?? resolveBaseUrl(),
+      scopes: scopes,
+      expiresIn: (map['expiresIn'] as String?) ?? '',
+    );
+  }
+
   LlmConfig _fromApiConfig(Map<String, dynamic> config) {
     final rawConfig = config['config'];
     final map = rawConfig is Map
@@ -312,4 +355,20 @@ class LlmConfigService {
         return 'https://api.anthropic.com';
     }
   }
+}
+
+class PlatformTokenBundle {
+  const PlatformTokenBundle({
+    required this.token,
+    required this.pluginId,
+    required this.baseUrl,
+    required this.scopes,
+    required this.expiresIn,
+  });
+
+  final String token;
+  final String pluginId;
+  final String baseUrl;
+  final List<String> scopes;
+  final String expiresIn;
 }

--- a/apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
+++ b/apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
@@ -239,10 +239,14 @@ class LlmConfigService {
             .toList()
         : const <String>[];
 
+    final rawBaseUrl = (map['baseUrl'] as String?)?.trim();
+
     return PlatformTokenBundle(
       token: (map['token'] as String?) ?? '',
       pluginId: (map['pluginId'] as String?) ?? pluginId,
-      baseUrl: (map['baseUrl'] as String?) ?? resolveBaseUrl(),
+      baseUrl: rawBaseUrl != null && rawBaseUrl.isNotEmpty
+          ? rawBaseUrl
+          : resolveBaseUrl(),
       scopes: scopes,
       expiresIn: (map['expiresIn'] as String?) ?? '',
     );

--- a/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
+++ b/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
@@ -28,8 +28,6 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
   bool _saving = false;
   bool _deleting = false;
   bool _showApiKey = false;
-  bool _loadingPlatformToken = false;
-  PlatformTokenBundle? _platformTokenBundle;
 
   @override
   void initState() {
@@ -264,32 +262,6 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
     refreshedMessenger.showSnackBar(SnackBar(content: Text(successMessage)));
   }
 
-  Future<void> _loadPlatformToken() async {
-    if (_loadingPlatformToken) return;
-    setState(() => _loadingPlatformToken = true);
-    try {
-      final bundle = await _service.fetchPlatformToken();
-      if (!mounted) return;
-      setState(() => _platformTokenBundle = bundle);
-      final messenger = ScaffoldMessenger.maybeOf(context);
-      messenger?.hideCurrentSnackBar();
-      messenger?.showSnackBar(
-        const SnackBar(content: Text('小龙虾 Token 已生成，可复制到远端服务')),
-      );
-    } catch (_) {
-      if (!mounted) return;
-      final messenger = ScaffoldMessenger.maybeOf(context);
-      messenger?.hideCurrentSnackBar();
-      messenger?.showSnackBar(
-        const SnackBar(content: Text('获取小龙虾 Token 失败')),
-      );
-    } finally {
-      if (mounted) {
-        setState(() => _loadingPlatformToken = false);
-      }
-    }
-  }
-
   Widget _buildConfigSelector() {
     return Wrap(
       spacing: 8,
@@ -456,72 +428,6 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
                     'Config Slot: ${_activeSlotIdHint()}',
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
-                  const SizedBox(height: 24),
-                  const Divider(),
-                  const SizedBox(height: 12),
-                  Text(
-                    'OpenClaw / 小龙虾 对接',
-                    style: Theme.of(context).textTheme.titleSmall,
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    children: [
-                      OutlinedButton.icon(
-                        onPressed:
-                            _loadingPlatformToken ? null : _loadPlatformToken,
-                        icon: _loadingPlatformToken
-                            ? const SizedBox(
-                                width: 16,
-                                height: 16,
-                                child:
-                                    CircularProgressIndicator(strokeWidth: 2),
-                              )
-                            : const Icon(Icons.vpn_key_outlined),
-                        label: Text(
-                          _loadingPlatformToken
-                              ? 'Generating...'
-                              : 'Get Xiaolongxia Token',
-                        ),
-                      ),
-                    ],
-                  ),
-                  if (_platformTokenBundle != null) ...[
-                    const SizedBox(height: 8),
-                    Text(
-                      'Plugin ID: ${_platformTokenBundle!.pluginId}',
-                      style: Theme.of(context).textTheme.bodySmall,
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      'Base URL: ${_platformTokenBundle!.baseUrl}',
-                      style: Theme.of(context).textTheme.bodySmall,
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      'Scopes: ${_platformTokenBundle!.scopes.join(', ')}',
-                      style: Theme.of(context).textTheme.bodySmall,
-                    ),
-                    const SizedBox(height: 8),
-                    TextFormField(
-                      key: ValueKey(_platformTokenBundle!.token),
-                      initialValue: _platformTokenBundle!.token,
-                      readOnly: true,
-                      decoration: InputDecoration(
-                        labelText: 'Xiaolongxia Token',
-                        suffixIcon: IconButton(
-                          tooltip: 'Copy Xiaolongxia Token',
-                          icon: const Icon(Icons.copy_outlined),
-                          onPressed: () {
-                            _copyToClipboard(
-                              value: _platformTokenBundle!.token,
-                              emptyMessage: 'Xiaolongxia Token is empty',
-                              successMessage: 'Xiaolongxia Token copied',
-                            );
-                          },
-                        ),
-                      ),
-                    ),
-                  ],
                   const SizedBox(height: 24),
                   Row(
                     children: [

--- a/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
+++ b/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
@@ -503,6 +503,7 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
                     ),
                     const SizedBox(height: 8),
                     TextFormField(
+                      key: ValueKey(_platformTokenBundle!.token),
                       initialValue: _platformTokenBundle!.token,
                       readOnly: true,
                       decoration: InputDecoration(

--- a/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
+++ b/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'llm_config_service.dart';
 
@@ -237,6 +238,25 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
     }
   }
 
+  Future<void> _copyToClipboard({
+    required String value,
+    required String emptyMessage,
+    required String successMessage,
+  }) async {
+    final text = value.trim();
+    if (text.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(emptyMessage)));
+      return;
+    }
+    await Clipboard.setData(ClipboardData(text: text));
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(successMessage)));
+  }
+
   Widget _buildConfigSelector() {
     return Wrap(
       spacing: 8,
@@ -298,7 +318,20 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
                   const SizedBox(height: 12),
                   TextFormField(
                     controller: _baseUrlController,
-                    decoration: const InputDecoration(labelText: 'Base URL'),
+                    decoration: InputDecoration(
+                      labelText: 'Base URL',
+                      suffixIcon: IconButton(
+                        tooltip: 'Copy API URL',
+                        icon: const Icon(Icons.copy_outlined),
+                        onPressed: () {
+                          _copyToClipboard(
+                            value: _baseUrlController.text,
+                            emptyMessage: 'API URL is empty',
+                            successMessage: 'API URL copied',
+                          );
+                        },
+                      ),
+                    ),
                     validator: (value) {
                       final text = value?.trim() ?? '';
                       if (text.isEmpty) return 'Base URL is required';
@@ -318,12 +351,32 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
                       helperText: _configs[_activeConfigIndex].id == null
                           ? null
                           : 'Leave blank to keep your existing key',
-                      suffixIcon: IconButton(
-                        icon: Icon(
-                          _showApiKey ? Icons.visibility_off : Icons.visibility,
-                        ),
-                        onPressed: () =>
-                            setState(() => _showApiKey = !_showApiKey),
+                      suffixIcon: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            tooltip: 'Copy API Key',
+                            icon: const Icon(Icons.copy_outlined),
+                            onPressed: () {
+                              _copyToClipboard(
+                                value: _apiKeyController.text,
+                                emptyMessage: 'API Key is empty',
+                                successMessage: 'API Key copied',
+                              );
+                            },
+                          ),
+                          IconButton(
+                            tooltip:
+                                _showApiKey ? 'Hide API key' : 'Show API key',
+                            icon: Icon(
+                              _showApiKey
+                                  ? Icons.visibility_off
+                                  : Icons.visibility,
+                            ),
+                            onPressed: () =>
+                                setState(() => _showApiKey = !_showApiKey),
+                          ),
+                        ],
                       ),
                     ),
                     validator: (value) {

--- a/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
+++ b/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
@@ -28,6 +28,8 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
   bool _saving = false;
   bool _deleting = false;
   bool _showApiKey = false;
+  bool _loadingPlatformToken = false;
+  PlatformTokenBundle? _platformTokenBundle;
 
   @override
   void initState() {
@@ -243,18 +245,49 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
     required String emptyMessage,
     required String successMessage,
   }) async {
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+
     final text = value.trim();
+    messenger.hideCurrentSnackBar();
     if (text.isEmpty) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(emptyMessage)));
+      messenger.showSnackBar(SnackBar(content: Text(emptyMessage)));
       return;
     }
     await Clipboard.setData(ClipboardData(text: text));
     if (!mounted) return;
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(successMessage)));
+
+    final refreshedMessenger = ScaffoldMessenger.maybeOf(context);
+    if (refreshedMessenger == null) return;
+    refreshedMessenger.hideCurrentSnackBar();
+    refreshedMessenger.showSnackBar(SnackBar(content: Text(successMessage)));
+  }
+
+  Future<void> _loadPlatformToken() async {
+    if (_loadingPlatformToken) return;
+    setState(() => _loadingPlatformToken = true);
+    try {
+      final bundle = await _service.fetchPlatformToken();
+      if (!mounted) return;
+      setState(() => _platformTokenBundle = bundle);
+      final messenger = ScaffoldMessenger.maybeOf(context);
+      messenger?.hideCurrentSnackBar();
+      messenger?.showSnackBar(
+        const SnackBar(content: Text('小龙虾 Token 已生成，可复制到远端服务')),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      final messenger = ScaffoldMessenger.maybeOf(context);
+      messenger?.hideCurrentSnackBar();
+      messenger?.showSnackBar(
+        const SnackBar(content: Text('获取小龙虾 Token 失败')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _loadingPlatformToken = false);
+      }
+    }
   }
 
   Widget _buildConfigSelector() {
@@ -423,6 +456,71 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
                     'Config Slot: ${_activeSlotIdHint()}',
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
+                  const SizedBox(height: 24),
+                  const Divider(),
+                  const SizedBox(height: 12),
+                  Text(
+                    'OpenClaw / 小龙虾 对接',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      OutlinedButton.icon(
+                        onPressed:
+                            _loadingPlatformToken ? null : _loadPlatformToken,
+                        icon: _loadingPlatformToken
+                            ? const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Icon(Icons.vpn_key_outlined),
+                        label: Text(
+                          _loadingPlatformToken
+                              ? 'Generating...'
+                              : 'Get Xiaolongxia Token',
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (_platformTokenBundle != null) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      'Plugin ID: ${_platformTokenBundle!.pluginId}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      'Base URL: ${_platformTokenBundle!.baseUrl}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      'Scopes: ${_platformTokenBundle!.scopes.join(', ')}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    const SizedBox(height: 8),
+                    TextFormField(
+                      initialValue: _platformTokenBundle!.token,
+                      readOnly: true,
+                      decoration: InputDecoration(
+                        labelText: 'Xiaolongxia Token',
+                        suffixIcon: IconButton(
+                          tooltip: 'Copy Xiaolongxia Token',
+                          icon: const Icon(Icons.copy_outlined),
+                          onPressed: () {
+                            _copyToClipboard(
+                              value: _platformTokenBundle!.token,
+                              emptyMessage: 'Xiaolongxia Token is empty',
+                              successMessage: 'Xiaolongxia Token copied',
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+                  ],
                   const SizedBox(height: 24),
                   Row(
                     children: [

--- a/apps/mobile_chat_app/lib/features/settings/openclaw_token_settings_screen.dart
+++ b/apps/mobile_chat_app/lib/features/settings/openclaw_token_settings_screen.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'llm_config_service.dart';
+
+class OpenclawTokenSettingsScreen extends StatefulWidget {
+  const OpenclawTokenSettingsScreen({super.key, LlmConfigService? service})
+      : _service = service ?? const LlmConfigService();
+
+  final LlmConfigService _service;
+
+  @override
+  State<OpenclawTokenSettingsScreen> createState() =>
+      _OpenclawTokenSettingsScreenState();
+}
+
+class _OpenclawTokenSettingsScreenState
+    extends State<OpenclawTokenSettingsScreen> {
+  late final LlmConfigService _service;
+  bool _loadingPlatformToken = false;
+  PlatformTokenBundle? _platformTokenBundle;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget._service;
+  }
+
+  Future<void> _copyToClipboard({
+    required String value,
+    required String emptyMessage,
+    required String successMessage,
+  }) async {
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+
+    final text = value.trim();
+    messenger.hideCurrentSnackBar();
+    if (text.isEmpty) {
+      messenger.showSnackBar(SnackBar(content: Text(emptyMessage)));
+      return;
+    }
+    await Clipboard.setData(ClipboardData(text: text));
+    if (!mounted) return;
+
+    final refreshedMessenger = ScaffoldMessenger.maybeOf(context);
+    if (refreshedMessenger == null) return;
+    refreshedMessenger.hideCurrentSnackBar();
+    refreshedMessenger.showSnackBar(SnackBar(content: Text(successMessage)));
+  }
+
+  Future<void> _loadPlatformToken() async {
+    if (_loadingPlatformToken) return;
+    setState(() => _loadingPlatformToken = true);
+    try {
+      final bundle = await _service.fetchPlatformToken();
+      if (!mounted) return;
+      setState(() => _platformTokenBundle = bundle);
+      final messenger = ScaffoldMessenger.maybeOf(context);
+      messenger?.hideCurrentSnackBar();
+      messenger?.showSnackBar(
+        const SnackBar(content: Text('Openclaw Token generated')),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      final messenger = ScaffoldMessenger.maybeOf(context);
+      messenger?.hideCurrentSnackBar();
+      messenger?.showSnackBar(
+        const SnackBar(content: Text('Failed to generate Openclaw Token')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _loadingPlatformToken = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Openclaw Token')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          OutlinedButton.icon(
+            onPressed: _loadingPlatformToken ? null : _loadPlatformToken,
+            icon: _loadingPlatformToken
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.vpn_key_outlined),
+            label: Text(
+                _loadingPlatformToken ? 'Generating...' : 'Openclaw Token'),
+          ),
+          if (_platformTokenBundle != null) ...[
+            const SizedBox(height: 12),
+            Text('Plugin ID: ${_platformTokenBundle!.pluginId}'),
+            const SizedBox(height: 6),
+            Text('Base URL: ${_platformTokenBundle!.baseUrl}'),
+            const SizedBox(height: 6),
+            Text('Scopes: ${_platformTokenBundle!.scopes.join(', ')}'),
+            const SizedBox(height: 8),
+            TextFormField(
+              key: ValueKey(_platformTokenBundle!.token),
+              initialValue: _platformTokenBundle!.token,
+              readOnly: true,
+              decoration: InputDecoration(
+                labelText: 'Openclaw Token',
+                suffixIcon: IconButton(
+                  tooltip: 'Copy Openclaw Token',
+                  icon: const Icon(Icons.copy_outlined),
+                  onPressed: () {
+                    _copyToClipboard(
+                      value: _platformTokenBundle!.token,
+                      emptyMessage: 'Openclaw Token is empty',
+                      successMessage: 'Openclaw Token copied',
+                    );
+                  },
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile_chat_app/lib/features/settings/settings_screen.dart
+++ b/apps/mobile_chat_app/lib/features/settings/settings_screen.dart
@@ -71,7 +71,7 @@ class SettingsScreen extends StatelessWidget {
             leading: const Icon(Icons.vpn_key_outlined),
             title: const Text('Openclaw Token'),
             subtitle:
-                const Text('Generate plugin token for OpenClaw integration'),
+                const Text('Generate plugin token for Openclaw integration'),
             onTap: () {
               Navigator.of(context).push(
                 MaterialPageRoute<void>(

--- a/apps/mobile_chat_app/lib/features/settings/settings_screen.dart
+++ b/apps/mobile_chat_app/lib/features/settings/settings_screen.dart
@@ -3,6 +3,7 @@ import '../agents/agents_screen.dart';
 import '../auth/auth_service.dart';
 import '../auth/login_screen.dart';
 import 'model_settings_screen.dart';
+import 'openclaw_token_settings_screen.dart';
 
 /// Screen for managing app and agent settings.
 class SettingsScreen extends StatelessWidget {
@@ -62,6 +63,19 @@ class SettingsScreen extends StatelessWidget {
               Navigator.of(context).push(
                 MaterialPageRoute<void>(
                   builder: (_) => const AgentsScreen(),
+                ),
+              );
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.vpn_key_outlined),
+            title: const Text('Openclaw Token'),
+            subtitle:
+                const Text('Generate plugin token for OpenClaw integration'),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const OpenclawTokenSettingsScreen(),
                 ),
               );
             },

--- a/apps/mobile_chat_app/test/chat_history_api_service_test.dart
+++ b/apps/mobile_chat_app/test/chat_history_api_service_test.dart
@@ -98,42 +98,44 @@ void main() {
     expect(lastSeq, equals(7));
   });
 
-  test('filters transient empty assistant placeholder before persistence',
-      () async {
-    final client = MockClient((request) async {
-      expect(request.url.path.endsWith('/messages/batch'), isTrue);
-      final decoded = jsonDecode(request.body) as Map<String, dynamic>;
-      final messages =
-          (decoded['messages'] as List).cast<Map<String, dynamic>>();
-      expect(messages, hasLength(1));
-      expect(messages.single['messageId'], equals('msg-user'));
-      return http.Response(jsonEncode({'lastSeqId': 8}), 200);
-    });
+  test(
+    'filters transient empty assistant placeholder before persistence',
+    () async {
+      final client = MockClient((request) async {
+        expect(request.url.path.endsWith('/messages/batch'), isTrue);
+        final decoded = jsonDecode(request.body) as Map<String, dynamic>;
+        final messages = (decoded['messages'] as List)
+            .cast<Map<String, dynamic>>();
+        expect(messages, hasLength(1));
+        expect(messages.single['messageId'], equals('msg-user'));
+        return http.Response(jsonEncode({'lastSeqId': 8}), 200);
+      });
 
-    final service = ChatHistoryApiService(httpClient: client);
-    final lastSeq = await service.upsertMessages(
-      token: 'token-1',
-      messages: [
-        ChatMessage(
-          messageId: 'msg-user',
-          role: 'user',
-          content: 'DDD',
-          channelId: 'default',
-          sessionId: 'session:default:main',
-        ),
-        ChatMessage(
-          messageId: 'msg-assistant',
-          role: 'assistant',
-          content: '',
-          isStreaming: true,
-          channelId: 'default',
-          sessionId: 'session:default:main',
-        ),
-      ],
-    );
+      final service = ChatHistoryApiService(httpClient: client);
+      final lastSeq = await service.upsertMessages(
+        token: 'token-1',
+        messages: [
+          ChatMessage(
+            messageId: 'msg-user',
+            role: 'user',
+            content: 'DDD',
+            channelId: 'default',
+            sessionId: 'session:default:main',
+          ),
+          ChatMessage(
+            messageId: 'msg-assistant',
+            role: 'assistant',
+            content: '',
+            isStreaming: true,
+            channelId: 'default',
+            sessionId: 'session:default:main',
+          ),
+        ],
+      );
 
-    expect(lastSeq, equals(8));
-  });
+      expect(lastSeq, equals(8));
+    },
+  );
 
   test('respond sends one backend-owned orchestration request', () async {
     final client = MockClient((request) async {
@@ -142,7 +144,15 @@ void main() {
       final decoded = jsonDecode(request.body) as Map<String, dynamic>;
       expect(decoded['taskId'], equals('task-2'));
       expect(decoded['userMessage'], equals('1+3'));
-      return http.Response(jsonEncode({'text': '4', 'lastSeqId': 12}), 200);
+      return http.Response(
+        jsonEncode({
+          'text': '4',
+          'lastSeqId': 12,
+          'mode': 'sync',
+          'state': 'completed',
+        }),
+        200,
+      );
     });
 
     final service = ChatHistoryApiService(httpClient: client);
@@ -160,6 +170,8 @@ void main() {
 
     expect(result.text, equals('4'));
     expect(result.lastSeqId, equals(12));
+    expect(result.isAsync, isFalse);
+    expect(result.taskState, ChatTaskState.completed);
   });
 
   test('loads persisted scopes for channel/sidebar hydration', () async {
@@ -194,5 +206,53 @@ void main() {
     expect(scopes.first.channelId, equals('channel-1'));
     expect(scopes.first.threadId, equals('sub-1'));
     expect(scopes.first.sessionId, equals('session:channel-1:sub-1'));
+  });
+
+  test('loads scope settings and saves router updates', () async {
+    final client = MockClient((request) async {
+      if (request.method == 'GET') {
+        expect(request.url.path.endsWith('/chat/scope-settings'), isTrue);
+        return http.Response(
+          jsonEncode({
+            'settings': [
+              {
+                'scopeType': 'channel',
+                'channelId': 'default',
+                'router': 'openclaw',
+                'updatedAt': '2026-04-17T07:00:00.000Z',
+              },
+            ],
+          }),
+          200,
+        );
+      }
+
+      expect(request.method, equals('PUT'));
+      final decoded = jsonDecode(request.body) as Map<String, dynamic>;
+      expect(decoded['scopeType'], equals('thread'));
+      expect(decoded['channelId'], equals('default'));
+      expect(decoded['threadId'], equals('main'));
+      expect(decoded['router'], equals('default'));
+      return http.Response(
+        jsonEncode({
+          'setting': {'router': 'default'},
+        }),
+        200,
+      );
+    });
+
+    final service = ChatHistoryApiService(httpClient: client);
+    final settings = await service.loadScopeSettings(token: 'token-1');
+    await service.saveScopeSetting(
+      token: 'token-1',
+      scopeType: ChatScopeType.thread,
+      channelId: 'default',
+      threadId: 'main',
+      router: ChatRouter.defaultRoute,
+    );
+
+    expect(settings, hasLength(1));
+    expect(settings.single.scopeType, ChatScopeType.channel);
+    expect(settings.single.router, ChatRouter.openclaw);
   });
 }

--- a/apps/mobile_chat_app/test/chat_topology_and_task_protocol_test.dart
+++ b/apps/mobile_chat_app/test/chat_topology_and_task_protocol_test.dart
@@ -18,6 +18,15 @@ void main() {
     expect(resolved, 'default');
   });
 
+  test('parses router and scope type api values', () {
+    expect(chatRouterFromApi('openclaw'), ChatRouter.openclaw);
+    expect(chatRouterFromApi('default'), ChatRouter.defaultRoute);
+    expect(chatScopeTypeFromApi('channel'), ChatScopeType.channel);
+    expect(chatScopeTypeFromApi('thread'), ChatScopeType.thread);
+    expect(ChatRouter.openclaw.apiValue, 'openclaw');
+    expect(ChatScopeType.thread.apiValue, 'thread');
+  });
+
   test('applies acknowledged state and cursor to message', () {
     final protocol = ChatTaskProtocol();
     final envelope = ChatTaskEnvelope(
@@ -43,30 +52,32 @@ void main() {
     expect(next.checkpointCursor, startsWith('cursor:default:task-1'));
   });
 
-  test('does not apply acknowledged state when ack task id mismatches message task id',
-      () {
-    final protocol = ChatTaskProtocol();
-    final envelope = ChatTaskEnvelope(
-      taskId: 'task-2',
-      idempotencyKey: 'idem-2',
-      createdAt: DateTime(2026, 4, 4),
-      channelId: 'default',
-      sessionId: 'session:default:main',
-    );
-    final ack = protocol.acknowledge(envelope);
+  test(
+    'does not apply acknowledged state when ack task id mismatches message task id',
+    () {
+      final protocol = ChatTaskProtocol();
+      final envelope = ChatTaskEnvelope(
+        taskId: 'task-2',
+        idempotencyKey: 'idem-2',
+        createdAt: DateTime(2026, 4, 4),
+        channelId: 'default',
+        sessionId: 'session:default:main',
+      );
+      final ack = protocol.acknowledge(envelope);
 
-    final message = ChatMessage(
-      role: 'assistant',
-      content: '',
-      taskId: 'task-1',
-      taskState: ChatTaskState.accepted,
-    );
+      final message = ChatMessage(
+        role: 'assistant',
+        content: '',
+        taskId: 'task-1',
+        taskState: ChatTaskState.accepted,
+      );
 
-    final next = protocol.applyAcceptedState(message, ack);
+      final next = protocol.applyAcceptedState(message, ack);
 
-    expect(next.taskId, 'task-1');
-    expect(next.taskState, ChatTaskState.accepted);
-    expect(next.acknowledgedAt, isNull);
-    expect(next.checkpointCursor, isNull);
-  });
+      expect(next.taskId, 'task-1');
+      expect(next.taskState, ChatTaskState.accepted);
+      expect(next.acknowledgedAt, isNull);
+      expect(next.checkpointCursor, isNull);
+    },
+  );
 }

--- a/apps/mobile_chat_app/test/model_settings_screen_test.dart
+++ b/apps/mobile_chat_app/test/model_settings_screen_test.dart
@@ -267,5 +267,24 @@ void main() {
       expect(clipboardCalls, isEmpty);
       expect(find.text('API Key is empty'), findsOneWidget);
     });
+
+    testWidgets('copy api key action copies non-empty key to clipboard',
+        (tester) async {
+      final service = _FakeLlmConfigService(configs: [_persistedConfig]);
+      await tester.pumpWidget(_buildScreen(service));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+          find.widgetWithText(TextFormField, 'API Key'), ' test-api-key ');
+      await tester.tap(find.byTooltip('Copy API Key'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardCalls, hasLength(1));
+      expect(
+        clipboardCalls.single.arguments,
+        containsPair('text', 'test-api-key'),
+      );
+      expect(find.text('API Key copied'), findsOneWidget);
+    });
   });
 }

--- a/apps/mobile_chat_app/test/model_settings_screen_test.dart
+++ b/apps/mobile_chat_app/test/model_settings_screen_test.dart
@@ -12,18 +12,10 @@ class _FakeLlmConfigService extends LlmConfigService {
   _FakeLlmConfigService({
     List<LlmConfig>? configs,
     this.deleteThrows = false,
-    this.platformTokenBundle = const PlatformTokenBundle(
-      token: 'platform-token-123',
-      pluginId: 'plugin_local_main',
-      baseUrl: 'https://bricks.askman.dev',
-      scopes: ['events:read', 'events:ack'],
-      expiresIn: '30d',
-    ),
   }) : _initialConfigs = configs ?? const [];
 
   final List<LlmConfig> _initialConfigs;
   final bool deleteThrows;
-  final PlatformTokenBundle platformTokenBundle;
 
   final List<String> deletedIds = [];
 
@@ -40,12 +32,6 @@ class _FakeLlmConfigService extends LlmConfigService {
     if (deleteThrows) throw Exception('delete failed');
     deletedIds.add(id);
   }
-
-  @override
-  Future<PlatformTokenBundle> fetchPlatformToken({
-    String pluginId = 'plugin_local_main',
-  }) async =>
-      platformTokenBundle;
 }
 
 // ---------------------------------------------------------------------------
@@ -342,39 +328,6 @@ void main() {
         containsPair('text', 'test-api-key'),
       );
       expect(find.text('API Key copied'), findsOneWidget);
-    });
-
-    testWidgets('can fetch and copy xiaolongxia token', (tester) async {
-      final service = _FakeLlmConfigService(configs: [_persistedConfig]);
-      await tester.pumpWidget(_buildScreen(service));
-      await tester.pumpAndSettle();
-
-      await _scrollUntilVisible(
-          tester, find.text('Get Xiaolongxia Token').first);
-      await tester.tap(find.text('Get Xiaolongxia Token').first);
-      await tester.pumpAndSettle();
-
-      expect(find.textContaining('Plugin ID:'), findsOneWidget);
-      expect(find.textContaining('Base URL:'), findsOneWidget);
-      expect(find.widgetWithText(TextFormField, 'Xiaolongxia Token'),
-          findsOneWidget);
-
-      final copyTokenFinder = find.descendant(
-        of: find.widgetWithText(TextFormField, 'Xiaolongxia Token'),
-        matching: find.byIcon(Icons.copy_outlined),
-      );
-      await _scrollUntilVisible(tester, copyTokenFinder);
-      await tester.ensureVisible(copyTokenFinder);
-      await tester.pumpAndSettle();
-      await tester.tap(copyTokenFinder);
-      await tester.pumpAndSettle();
-
-      expect(clipboardCalls, hasLength(1));
-      expect(
-        clipboardCalls.single.arguments,
-        containsPair('text', 'platform-token-123'),
-      );
-      expect(find.textContaining('copied'), findsOneWidget);
     });
   });
 }

--- a/apps/mobile_chat_app/test/model_settings_screen_test.dart
+++ b/apps/mobile_chat_app/test/model_settings_screen_test.dart
@@ -358,6 +358,23 @@ void main() {
       expect(find.textContaining('Base URL:'), findsOneWidget);
       expect(find.widgetWithText(TextFormField, 'Xiaolongxia Token'),
           findsOneWidget);
+
+      final copyTokenFinder = find.descendant(
+        of: find.widgetWithText(TextFormField, 'Xiaolongxia Token'),
+        matching: find.byIcon(Icons.copy_outlined),
+      );
+      await _scrollUntilVisible(tester, copyTokenFinder);
+      await tester.ensureVisible(copyTokenFinder);
+      await tester.pumpAndSettle();
+      await tester.tap(copyTokenFinder);
+      await tester.pumpAndSettle();
+
+      expect(clipboardCalls, hasLength(1));
+      expect(
+        clipboardCalls.single.arguments,
+        containsPair('text', 'platform-token-123'),
+      );
+      expect(find.textContaining('copied'), findsOneWidget);
     });
   });
 }

--- a/apps/mobile_chat_app/test/model_settings_screen_test.dart
+++ b/apps/mobile_chat_app/test/model_settings_screen_test.dart
@@ -12,10 +12,18 @@ class _FakeLlmConfigService extends LlmConfigService {
   _FakeLlmConfigService({
     List<LlmConfig>? configs,
     this.deleteThrows = false,
+    this.platformTokenBundle = const PlatformTokenBundle(
+      token: 'platform-token-123',
+      pluginId: 'plugin_local_main',
+      baseUrl: 'https://bricks.askman.dev',
+      scopes: ['events:read', 'events:ack'],
+      expiresIn: '30d',
+    ),
   }) : _initialConfigs = configs ?? const [];
 
   final List<LlmConfig> _initialConfigs;
   final bool deleteThrows;
+  final PlatformTokenBundle platformTokenBundle;
 
   final List<String> deletedIds = [];
 
@@ -32,6 +40,12 @@ class _FakeLlmConfigService extends LlmConfigService {
     if (deleteThrows) throw Exception('delete failed');
     deletedIds.add(id);
   }
+
+  @override
+  Future<PlatformTokenBundle> fetchPlatformToken({
+    String pluginId = 'plugin_local_main',
+  }) async =>
+      platformTokenBundle;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,6 +84,18 @@ const _secondConfig = LlmConfig(
 Widget _buildScreen(LlmConfigService service) =>
     MaterialApp(home: ModelSettingsScreen(service: service));
 
+Future<void> _scrollUntilVisible(
+  WidgetTester tester,
+  Finder target, {
+  double delta = 300,
+}) async {
+  await tester.scrollUntilVisible(
+    target,
+    delta,
+    scrollable: find.byType(Scrollable).first,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -85,7 +111,8 @@ void main() {
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(OutlinedButton, 'Delete'));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
       expect(find.text('Delete configuration?'), findsOneWidget);
@@ -98,7 +125,8 @@ void main() {
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(OutlinedButton, 'Delete'));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
       // Dismiss via Cancel.
@@ -118,7 +146,8 @@ void main() {
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(OutlinedButton, 'Delete'));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
       // Tap the Delete button inside the AlertDialog (FilledButton).
@@ -146,7 +175,8 @@ void main() {
       await tester.pumpAndSettle();
 
       // Active config is the first (unsaved) one.
-      await tester.tap(find.widgetWithText(OutlinedButton, 'Delete'));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
       // No confirmation dialog should appear.
@@ -163,13 +193,14 @@ void main() {
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(OutlinedButton, 'Delete'));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
       // The form should still be present (blank config was auto-added).
       expect(find.byType(Form), findsOneWidget);
       // A Delete button should still be visible.
-      expect(find.widgetWithText(OutlinedButton, 'Delete'), findsOneWidget);
+      expect(find.byIcon(Icons.delete_outline), findsOneWidget);
     });
 
     testWidgets(
@@ -180,11 +211,19 @@ void main() {
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
 
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.save_outlined));
       final deleteBtn = tester.widget<OutlinedButton>(
-        find.widgetWithText(OutlinedButton, 'Delete'),
+        find.ancestor(
+          of: find.byIcon(Icons.delete_outline),
+          matching: find.byType(OutlinedButton),
+        ),
       );
       final saveBtn = tester.widget<FilledButton>(
-        find.widgetWithText(FilledButton, 'Save'),
+        find.ancestor(
+          of: find.byIcon(Icons.save_outlined),
+          matching: find.byType(FilledButton),
+        ),
       );
 
       expect(deleteBtn.onPressed, isNotNull);
@@ -201,7 +240,8 @@ void main() {
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(OutlinedButton, 'Delete'));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
       await tester.tap(
@@ -255,6 +295,23 @@ void main() {
       expect(find.text('API URL copied'), findsOneWidget);
     });
 
+    testWidgets('copy api url action shows empty snackbar when field is blank',
+        (tester) async {
+      final service = _FakeLlmConfigService(configs: [_persistedConfig]);
+      await tester.pumpWidget(_buildScreen(service));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Base URL'),
+        '   ',
+      );
+      await tester.tap(find.byTooltip('Copy API URL'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardCalls, isEmpty);
+      expect(find.text('API URL is empty'), findsOneWidget);
+    });
+
     testWidgets('copy api key action shows empty snackbar when field is blank',
         (tester) async {
       final service = _FakeLlmConfigService(configs: [_persistedConfig]);
@@ -285,6 +342,22 @@ void main() {
         containsPair('text', 'test-api-key'),
       );
       expect(find.text('API Key copied'), findsOneWidget);
+    });
+
+    testWidgets('can fetch and copy xiaolongxia token', (tester) async {
+      final service = _FakeLlmConfigService(configs: [_persistedConfig]);
+      await tester.pumpWidget(_buildScreen(service));
+      await tester.pumpAndSettle();
+
+      await _scrollUntilVisible(
+          tester, find.text('Get Xiaolongxia Token').first);
+      await tester.tap(find.text('Get Xiaolongxia Token').first);
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Plugin ID:'), findsOneWidget);
+      expect(find.textContaining('Base URL:'), findsOneWidget);
+      expect(find.widgetWithText(TextFormField, 'Xiaolongxia Token'),
+          findsOneWidget);
     });
   });
 }

--- a/apps/mobile_chat_app/test/model_settings_screen_test.dart
+++ b/apps/mobile_chat_app/test/model_settings_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_chat_app/features/settings/llm_config_service.dart';
 import 'package:mobile_chat_app/features/settings/model_settings_screen.dart';
@@ -74,12 +75,12 @@ Widget _buildScreen(LlmConfigService service) =>
 // ---------------------------------------------------------------------------
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('ModelSettingsScreen – delete flow', () {
-    testWidgets(
-        'delete button shows confirmation dialog for persisted config',
+    testWidgets('delete button shows confirmation dialog for persisted config',
         (tester) async {
-      final service =
-          _FakeLlmConfigService(configs: [_persistedConfig]);
+      final service = _FakeLlmConfigService(configs: [_persistedConfig]);
 
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
@@ -92,8 +93,7 @@ void main() {
 
     testWidgets('canceling confirmation dialog does not delete config',
         (tester) async {
-      final service =
-          _FakeLlmConfigService(configs: [_persistedConfig]);
+      final service = _FakeLlmConfigService(configs: [_persistedConfig]);
 
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
@@ -110,11 +110,10 @@ void main() {
       expect(find.text('claude-sonnet-4-5'), findsWidgets);
     });
 
-    testWidgets(
-        'confirming dialog calls deleteConfig with the correct id',
+    testWidgets('confirming dialog calls deleteConfig with the correct id',
         (tester) async {
-      final service = _FakeLlmConfigService(
-          configs: [_persistedConfig, _secondConfig]);
+      final service =
+          _FakeLlmConfigService(configs: [_persistedConfig, _secondConfig]);
 
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
@@ -140,8 +139,8 @@ void main() {
         'deleting unsaved config removes it locally without showing dialog',
         (tester) async {
       // First config has no id (unsaved); second is persisted.
-      final service = _FakeLlmConfigService(
-          configs: [_unsavedConfig, _secondConfig]);
+      final service =
+          _FakeLlmConfigService(configs: [_unsavedConfig, _secondConfig]);
 
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
@@ -156,8 +155,7 @@ void main() {
       expect(service.deletedIds, isEmpty);
     });
 
-    testWidgets(
-        'deleting the last config auto-adds a blank config',
+    testWidgets('deleting the last config auto-adds a blank config',
         (tester) async {
       // Single unsaved config – deletion is immediate (no dialog).
       final service = _FakeLlmConfigService(configs: [_unsavedConfig]);
@@ -174,10 +172,10 @@ void main() {
       expect(find.widgetWithText(OutlinedButton, 'Delete'), findsOneWidget);
     });
 
-    testWidgets('delete and save buttons are both visible and initially enabled',
+    testWidgets(
+        'delete and save buttons are both visible and initially enabled',
         (tester) async {
-      final service =
-          _FakeLlmConfigService(configs: [_persistedConfig]);
+      final service = _FakeLlmConfigService(configs: [_persistedConfig]);
 
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
@@ -218,6 +216,56 @@ void main() {
         find.text('Failed to delete model configuration'),
         findsOneWidget,
       );
+    });
+  });
+
+  group('ModelSettingsScreen – copy actions', () {
+    final clipboardCalls = <MethodCall>[];
+
+    setUp(() {
+      clipboardCalls.clear();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.setData') {
+          clipboardCalls.add(call);
+        }
+        return null;
+      });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    testWidgets('copy api url action copies base url to clipboard',
+        (tester) async {
+      final service = _FakeLlmConfigService(configs: [_persistedConfig]);
+      await tester.pumpWidget(_buildScreen(service));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Copy API URL'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardCalls, hasLength(1));
+      expect(
+        clipboardCalls.single.arguments,
+        containsPair('text', 'https://api.anthropic.com'),
+      );
+      expect(find.text('API URL copied'), findsOneWidget);
+    });
+
+    testWidgets('copy api key action shows empty snackbar when field is blank',
+        (tester) async {
+      final service = _FakeLlmConfigService(configs: [_persistedConfig]);
+      await tester.pumpWidget(_buildScreen(service));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Copy API Key'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardCalls, isEmpty);
+      expect(find.text('API Key is empty'), findsOneWidget);
     });
   });
 }

--- a/apps/mobile_chat_app/test/openclaw_token_settings_screen_test.dart
+++ b/apps/mobile_chat_app/test/openclaw_token_settings_screen_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_chat_app/features/settings/llm_config_service.dart';
+import 'package:mobile_chat_app/features/settings/openclaw_token_settings_screen.dart';
+import 'package:mobile_chat_app/features/settings/settings_screen.dart';
+
+class _FakeLlmConfigService extends LlmConfigService {
+  const _FakeLlmConfigService();
+
+  @override
+  Future<PlatformTokenBundle> fetchPlatformToken({
+    String pluginId = 'plugin_local_main',
+  }) async {
+    return const PlatformTokenBundle(
+      token: 'platform-token-123',
+      pluginId: 'plugin_local_main',
+      baseUrl: 'https://bricks.askman.dev',
+      scopes: ['events:read', 'events:ack'],
+      expiresIn: '30d',
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('settings screen includes Openclaw Token item', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SettingsScreen()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Openclaw Token'), findsOneWidget);
+    await tester.tap(find.text('Openclaw Token'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Openclaw Token'), findsWidgets);
+    expect(find.byType(OpenclawTokenSettingsScreen), findsOneWidget);
+  });
+
+  testWidgets('can generate and copy Openclaw Token', (tester) async {
+    final clipboardCalls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.setData') {
+        clipboardCalls.add(call);
+      }
+      return null;
+    });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    await tester.pumpWidget(
+      const MaterialApp(
+          home: OpenclawTokenSettingsScreen(service: _FakeLlmConfigService())),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Openclaw Token'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Plugin ID:'), findsOneWidget);
+    expect(
+        find.widgetWithText(TextFormField, 'Openclaw Token'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Copy Openclaw Token'));
+    await tester.pumpAndSettle();
+
+    expect(clipboardCalls, hasLength(1));
+    expect(clipboardCalls.single.arguments,
+        containsPair('text', 'platform-token-123'));
+    expect(find.text('Openclaw Token copied'), findsOneWidget);
+  });
+}

--- a/apps/node_backend/src/app.test.ts
+++ b/apps/node_backend/src/app.test.ts
@@ -1,0 +1,107 @@
+import express from 'express';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const runMigrationsMock = vi.fn(async () => {});
+
+const authRouter = express.Router();
+const configRouter = express.Router();
+const llmRouter = express.Router();
+const chatRouter = express.Router();
+const platformRouter = express.Router();
+
+authRouter.get('/noop', (_req, res) => {
+  res.json({ ok: true });
+});
+
+configRouter.get('/noop', (_req, res) => {
+  res.json({ ok: true });
+});
+
+llmRouter.get('/noop', (_req, res) => {
+  res.json({ ok: true });
+});
+
+chatRouter.get('/sync/:sessionId', (_req, res) => {
+  res.json({ messages: [], lastSeqId: 0 });
+});
+
+platformRouter.get('/noop', (_req, res) => {
+  res.json({ ok: true });
+});
+
+vi.mock('./db/migrate.js', () => ({
+  runMigrations: runMigrationsMock,
+}));
+
+vi.mock('./routes/auth.js', () => ({
+  default: authRouter,
+}));
+
+vi.mock('./routes/config.js', () => ({
+  default: configRouter,
+}));
+
+vi.mock('./routes/llm.js', () => ({
+  default: llmRouter,
+}));
+
+vi.mock('./routes/chat.js', () => ({
+  default: chatRouter,
+}));
+
+vi.mock('./routes/platform.js', () => ({
+  default: platformRouter,
+}));
+
+let server: ReturnType<express.Express['listen']> | null = null;
+let baseUrl = '';
+
+beforeAll(async () => {
+  const { default: app } = await import('./app.js');
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const address = server?.address();
+      if (address && typeof address === 'object') {
+        baseUrl = `http://127.0.0.1:${address.port}`;
+      }
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    if (!server) {
+      resolve();
+      return;
+    }
+    server.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+});
+
+describe('app rate limiting', () => {
+  it('skips the generic api limiter for chat sync polling', async () => {
+    for (let i = 0; i < 110; i += 1) {
+      const response = await fetch(
+        `${baseUrl}/api/chat/sync/${encodeURIComponent('session:default:main')}?afterSeq=${i}`,
+      );
+      expect(response.status).toBe(200);
+    }
+  });
+
+  it('still applies the generic api limiter to non-sync api routes', async () => {
+    let response: globalThis.Response | null = null;
+    for (let i = 0; i < 101; i += 1) {
+      response = await fetch(`${baseUrl}/api/config/noop`);
+    }
+
+    expect(response?.status).toBe(429);
+  });
+});

--- a/apps/node_backend/src/app.ts
+++ b/apps/node_backend/src/app.ts
@@ -53,6 +53,9 @@ const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 100, // limit each IP to 100 requests per windowMs
   message: 'Too many requests from this IP, please try again later.',
+  // `/api/chat/sync/*` is polled by authenticated chat clients and uses a
+  // route-specific limiter keyed by user/session instead of the coarse IP cap.
+  skip: (req) => req.originalUrl.startsWith('/api/chat/sync/'),
 });
 
 app.use('/api/', limiter);

--- a/apps/node_backend/src/app.ts
+++ b/apps/node_backend/src/app.ts
@@ -7,6 +7,7 @@ import authRoutes from './routes/auth.js';
 import configRoutes from './routes/config.js';
 import llmRoutes from './routes/llm.js';
 import chatRoutes from './routes/chat.js';
+import platformRoutes from './routes/platform.js';
 import { runMigrations } from './db/migrate.js';
 
 // Load environment variables (no-op in Vercel production where env vars are injected directly)
@@ -93,6 +94,7 @@ app.use('/api', authRoutes);
 app.use('/api/config', configRoutes);
 app.use('/api/llm', llmRoutes);
 app.use('/api/chat', chatRoutes);
+app.use('/api/v1/platform', platformRoutes);
 
 // 404 handler
 app.use((req: Request, res: Response) => {

--- a/apps/node_backend/src/db/migrations/009_create_chat_scope_settings.sql
+++ b/apps/node_backend/src/db/migrations/009_create_chat_scope_settings.sql
@@ -1,0 +1,28 @@
+-- Migration: Create chat_scope_settings table
+-- Description: Persist explicit router settings for chat channels and threads.
+-- Version: 009
+-- Date: 2026-04-17
+
+CREATE TABLE IF NOT EXISTS chat_scope_settings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  scope_type VARCHAR(16) NOT NULL CHECK (scope_type IN ('channel', 'thread')),
+  channel_id VARCHAR(255) NOT NULL,
+  thread_id VARCHAR(255) NOT NULL DEFAULT '',
+  router VARCHAR(32) NOT NULL CHECK (router IN ('default', 'openclaw')),
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  CHECK (
+    (scope_type = 'channel' AND thread_id = '') OR
+    (scope_type = 'thread' AND thread_id <> '')
+  ),
+  UNIQUE (user_id, scope_type, channel_id, thread_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_scope_settings_user_scope
+  ON chat_scope_settings(user_id, channel_id, scope_type, thread_id);
+
+CREATE TRIGGER update_chat_scope_settings_updated_at
+  BEFORE UPDATE ON chat_scope_settings
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();

--- a/apps/node_backend/src/middleware/platformAuth.ts
+++ b/apps/node_backend/src/middleware/platformAuth.ts
@@ -108,8 +108,12 @@ export function authenticatePlatformApiKey(
       }
       scopedUserId = payload.userId;
       tokenScopes = Array.isArray(payload.scopes) ? payload.scopes : undefined;
-    } catch {
-      sendAuthError(res, 401, 'UNAUTHORIZED', 'invalid api key');
+    } catch (error) {
+      if (error instanceof Error && error.message === 'JWT_SECRET environment variable is not set') {
+        sendAuthError(res, 500, 'CONFIGURATION_ERROR', 'server authentication is not configured');
+        return;
+      }
+      sendAuthError(res, 401, 'UNAUTHORIZED', 'invalid bearer token');
       return;
     }
   }
@@ -126,7 +130,7 @@ export function requirePlatformScope(scope: string) {
   return (req: PlatformAuthRequest, res: Response, next: NextFunction): void => {
     const scopes = req.platformScopes;
     if (!scopes || !scopes.has(scope)) {
-      sendAuthError(res, 403, 'FORBIDDEN', `key lacks ${scope}`);
+      sendAuthError(res, 403, 'FORBIDDEN', `token lacks ${scope}`);
       return;
     }
     next();

--- a/apps/node_backend/src/middleware/platformAuth.ts
+++ b/apps/node_backend/src/middleware/platformAuth.ts
@@ -50,7 +50,7 @@ export function issuePlatformAccessToken(params: {
 }): string {
   const pluginId = params.pluginId.trim();
   if (!pluginId) {
-    throw new Error('pluginId must be a non-empty string');
+    throw new Error('pluginId is required and must not be empty or whitespace-only');
   }
   const payload: PlatformJwtPayload = {
     typ: 'platform_plugin',

--- a/apps/node_backend/src/middleware/platformAuth.ts
+++ b/apps/node_backend/src/middleware/platformAuth.ts
@@ -38,6 +38,10 @@ function getJwtSecret(): string {
   return secret;
 }
 
+/**
+ * Issues a scoped platform JWT for plugin pull-only APIs.
+ * `pluginId` is required and must match `X-Bricks-Plugin-Id` on authenticated requests.
+ */
 export function issuePlatformAccessToken(params: {
   userId: string;
   pluginId: string;

--- a/apps/node_backend/src/middleware/platformAuth.ts
+++ b/apps/node_backend/src/middleware/platformAuth.ts
@@ -50,7 +50,7 @@ export function issuePlatformAccessToken(params: {
 }): string {
   const pluginId = params.pluginId.trim();
   if (!pluginId) {
-    throw new Error('pluginId is required');
+    throw new Error('pluginId must be a non-empty string');
   }
   const payload: PlatformJwtPayload = {
     typ: 'platform_plugin',

--- a/apps/node_backend/src/middleware/platformAuth.ts
+++ b/apps/node_backend/src/middleware/platformAuth.ts
@@ -1,0 +1,134 @@
+import type { NextFunction, Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface PlatformAuthRequest extends Request {
+  platformPluginId?: string;
+  platformScopes?: Set<string>;
+  platformUserId?: string;
+}
+
+interface PlatformJwtPayload {
+  typ?: string;
+  userId?: string;
+  pluginId?: string;
+  scopes?: string[];
+  iat?: number;
+  exp?: number;
+}
+
+function parseScopes(raw: string | undefined): Set<string> {
+  const fallback = 'events:read,events:ack,messages:write,conversations:read';
+  return new Set(
+    (raw ?? fallback)
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+}
+
+function requestId(): string {
+  return `req_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getJwtSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret || secret.trim().length === 0) {
+    throw new Error('JWT_SECRET environment variable is not set');
+  }
+  return secret;
+}
+
+export function issuePlatformAccessToken(params: {
+  userId: string;
+  pluginId?: string;
+  scopes?: string[];
+  expiresIn?: string;
+}): string {
+  const payload: PlatformJwtPayload = {
+    typ: 'platform_plugin',
+    userId: params.userId,
+    pluginId: params.pluginId,
+    scopes: params.scopes,
+  };
+  return jwt.sign(payload, getJwtSecret(), {
+    expiresIn: (params.expiresIn ?? '30d') as any,
+  });
+}
+
+function sendAuthError(res: Response, code: number, errorCode: string, message: string): void {
+  res.status(code).json({
+    error: {
+      code: errorCode,
+      message,
+      retryable: false,
+    },
+    requestId: requestId(),
+  });
+}
+
+export function authenticatePlatformApiKey(
+  req: PlatformAuthRequest,
+  res: Response,
+  next: NextFunction,
+): void {
+  const configuredKey = process.env.BRICKS_PLATFORM_API_KEY?.trim();
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    sendAuthError(res, 401, 'UNAUTHORIZED', 'missing bearer token');
+    return;
+  }
+
+  const token = authHeader.slice(7).trim();
+  if (!token) {
+    sendAuthError(res, 401, 'UNAUTHORIZED', 'invalid api key');
+    return;
+  }
+
+  const pluginIdHeader = req.header('X-Bricks-Plugin-Id')?.trim();
+  if (!pluginIdHeader) {
+    sendAuthError(res, 400, 'MISSING_PLUGIN_ID', 'X-Bricks-Plugin-Id header is required');
+    return;
+  }
+
+  let scopedUserId: string | undefined;
+  let tokenScopes: string[] | undefined;
+  if (configuredKey && token === configuredKey) {
+    // Static key mode (environment-level shared token).
+  } else {
+    try {
+      const payload = jwt.verify(token, getJwtSecret()) as PlatformJwtPayload;
+      if (payload.typ !== 'platform_plugin' || !payload.userId) {
+        sendAuthError(res, 401, 'UNAUTHORIZED', 'invalid platform token payload');
+        return;
+      }
+      if (payload.pluginId && payload.pluginId !== pluginIdHeader) {
+        sendAuthError(res, 403, 'FORBIDDEN', 'token pluginId does not match header');
+        return;
+      }
+      scopedUserId = payload.userId;
+      tokenScopes = Array.isArray(payload.scopes) ? payload.scopes : undefined;
+    } catch {
+      sendAuthError(res, 401, 'UNAUTHORIZED', 'invalid api key');
+      return;
+    }
+  }
+
+  req.platformPluginId = pluginIdHeader;
+  req.platformScopes = tokenScopes
+    ? new Set(tokenScopes)
+    : parseScopes(process.env.BRICKS_PLATFORM_API_SCOPES);
+  req.platformUserId = scopedUserId;
+  next();
+}
+
+export function requirePlatformScope(scope: string) {
+  return (req: PlatformAuthRequest, res: Response, next: NextFunction): void => {
+    const scopes = req.platformScopes;
+    if (!scopes || !scopes.has(scope)) {
+      sendAuthError(res, 403, 'FORBIDDEN', `key lacks ${scope}`);
+      return;
+    }
+    next();
+  };
+}

--- a/apps/node_backend/src/middleware/platformAuth.ts
+++ b/apps/node_backend/src/middleware/platformAuth.ts
@@ -40,14 +40,18 @@ function getJwtSecret(): string {
 
 export function issuePlatformAccessToken(params: {
   userId: string;
-  pluginId?: string;
+  pluginId: string;
   scopes?: string[];
   expiresIn?: string;
 }): string {
+  const pluginId = params.pluginId.trim();
+  if (!pluginId) {
+    throw new Error('pluginId is required');
+  }
   const payload: PlatformJwtPayload = {
     typ: 'platform_plugin',
     userId: params.userId,
-    pluginId: params.pluginId,
+    pluginId,
     scopes: params.scopes,
   };
   return jwt.sign(payload, getJwtSecret(), {
@@ -98,11 +102,16 @@ export function authenticatePlatformApiKey(
   } else {
     try {
       const payload = jwt.verify(token, getJwtSecret()) as PlatformJwtPayload;
-      if (payload.typ !== 'platform_plugin' || !payload.userId) {
+      if (
+        payload.typ !== 'platform_plugin' ||
+        !payload.userId ||
+        !payload.pluginId ||
+        payload.pluginId.trim().length === 0
+      ) {
         sendAuthError(res, 401, 'UNAUTHORIZED', 'invalid platform token payload');
         return;
       }
-      if (payload.pluginId && payload.pluginId !== pluginIdHeader) {
+      if (payload.pluginId !== pluginIdHeader) {
         sendAuthError(res, 403, 'FORBIDDEN', 'token pluginId does not match header');
         return;
       }

--- a/apps/node_backend/src/routes/chat.test.ts
+++ b/apps/node_backend/src/routes/chat.test.ts
@@ -1,0 +1,191 @@
+import express from 'express';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  acceptTaskMock,
+  listSessionMessagesForModelMock,
+  syncMessagesMock,
+  upsertMessagesMock,
+  listUserScopesMock,
+  listChatScopeSettingsMock,
+  resolveChatRouterMock,
+  upsertChatScopeSettingMock,
+  deleteChatScopeSettingMock,
+  generateWithUserConfigMock,
+} = vi.hoisted(() => ({
+  acceptTaskMock: vi.fn(async () => ({
+    taskId: 'task-1',
+    sessionId: 'session:default:main',
+    state: 'accepted',
+    acceptedAt: '2026-04-17T07:00:00.000Z',
+  })),
+  listSessionMessagesForModelMock: vi.fn(async () => []),
+  syncMessagesMock: vi.fn(async () => ({ messages: [], lastSeqId: 0 })),
+  upsertMessagesMock: vi.fn(async () => ({ lastSeqId: 7 })),
+  listUserScopesMock: vi.fn(async () => []),
+  listChatScopeSettingsMock: vi.fn(async () => []),
+  resolveChatRouterMock: vi.fn(async () => 'default'),
+  upsertChatScopeSettingMock: vi.fn(async () => ({
+    scopeType: 'channel',
+    channelId: 'default',
+    threadId: null,
+    router: 'openclaw',
+    createdAt: '2026-04-17T07:00:00.000Z',
+    updatedAt: '2026-04-17T07:00:00.000Z',
+  })),
+  deleteChatScopeSettingMock: vi.fn(async () => ({ deleted: true })),
+  generateWithUserConfigMock: vi.fn(async () => ({
+    text: 'sync reply',
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-5',
+  })),
+}));
+
+vi.mock('../services/chatAsyncTransportService.js', () => ({
+  acceptTask: acceptTaskMock,
+  listSessionMessagesForModel: listSessionMessagesForModelMock,
+  listUserScopes: listUserScopesMock,
+  syncMessages: syncMessagesMock,
+  upsertMessages: upsertMessagesMock,
+}));
+
+vi.mock('../services/chatRouterService.js', () => ({
+  CHAT_ROUTER_DEFAULT: 'default',
+  CHAT_ROUTER_OPENCLAW: 'openclaw',
+  deleteChatScopeSetting: deleteChatScopeSettingMock,
+  listChatScopeSettings: listChatScopeSettingsMock,
+  resolveChatRouter: resolveChatRouterMock,
+  upsertChatScopeSetting: upsertChatScopeSettingMock,
+}));
+
+vi.mock('../llm/llm_service.js', () => ({
+  generateWithUserConfig: generateWithUserConfigMock,
+}));
+
+vi.mock('../middleware/auth.js', () => ({
+  authenticate: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    (req as express.Request & { userId?: string }).userId = 'user-123';
+    next();
+  },
+}));
+
+let server: ReturnType<express.Express['listen']> | null = null;
+let baseUrl = '';
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  const { default: chatRoutes } = await import('./chat.js');
+  app.use('/api/chat', chatRoutes);
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const address = server?.address();
+      if (address && typeof address === 'object') {
+        baseUrl = `http://127.0.0.1:${address.port}`;
+      }
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    if (!server) {
+      resolve();
+      return;
+    }
+    server.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+});
+
+describe('chat routes', () => {
+  beforeEach(() => {
+    acceptTaskMock.mockClear();
+    listSessionMessagesForModelMock.mockClear();
+    syncMessagesMock.mockClear();
+    upsertMessagesMock.mockClear();
+    listUserScopesMock.mockClear();
+    listChatScopeSettingsMock.mockClear();
+    resolveChatRouterMock.mockClear();
+    upsertChatScopeSettingMock.mockClear();
+    deleteChatScopeSettingMock.mockClear();
+    generateWithUserConfigMock.mockClear();
+  });
+
+  it('routes OpenClaw scopes to async pending dispatch', async () => {
+    resolveChatRouterMock.mockResolvedValueOnce('openclaw');
+
+    const response = await fetch(`${baseUrl}/api/chat/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        taskId: 'task-1',
+        idempotencyKey: 'idem-1',
+        channelId: 'default',
+        sessionId: 'session:default:main',
+        userMessageId: 'msg-user-1',
+        assistantMessageId: 'msg-assistant-1',
+        userMessage: 'hello',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      mode?: string;
+      state?: string;
+      text?: string;
+      lastSeqId?: number;
+    };
+    expect(body.mode).toBe('async');
+    expect(body.state).toBe('dispatched');
+    expect(body.text).toBe('Waiting for OpenClaw...');
+    expect(body.lastSeqId).toBe(7);
+    expect(generateWithUserConfigMock).not.toHaveBeenCalled();
+    expect(upsertMessagesMock).toHaveBeenCalledWith(
+      'user-123',
+      expect.arrayContaining([
+        expect.objectContaining({
+          messageId: 'msg-user-1',
+          role: 'user',
+          taskState: 'dispatched',
+          metadata: expect.objectContaining({
+            source: 'backend.respond.openclaw',
+            pendingAssistantMessageId: 'msg-assistant-1',
+          }),
+        }),
+        expect.objectContaining({
+          messageId: 'msg-assistant-1',
+          role: 'assistant',
+          taskState: 'dispatched',
+        }),
+      ]),
+    );
+  });
+
+  it('supports clearing a scope setting by sending router=null', async () => {
+    const response = await fetch(`${baseUrl}/api/chat/scope-settings`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        scopeType: 'thread',
+        channelId: 'default',
+        threadId: 'main',
+        router: null,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(deleteChatScopeSettingMock).toHaveBeenCalledWith('user-123', {
+      scopeType: 'thread',
+      channelId: 'default',
+      threadId: 'main',
+    });
+  });
+});

--- a/apps/node_backend/src/routes/chat.test.ts
+++ b/apps/node_backend/src/routes/chat.test.ts
@@ -188,4 +188,23 @@ describe('chat routes', () => {
       threadId: 'main',
     });
   });
+
+  it('rate limits sync polling per user and session after 120 requests per minute', async () => {
+    const encodedSessionId = encodeURIComponent('session:rate-limit:main');
+
+    for (let i = 0; i < 120; i += 1) {
+      const response = await fetch(
+        `${baseUrl}/api/chat/sync/${encodedSessionId}?afterSeq=${i}`,
+      );
+      expect(response.status).toBe(200);
+    }
+
+    const limited = await fetch(
+      `${baseUrl}/api/chat/sync/${encodedSessionId}?afterSeq=999`,
+    );
+
+    expect(limited.status).toBe(429);
+    const body = (await limited.json()) as { error?: string };
+    expect(body.error).toContain('Too many sync requests');
+  });
 });

--- a/apps/node_backend/src/routes/chat.ts
+++ b/apps/node_backend/src/routes/chat.ts
@@ -9,11 +9,23 @@ import {
   type AcceptTaskInput,
   type MessageUpsertInput,
 } from '../services/chatAsyncTransportService.js';
+import {
+  CHAT_ROUTER_DEFAULT,
+  CHAT_ROUTER_OPENCLAW,
+  deleteChatScopeSetting,
+  listChatScopeSettings,
+  resolveChatRouter,
+  type ChatRouter,
+  type ChatScopeType,
+  upsertChatScopeSetting,
+} from '../services/chatRouterService.js';
 import { generateWithUserConfig } from '../llm/llm_service.js';
 import type { LlmProvider } from '../llm/types.js';
 
 const router = express.Router();
 router.use(authenticate);
+
+const OPENCLAW_PENDING_TEXT = 'Waiting for OpenClaw...';
 
 function parseSessionId(value: unknown): string | null {
   if (typeof value !== 'string') return null;
@@ -26,6 +38,18 @@ function parseProvider(value: unknown): LlmProvider | undefined {
   if (value === 'anthropic' || value === 'google_ai_studio') return value;
   if (value === 'gemini') return 'google_ai_studio';
   return undefined;
+}
+
+function parseChatRouter(value: unknown): ChatRouter | null {
+  if (value === CHAT_ROUTER_DEFAULT || value === CHAT_ROUTER_OPENCLAW) {
+    return value;
+  }
+  return null;
+}
+
+function parseScopeType(value: unknown): ChatScopeType | null {
+  if (value === 'channel' || value === 'thread') return value;
+  return null;
 }
 
 router.post('/respond', async (req: AuthRequest, res: Response) => {
@@ -41,6 +65,7 @@ router.post('/respond', async (req: AuthRequest, res: Response) => {
     const idempotencyKey = parseSessionId(body.idempotencyKey);
     const channelId = parseSessionId(body.channelId);
     const sessionId = parseSessionId(body.sessionId);
+    const threadId = parseSessionId(body.threadId);
     const userMessageId = parseSessionId(body.userMessageId);
     const assistantMessageId = parseSessionId(body.assistantMessageId);
     const userMessage = typeof body.userMessage === 'string' ? body.userMessage.trim() : '';
@@ -58,13 +83,76 @@ router.post('/respond', async (req: AuthRequest, res: Response) => {
       idempotencyKey,
       channelId,
       sessionId,
-      threadId: parseSessionId(body.threadId),
+      threadId,
       resolvedBotId: parseSessionId(body.resolvedBotId),
       resolvedSkillId: parseSessionId(body.resolvedSkillId),
     };
+    const resolvedRouter = await resolveChatRouter(userId, {
+      channelId,
+      threadId,
+    });
     const acceptedTask = await acceptTask(userId, input);
     const acceptedTaskId = acceptedTask.taskId;
     const acceptedSessionId = acceptedTask.sessionId;
+
+    const userMessageMetadata = {
+      resolvedBotId: input.resolvedBotId,
+      resolvedSkillId: input.resolvedSkillId,
+      source:
+        resolvedRouter === CHAT_ROUTER_OPENCLAW
+          ? 'backend.respond.openclaw'
+          : 'backend.respond',
+      pendingAssistantMessageId:
+        resolvedRouter === CHAT_ROUTER_OPENCLAW ? assistantMessageId : undefined,
+    };
+
+    if (resolvedRouter === CHAT_ROUTER_OPENCLAW) {
+      const persisted = await upsertMessages(userId, [
+        {
+          messageId: userMessageId,
+          taskId: acceptedTaskId,
+          channelId,
+          sessionId: acceptedSessionId,
+          threadId: input.threadId,
+          role: 'user',
+          content: userMessage,
+          taskState: 'dispatched',
+          checkpointCursor: null,
+          metadata: userMessageMetadata,
+          createdAt: typeof body.createdAt === 'string' ? body.createdAt : null,
+        },
+        {
+          messageId: assistantMessageId,
+          taskId: acceptedTaskId,
+          channelId,
+          sessionId: acceptedSessionId,
+          threadId: input.threadId,
+          role: 'assistant',
+          content: OPENCLAW_PENDING_TEXT,
+          taskState: 'dispatched',
+          checkpointCursor: null,
+          metadata: {
+            resolvedBotId: input.resolvedBotId,
+            resolvedSkillId: input.resolvedSkillId,
+            source: 'backend.respond.openclaw.placeholder',
+            pendingFromMessageId: userMessageId,
+          },
+          createdAt: typeof body.createdAt === 'string' ? body.createdAt : null,
+        },
+      ]);
+
+      res.json({
+        taskId: acceptedTaskId,
+        sessionId: acceptedSessionId,
+        assistantMessageId,
+        text: OPENCLAW_PENDING_TEXT,
+        lastSeqId: persisted.lastSeqId,
+        state: 'dispatched',
+        mode: 'async',
+        router: resolvedRouter,
+      });
+      return;
+    }
 
     await upsertMessages(userId, [
       {
@@ -77,11 +165,7 @@ router.post('/respond', async (req: AuthRequest, res: Response) => {
         content: userMessage,
         taskState: 'accepted',
         checkpointCursor: null,
-        metadata: {
-          resolvedBotId: input.resolvedBotId,
-          resolvedSkillId: input.resolvedSkillId,
-          source: 'backend.respond',
-        },
+        metadata: userMessageMetadata,
         createdAt: typeof body.createdAt === 'string' ? body.createdAt : null,
       },
     ]);
@@ -131,6 +215,9 @@ router.post('/respond', async (req: AuthRequest, res: Response) => {
       provider: response.provider,
       model: response.model,
       lastSeqId: persisted.lastSeqId,
+      state: 'completed',
+      mode: 'sync',
+      router: resolvedRouter,
     });
   } catch (error) {
     console.error('Chat respond error:', error);
@@ -310,6 +397,83 @@ router.get('/scopes', async (req: AuthRequest, res: Response) => {
     res.json({ scopes });
   } catch (error) {
     console.error('List chat scopes error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.get('/scope-settings', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const settings = await listChatScopeSettings(userId);
+    res.json({ settings });
+  } catch (error) {
+    console.error('List chat scope settings error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.put('/scope-settings', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const body = req.body ?? {};
+    const scopeType = parseScopeType(body.scopeType);
+    const channelId = parseSessionId(body.channelId);
+    const threadId = parseSessionId(body.threadId);
+    const routerValue =
+      body.router === null || body.router === undefined
+        ? null
+        : parseChatRouter(body.router);
+
+    if (!scopeType || !channelId) {
+      res.status(400).json({
+        error: 'Invalid payload: scopeType and channelId are required',
+      });
+      return;
+    }
+
+    if (scopeType === 'thread' && !threadId) {
+      res.status(400).json({
+        error: 'Invalid payload: threadId is required for thread scope settings',
+      });
+      return;
+    }
+
+    if (body.router !== null && body.router !== undefined && !routerValue) {
+      res.status(400).json({
+        error: 'Invalid payload: router must be "default", "openclaw", or null',
+      });
+      return;
+    }
+
+    if (routerValue == null) {
+      const deleted = await deleteChatScopeSetting(userId, {
+        scopeType,
+        channelId,
+        threadId,
+      });
+      res.json({ deleted: deleted.deleted });
+      return;
+    }
+
+    const setting = await upsertChatScopeSetting(userId, {
+      scopeType,
+      channelId,
+      threadId,
+      router: routerValue,
+    });
+    res.json({ setting });
+  } catch (error) {
+    console.error('Upsert chat scope setting error:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/apps/node_backend/src/routes/chat.ts
+++ b/apps/node_backend/src/routes/chat.ts
@@ -1,4 +1,5 @@
 import express, { Response } from 'express';
+import rateLimit from 'express-rate-limit';
 import { authenticate, AuthRequest } from '../middleware/auth.js';
 import {
   acceptTask,
@@ -26,6 +27,8 @@ const router = express.Router();
 router.use(authenticate);
 
 const OPENCLAW_PENDING_TEXT = 'Waiting for OpenClaw...';
+const CHAT_SYNC_WINDOW_MS = 60 * 1000;
+const CHAT_SYNC_MAX_REQUESTS_PER_WINDOW = 120;
 
 function parseSessionId(value: unknown): string | null {
   if (typeof value !== 'string') return null;
@@ -51,6 +54,24 @@ function parseScopeType(value: unknown): ChatScopeType | null {
   if (value === 'channel' || value === 'thread') return value;
   return null;
 }
+
+const syncLimiter = rateLimit({
+  windowMs: CHAT_SYNC_WINDOW_MS,
+  max: CHAT_SYNC_MAX_REQUESTS_PER_WINDOW,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => {
+    const userId =
+      typeof (req as AuthRequest).userId === 'string'
+        ? (req as AuthRequest).userId
+        : 'anonymous';
+    const sessionId = parseSessionId(req.params.sessionId) ?? 'invalid-session';
+    return `${userId}:${sessionId}`;
+  },
+  message: {
+    error: 'Too many sync requests for this chat session, please try again later.',
+  },
+});
 
 router.post('/respond', async (req: AuthRequest, res: Response) => {
   try {
@@ -319,7 +340,7 @@ router.put('/messages/batch', async (req: AuthRequest, res: Response) => {
   }
 });
 
-router.get('/sync/:sessionId', async (req: AuthRequest, res: Response) => {
+router.get('/sync/:sessionId', syncLimiter, async (req: AuthRequest, res: Response) => {
   try {
     const userId = req.userId;
     if (!userId) {

--- a/apps/node_backend/src/routes/config.ts
+++ b/apps/node_backend/src/routes/config.ts
@@ -147,9 +147,9 @@ router.get('/platform-token', async (req: AuthRequest, res: Response) => {
       return;
     }
 
-    const requestedPluginId = typeof req.query.pluginId === 'string' ? req.query.pluginId.trim() : '';
+    const queryPluginId = typeof req.query.pluginId === 'string' ? req.query.pluginId.trim() : '';
     const pluginId =
-      requestedPluginId ||
+      queryPluginId ||
       process.env.BRICKS_PLATFORM_DEFAULT_PLUGIN_ID?.trim() ||
       'plugin_local_main';
     const scopes = (process.env.BRICKS_PLATFORM_API_SCOPES ??

--- a/apps/node_backend/src/routes/config.ts
+++ b/apps/node_backend/src/routes/config.ts
@@ -7,6 +7,7 @@ import {
   updateApiConfig,
   deleteApiConfig,
 } from '../services/configService.js';
+import { issuePlatformAccessToken } from '../middleware/platformAuth.js';
 
 const router = express.Router();
 const ALLOWED_PROVIDERS = new Set(['anthropic', 'google_ai_studio']);
@@ -129,6 +130,49 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     res.json(configs.map(sanitizeConfigForResponse));
   } catch (error) {
     console.error('Get configs error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /config/platform-token
+ * Issue a scoped pull-only platform token for remote OpenClaw/小龙虾 adapters.
+ */
+router.get('/platform-token', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.userId;
+
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const pluginId =
+      (typeof req.query.pluginId === 'string' ? req.query.pluginId : null) ??
+      process.env.BRICKS_PLATFORM_DEFAULT_PLUGIN_ID ??
+      'plugin_local_main';
+    const scopes = (process.env.BRICKS_PLATFORM_API_SCOPES ??
+            'events:read,events:ack,messages:write,conversations:read')
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+
+    const token = issuePlatformAccessToken({
+      userId,
+      pluginId,
+      scopes,
+      expiresIn: '30d',
+    });
+
+    res.json({
+      token,
+      pluginId,
+      scopes,
+      baseUrl: process.env.BRICKS_PLATFORM_BASE_URL?.trim() || process.env.API_BASE_URL?.trim() || '',
+      expiresIn: '30d',
+    });
+  } catch (error) {
+    console.error('Get platform token error:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/apps/node_backend/src/routes/config.ts
+++ b/apps/node_backend/src/routes/config.ts
@@ -147,9 +147,10 @@ router.get('/platform-token', async (req: AuthRequest, res: Response) => {
       return;
     }
 
+    const requestedPluginId = typeof req.query.pluginId === 'string' ? req.query.pluginId.trim() : '';
     const pluginId =
-      (typeof req.query.pluginId === 'string' ? req.query.pluginId : null) ??
-      process.env.BRICKS_PLATFORM_DEFAULT_PLUGIN_ID ??
+      requestedPluginId ||
+      process.env.BRICKS_PLATFORM_DEFAULT_PLUGIN_ID?.trim() ||
       'plugin_local_main';
     const scopes = (process.env.BRICKS_PLATFORM_API_SCOPES ??
             'events:read,events:ack,messages:write,conversations:read')

--- a/apps/node_backend/src/routes/platform.test.ts
+++ b/apps/node_backend/src/routes/platform.test.ts
@@ -1,0 +1,135 @@
+import express from 'express';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
+import { issuePlatformAccessToken } from '../middleware/platformAuth.js';
+
+vi.mock('../services/platformIntegrationService.js', () => ({
+  listPlatformEvents: vi.fn(async () => ({ nextCursor: 'cur_0', events: [] })),
+  ackPlatformEvents: vi.fn(async () => ({ ok: true })),
+  createPlatformMessage: vi.fn(),
+  patchPlatformMessage: vi.fn(),
+  resolveConversation: vi.fn(),
+}));
+
+let server: ReturnType<express.Express['listen']> | null = null;
+let baseUrl = '';
+
+beforeAll(async () => {
+  process.env.BRICKS_PLATFORM_API_KEY = 'test-platform-key';
+  process.env.BRICKS_PLATFORM_API_SCOPES = 'events:read,events:ack,messages:write,conversations:read';
+  process.env.JWT_SECRET = 'test-jwt-secret';
+
+  const app = express();
+  app.use(express.json());
+  const { default: platformRoutes } = await import('./platform.js');
+  app.use('/api/v1/platform', platformRoutes);
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const address = server?.address();
+      if (address && typeof address === 'object') {
+        baseUrl = `http://127.0.0.1:${address.port}`;
+      }
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    if (!server) {
+      resolve();
+      return;
+    }
+    server.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+});
+
+describe('platform route auth and ack constraints', () => {
+  it('returns 400 when plugin header is missing', async () => {
+    const response = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-platform-key',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ackedEventIds: ['evt_1'], cursor: 'cur_1' }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('MISSING_PLUGIN_ID');
+  });
+
+  it('rejects pluginId in ack body with 400', async () => {
+    const response = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-platform-key',
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({ pluginId: 'forbidden', ackedEventIds: ['evt_1'], cursor: 'cur_1' }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('INVALID_PAYLOAD');
+  });
+
+  it('accepts valid ack payload idempotently', async () => {
+    const first = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-platform-key',
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({ ackedEventIds: ['evt_1'], cursor: 'cur_1' }),
+    });
+
+    const second = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-platform-key',
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({ ackedEventIds: ['evt_1'], cursor: 'cur_1' }),
+    });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+
+    const body = (await second.json()) as { ok?: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  it('accepts user-scoped JWT platform token', async () => {
+    const jwtToken = issuePlatformAccessToken({
+      userId: 'user-123',
+      pluginId: 'plugin_local_main',
+      scopes: ['events:ack'],
+      expiresIn: '1h',
+    });
+    const response = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwtToken}`,
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({ ackedEventIds: ['evt_2'], cursor: 'cur_2' }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok?: boolean };
+    expect(body.ok).toBe(true);
+  });
+});

--- a/apps/node_backend/src/routes/platform.test.ts
+++ b/apps/node_backend/src/routes/platform.test.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import jwt from 'jsonwebtoken';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { vi } from 'vitest';
 import { issuePlatformAccessToken } from '../middleware/platformAuth.js';
@@ -135,6 +136,31 @@ describe('platform route auth and ack constraints', () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as { ok?: boolean };
     expect(body.ok).toBe(true);
+  });
+
+  it('rejects JWT platform token without pluginId claim', async () => {
+    const jwtToken = jwt.sign(
+      {
+        typ: 'platform_plugin',
+        userId: 'user-123',
+        scopes: ['events:ack'],
+      },
+      process.env.JWT_SECRET!,
+      { expiresIn: '1h' },
+    );
+    const response = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwtToken}`,
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({ ackedEventIds: ['evt_2'], cursor: 'cur_2' }),
+    });
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('UNAUTHORIZED');
   });
 
   it('JWT events listing passes userId to service', async () => {

--- a/apps/node_backend/src/routes/platform.test.ts
+++ b/apps/node_backend/src/routes/platform.test.ts
@@ -2,11 +2,15 @@ import express from 'express';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { vi } from 'vitest';
 import { issuePlatformAccessToken } from '../middleware/platformAuth.js';
+import {
+  listPlatformEvents,
+  createPlatformMessage,
+} from '../services/platformIntegrationService.js';
 
 vi.mock('../services/platformIntegrationService.js', () => ({
   listPlatformEvents: vi.fn(async () => ({ nextCursor: 'cur_0', events: [] })),
   ackPlatformEvents: vi.fn(async () => ({ ok: true })),
-  createPlatformMessage: vi.fn(),
+  createPlatformMessage: vi.fn(async () => ({ messageId: 'msg_test', conversationId: 'conv_1', revision: 1 })),
   patchPlatformMessage: vi.fn(),
   resolveConversation: vi.fn(),
 }));
@@ -131,5 +135,86 @@ describe('platform route auth and ack constraints', () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as { ok?: boolean };
     expect(body.ok).toBe(true);
+  });
+
+  it('JWT events listing passes userId to service', async () => {
+    const jwtToken = issuePlatformAccessToken({
+      userId: 'user-456',
+      pluginId: 'plugin_local_main',
+      scopes: ['events:read'],
+      expiresIn: '1h',
+    });
+
+    vi.mocked(listPlatformEvents).mockClear();
+
+    const response = await fetch(`${baseUrl}/api/v1/platform/events?cursor=cur_0`, {
+      headers: {
+        Authorization: `Bearer ${jwtToken}`,
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(listPlatformEvents)).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-456' }),
+    );
+  });
+
+  it('JWT token prevents userId override in POST /messages', async () => {
+    const jwtToken = issuePlatformAccessToken({
+      userId: 'user-123',
+      pluginId: 'plugin_local_main',
+      scopes: ['messages:write'],
+      expiresIn: '1h',
+    });
+
+    const response = await fetch(`${baseUrl}/api/v1/platform/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwtToken}`,
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({
+        userId: 'different-user',
+        conversationId: 'conv-1',
+        channelId: 'ch-1',
+        text: 'hello',
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('FORBIDDEN');
+  });
+
+  it('JWT token uses token userId when body userId is absent in POST /messages', async () => {
+    const jwtToken = issuePlatformAccessToken({
+      userId: 'user-123',
+      pluginId: 'plugin_local_main',
+      scopes: ['messages:write'],
+      expiresIn: '1h',
+    });
+
+    vi.mocked(createPlatformMessage).mockClear();
+
+    const response = await fetch(`${baseUrl}/api/v1/platform/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwtToken}`,
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({
+        conversationId: 'conv-1',
+        channelId: 'ch-1',
+        text: 'hello',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(createPlatformMessage)).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-123' }),
+    );
   });
 });

--- a/apps/node_backend/src/routes/platform.ts
+++ b/apps/node_backend/src/routes/platform.ts
@@ -38,8 +38,28 @@ function readTrimmedString(input: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+/**
+ * Resolves the effective userId for a platform request.
+ * When a JWT token is present, its userId is canonical and body userId must match or be absent.
+ * In static API key mode, body userId is used directly.
+ * Returns the resolved userId or null if unavailable, and an error descriptor if mismatch is detected.
+ */
+function resolveRequestUserId(
+  platformUserId: string | undefined,
+  bodyUserId: string | null,
+): { userId: string | null; mismatch: boolean } {
+  if (platformUserId) {
+    if (bodyUserId && bodyUserId !== platformUserId) {
+      return { userId: null, mismatch: true };
+    }
+    return { userId: platformUserId, mismatch: false };
+  }
+  return { userId: bodyUserId, mismatch: false };
+}
+
 router.get('/events', requirePlatformScope('events:read'), async (req: Request, res: Response) => {
   try {
+    const platformReq = req as PlatformAuthRequest;
     const cursor = readTrimmedString(req.query.cursor);
     const limitRaw = req.query.limit;
     const limit =
@@ -52,7 +72,11 @@ router.get('/events', requirePlatformScope('events:read'), async (req: Request, 
       return;
     }
 
-    const response = await listPlatformEvents({ cursor: cursor ?? undefined, limit });
+    const response = await listPlatformEvents({
+      cursor: cursor ?? undefined,
+      limit,
+      userId: platformReq.platformUserId,
+    });
     res.status(200).json(response);
   } catch (error) {
     if (error instanceof Error && error.message === 'INVALID_CURSOR') {
@@ -91,6 +115,10 @@ router.post(
       });
       res.status(200).json({ ok: true });
     } catch (error) {
+      if (error instanceof Error && error.message === 'INVALID_CURSOR') {
+        sendError(res, 400, 'INVALID_CURSOR', 'cursor is malformed');
+        return;
+      }
       console.error('platform ack error:', error);
       sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
     }
@@ -102,18 +130,28 @@ router.post(
   requirePlatformScope('messages:write'),
   async (req: PlatformAuthRequest, res: Response) => {
   try {
-    const userId = readTrimmedString(req.body?.userId) ?? req.platformUserId ?? null;
+    const { userId, mismatch } = resolveRequestUserId(
+      req.platformUserId,
+      readTrimmedString(req.body?.userId),
+    );
+    if (mismatch) {
+      sendError(res, 403, 'FORBIDDEN', 'userId in body does not match token');
+      return;
+    }
+
     const conversationId = readTrimmedString(req.body?.conversationId);
     const channelId = readTrimmedString(req.body?.channelId);
-    const text = readTrimmedString(req.body?.text);
-    const role = readTrimmedString(req.body?.role) ?? 'assistant';
+    // Support both `text` and `content` field names per OpenClaw contract
+    const text = readTrimmedString(req.body?.text) ?? readTrimmedString(req.body?.content);
+    // Support both `role` and `author` field names per OpenClaw contract
+    const role = readTrimmedString(req.body?.role) ?? readTrimmedString(req.body?.author) ?? 'assistant';
 
     if (!userId || !conversationId || !channelId || !text) {
       sendError(
         res,
         400,
         'INVALID_PAYLOAD',
-        'userId, conversationId, channelId, text are required',
+        'userId, conversationId, channelId, and text or content are required',
       );
       return;
     }
@@ -146,9 +184,17 @@ router.patch(
   async (req: PlatformAuthRequest, res: Response) => {
     try {
       const messageId = readTrimmedString(req.params.messageId);
-      const userId = readTrimmedString(req.body?.userId) ?? req.platformUserId ?? null;
+      const { userId, mismatch } = resolveRequestUserId(
+        req.platformUserId,
+        readTrimmedString(req.body?.userId),
+      );
+      if (mismatch) {
+        sendError(res, 403, 'FORBIDDEN', 'userId in body does not match token');
+        return;
+      }
+
       if (!messageId || !userId) {
-        sendError(res, 400, 'INVALID_PAYLOAD', 'messageId param and userId body are required');
+        sendError(res, 400, 'INVALID_PAYLOAD', 'messageId param and userId are required');
         return;
       }
 
@@ -182,6 +228,7 @@ router.get(
   requirePlatformScope('conversations:read'),
   async (req: Request, res: Response) => {
     try {
+      const platformReq = req as PlatformAuthRequest;
       const conversationId = readTrimmedString(req.query.conversationId);
       const rawId = readTrimmedString(req.query.rawId);
       if (!conversationId && !rawId) {
@@ -189,7 +236,11 @@ router.get(
         return;
       }
 
-      const resolved = await resolveConversation({ conversationId: conversationId ?? undefined, rawId: rawId ?? undefined });
+      const resolved = await resolveConversation({
+        conversationId: conversationId ?? undefined,
+        rawId: rawId ?? undefined,
+        userId: platformReq.platformUserId,
+      });
       if (!resolved) {
         sendError(res, 404, 'CONVERSATION_NOT_FOUND', 'conversation not found');
         return;

--- a/apps/node_backend/src/routes/platform.ts
+++ b/apps/node_backend/src/routes/platform.ts
@@ -1,0 +1,206 @@
+import express, { type Request, type Response } from 'express';
+import {
+  authenticatePlatformApiKey,
+  requirePlatformScope,
+  type PlatformAuthRequest,
+} from '../middleware/platformAuth.js';
+import {
+  ackPlatformEvents,
+  createPlatformMessage,
+  listPlatformEvents,
+  patchPlatformMessage,
+  resolveConversation,
+} from '../services/platformIntegrationService.js';
+
+const router = express.Router();
+router.use(authenticatePlatformApiKey);
+
+function requestId(): string {
+  return `req_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function sendError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  retryable = false,
+): void {
+  res.status(status).json({
+    error: { code, message, retryable },
+    requestId: requestId(),
+  });
+}
+
+function readTrimmedString(input: unknown): string | null {
+  if (typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+router.get('/events', requirePlatformScope('events:read'), async (req: Request, res: Response) => {
+  try {
+    const cursor = readTrimmedString(req.query.cursor);
+    const limitRaw = req.query.limit;
+    const limit =
+      typeof limitRaw === 'string' && limitRaw.trim().length > 0
+        ? Number.parseInt(limitRaw, 10)
+        : undefined;
+
+    if (limit !== undefined && (!Number.isFinite(limit) || limit <= 0)) {
+      sendError(res, 400, 'INVALID_LIMIT', 'limit must be a positive integer');
+      return;
+    }
+
+    const response = await listPlatformEvents({ cursor: cursor ?? undefined, limit });
+    res.status(200).json(response);
+  } catch (error) {
+    if (error instanceof Error && error.message === 'INVALID_CURSOR') {
+      sendError(res, 400, 'INVALID_CURSOR', 'cursor is malformed');
+      return;
+    }
+    console.error('platform events error:', error);
+    sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
+  }
+});
+
+router.post(
+  '/events/ack',
+  requirePlatformScope('events:ack'),
+  async (req: PlatformAuthRequest, res: Response) => {
+    try {
+      if (req.body && typeof req.body === 'object' && 'pluginId' in req.body) {
+        sendError(res, 400, 'INVALID_PAYLOAD', 'pluginId body field is forbidden');
+        return;
+      }
+
+      const ackedEventIds = Array.isArray(req.body?.ackedEventIds)
+        ? req.body.ackedEventIds.filter((v: unknown) => typeof v === 'string' && v.trim().length > 0)
+        : null;
+      const cursor = readTrimmedString(req.body?.cursor);
+
+      if (!ackedEventIds || !cursor) {
+        sendError(res, 400, 'INVALID_PAYLOAD', 'ackedEventIds and cursor are required');
+        return;
+      }
+
+      await ackPlatformEvents({
+        pluginId: req.platformPluginId ?? 'unknown',
+        ackedEventIds,
+        cursor,
+      });
+      res.status(200).json({ ok: true });
+    } catch (error) {
+      console.error('platform ack error:', error);
+      sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
+    }
+  },
+);
+
+router.post(
+  '/messages',
+  requirePlatformScope('messages:write'),
+  async (req: PlatformAuthRequest, res: Response) => {
+  try {
+    const userId = readTrimmedString(req.body?.userId) ?? req.platformUserId ?? null;
+    const conversationId = readTrimmedString(req.body?.conversationId);
+    const channelId = readTrimmedString(req.body?.channelId);
+    const text = readTrimmedString(req.body?.text);
+    const role = readTrimmedString(req.body?.role) ?? 'assistant';
+
+    if (!userId || !conversationId || !channelId || !text) {
+      sendError(
+        res,
+        400,
+        'INVALID_PAYLOAD',
+        'userId, conversationId, channelId, text are required',
+      );
+      return;
+    }
+
+    const result = await createPlatformMessage({
+      userId,
+      conversationId,
+      channelId,
+      threadId: readTrimmedString(req.body?.threadId),
+      text,
+      role,
+      clientToken: readTrimmedString(req.body?.clientToken) ?? undefined,
+      metadata:
+        req.body?.metadata && typeof req.body.metadata === 'object' && !Array.isArray(req.body.metadata)
+          ? (req.body.metadata as Record<string, unknown>)
+          : undefined,
+    });
+
+    res.status(200).json(result);
+    } catch (error) {
+      console.error('platform create message error:', error);
+      sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
+    }
+  },
+);
+
+router.patch(
+  '/messages/:messageId',
+  requirePlatformScope('messages:write'),
+  async (req: PlatformAuthRequest, res: Response) => {
+    try {
+      const messageId = readTrimmedString(req.params.messageId);
+      const userId = readTrimmedString(req.body?.userId) ?? req.platformUserId ?? null;
+      if (!messageId || !userId) {
+        sendError(res, 400, 'INVALID_PAYLOAD', 'messageId param and userId body are required');
+        return;
+      }
+
+      const text = readTrimmedString(req.body?.text);
+      const metadata =
+        req.body?.metadata && typeof req.body.metadata === 'object' && !Array.isArray(req.body.metadata)
+          ? (req.body.metadata as Record<string, unknown>)
+          : undefined;
+
+      if (!text && !metadata) {
+        sendError(res, 400, 'INVALID_PAYLOAD', 'at least one of text or metadata is required');
+        return;
+      }
+
+      const result = await patchPlatformMessage({ userId, messageId, text: text ?? undefined, metadata });
+      if (!result) {
+        sendError(res, 404, 'MESSAGE_NOT_FOUND', 'message not found');
+        return;
+      }
+
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('platform patch message error:', error);
+      sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
+    }
+  },
+);
+
+router.get(
+  '/conversations/resolve',
+  requirePlatformScope('conversations:read'),
+  async (req: Request, res: Response) => {
+    try {
+      const conversationId = readTrimmedString(req.query.conversationId);
+      const rawId = readTrimmedString(req.query.rawId);
+      if (!conversationId && !rawId) {
+        sendError(res, 400, 'INVALID_QUERY', 'conversationId or rawId is required');
+        return;
+      }
+
+      const resolved = await resolveConversation({ conversationId: conversationId ?? undefined, rawId: rawId ?? undefined });
+      if (!resolved) {
+        sendError(res, 404, 'CONVERSATION_NOT_FOUND', 'conversation not found');
+        return;
+      }
+
+      res.status(200).json(resolved);
+    } catch (error) {
+      console.error('platform resolve conversation error:', error);
+      sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
+    }
+  },
+);
+
+export default router;

--- a/apps/node_backend/src/services/chatAsyncTransportService.test.ts
+++ b/apps/node_backend/src/services/chatAsyncTransportService.test.ts
@@ -86,6 +86,7 @@ describe('chatAsyncTransportService', () => {
     const clientQueryMock = vi.fn()
       .mockResolvedValueOnce({ rows: [], rowCount: 0 })             // BEGIN
       .mockResolvedValueOnce({ rows: [{ counter: 11 }], rowCount: 1 }) // counter++
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })             // SELECT existing metadata
       .mockResolvedValueOnce({ rows: [], rowCount: 1 })             // INSERT message
       .mockResolvedValueOnce({ rows: [], rowCount: 1 })             // INSERT checkpoint
       .mockResolvedValueOnce({ rows: [], rowCount: 0 });            // COMMIT
@@ -112,7 +113,7 @@ describe('chatAsyncTransportService', () => {
     ]);
 
     expect(result.lastSeqId).toBe(11);
-    expect(clientQueryMock).toHaveBeenCalledTimes(5);
+    expect(clientQueryMock).toHaveBeenCalledTimes(6);
   });
 
   it('upsertMessages rolls back on error', async () => {
@@ -148,6 +149,60 @@ describe('chatAsyncTransportService', () => {
     ).rejects.toThrow('DB error');
 
     expect(releaseMock).toHaveBeenCalled();
+  });
+
+  it('upsertMessages preserves existing server metadata keys', async () => {
+    const clientQueryMock = vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // BEGIN
+        .mockResolvedValueOnce({ rows: [{ counter: 12 }], rowCount: 1 }) // counter++
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              metadata: JSON.stringify({
+                source: 'backend.respond.openclaw',
+                pendingAssistantMessageId: 'msg-assistant-1',
+              }),
+            },
+          ],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 }) // INSERT message
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 }) // checkpoint
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // COMMIT
+
+    connectMock.mockResolvedValueOnce({
+      query: clientQueryMock,
+      release: vi.fn(),
+    });
+
+    await upsertMessages('u-1', [
+      {
+        messageId: 'msg-user-1',
+        taskId: 'task-1',
+        channelId: 'default',
+        sessionId: 'session:default:main',
+        threadId: null,
+        role: 'user',
+        content: 'hello',
+        taskState: 'dispatched',
+        checkpointCursor: null,
+        metadata: { resolvedBotId: 'ask' },
+        createdAt: null,
+      },
+    ]);
+
+    expect(clientQueryMock).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining('INSERT INTO chat_messages'),
+      expect.arrayContaining([
+        JSON.stringify({
+          source: 'backend.respond.openclaw',
+          pendingAssistantMessageId: 'msg-assistant-1',
+          resolvedBotId: 'ask',
+        }),
+      ]),
+    );
   });
 
   it('syncMessages returns ordered deltas using write_seq cursor', async () => {
@@ -198,6 +253,7 @@ describe('chatAsyncTransportService', () => {
       ],
       rowCount: 2,
     });
+    queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 });
 
     const scopes = await listUserScopes('u-1');
     expect(scopes).toEqual([
@@ -212,6 +268,34 @@ describe('chatAsyncTransportService', () => {
         threadId: 'main',
         sessionId: 'session:default:main',
         lastActivityAt: '2026-04-08T10:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('listUserScopes includes configured scopes without message history', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          scope_type: 'channel',
+          channel_id: 'openclaw-lab',
+          thread_id: '',
+          router: 'openclaw',
+          created_at: '2026-04-17T07:00:00.000Z',
+          updated_at: '2026-04-17T07:00:00.000Z',
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const scopes = await listUserScopes('u-1');
+
+    expect(scopes).toEqual([
+      {
+        channelId: 'openclaw-lab',
+        threadId: 'main',
+        sessionId: 'session:openclaw-lab:main',
+        lastActivityAt: null,
       },
     ]);
   });

--- a/apps/node_backend/src/services/chatAsyncTransportService.ts
+++ b/apps/node_backend/src/services/chatAsyncTransportService.ts
@@ -1,4 +1,9 @@
 import pool from '../db/index.js';
+import {
+  buildChatSessionId,
+  listChatScopeSettings,
+  normalizeChatThreadId,
+} from './chatRouterService.js';
 
 export interface AcceptTaskInput {
   taskId: string;
@@ -66,7 +71,7 @@ export interface ChatPersistedScope {
   channelId: string;
   threadId: string;
   sessionId: string;
-  lastActivityAt: string;
+  lastActivityAt: string | null;
 }
 
 function parseMetadata(raw: unknown): Record<string, unknown> | null {
@@ -194,6 +199,18 @@ export async function upsertMessages(
       }
       const writeSeq = Number(seqResult.rows[0].counter);
 
+      const existingMessage = await client.query<{ metadata: unknown }>(
+        `SELECT metadata
+           FROM chat_messages
+          WHERE user_id = $1 AND message_id = $2
+          LIMIT 1`,
+        [userId, message.messageId],
+      );
+      const mergedMetadata = {
+        ...(parseMetadata(existingMessage.rows[0]?.metadata) ?? {}),
+        ...(message.metadata ?? {}),
+      };
+
       await client.query(
         `INSERT INTO chat_messages (
             message_id,
@@ -229,7 +246,7 @@ export async function upsertMessages(
           message.content,
           message.taskState ?? null,
           message.checkpointCursor ?? null,
-          JSON.stringify(message.metadata ?? {}),
+          JSON.stringify(mergedMetadata),
           message.createdAt ?? null,
           writeSeq,
         ],
@@ -331,7 +348,8 @@ export async function listSessionMessagesForModel(
 }
 
 export async function listUserScopes(userId: string): Promise<ChatPersistedScope[]> {
-  const result = await pool.query<ChatScopeRow>(
+  const [result, settings] = await Promise.all([
+    pool.query<ChatScopeRow>(
     `SELECT
         scope.channel_id,
         scope.thread_id,
@@ -354,15 +372,45 @@ export async function listUserScopes(userId: string): Promise<ChatPersistedScope
         FROM chat_tasks
         WHERE user_id = $1
       ) scope
-      GROUP BY scope.channel_id, scope.thread_id, scope.session_id
-      ORDER BY last_activity_at DESC`,
+       GROUP BY scope.channel_id, scope.thread_id, scope.session_id
+       ORDER BY last_activity_at DESC`,
     [userId],
-  );
+    ),
+    listChatScopeSettings(userId),
+  ]);
 
-  return result.rows.map((row) => ({
-    channelId: row.channel_id,
-    threadId: row.thread_id ?? 'main',
-    sessionId: row.session_id,
-    lastActivityAt: row.last_activity_at,
-  }));
+  const bySessionId = new Map<string, ChatPersistedScope>();
+  for (const row of result.rows) {
+    const threadId = normalizeChatThreadId(row.thread_id);
+    bySessionId.set(row.session_id, {
+      channelId: row.channel_id,
+      threadId,
+      sessionId: row.session_id,
+      lastActivityAt: row.last_activity_at,
+    });
+  }
+
+  for (const setting of settings) {
+    const threadId =
+      setting.scopeType === 'thread'
+        ? normalizeChatThreadId(setting.threadId)
+        : 'main';
+    const sessionId = buildChatSessionId(setting.channelId, threadId);
+    if (bySessionId.has(sessionId)) continue;
+    bySessionId.set(sessionId, {
+      channelId: setting.channelId,
+      threadId,
+      sessionId,
+      lastActivityAt: null,
+    });
+  }
+
+  return [...bySessionId.values()].sort((a, b) => {
+    if (a.lastActivityAt && b.lastActivityAt) {
+      return b.lastActivityAt.localeCompare(a.lastActivityAt);
+    }
+    if (b.lastActivityAt) return 1;
+    if (a.lastActivityAt) return -1;
+    return a.sessionId.localeCompare(b.sessionId);
+  });
 }

--- a/apps/node_backend/src/services/chatRouterService.test.ts
+++ b/apps/node_backend/src/services/chatRouterService.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+}));
+
+vi.mock('../db/index.js', () => ({
+  default: {
+    query: queryMock,
+  },
+}));
+
+import {
+  CHAT_ROUTER_DEFAULT,
+  buildChatSessionId,
+  deleteChatScopeSetting,
+  listChatScopeSettings,
+  normalizeChatThreadId,
+  resolveChatRouter,
+  upsertChatScopeSetting,
+} from './chatRouterService.js';
+
+describe('chatRouterService', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it('normalizes empty thread ids to main and builds session ids consistently', () => {
+    expect(normalizeChatThreadId(null)).toBe('main');
+    expect(normalizeChatThreadId('')).toBe('main');
+    expect(buildChatSessionId('channel-a', null)).toBe('session:channel-a:main');
+    expect(buildChatSessionId('channel-a', 'sub-1')).toBe('session:channel-a:sub-1');
+  });
+
+  it('lists scope settings with nullable channel-level thread id', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          scope_type: 'channel',
+          channel_id: 'default',
+          thread_id: '',
+          router: 'openclaw',
+          created_at: '2026-04-17T07:00:00.000Z',
+          updated_at: '2026-04-17T07:05:00.000Z',
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const settings = await listChatScopeSettings('u-1');
+
+    expect(settings).toEqual([
+      {
+        scopeType: 'channel',
+        channelId: 'default',
+        threadId: null,
+        router: 'openclaw',
+        createdAt: '2026-04-17T07:00:00.000Z',
+        updatedAt: '2026-04-17T07:05:00.000Z',
+      },
+    ]);
+  });
+
+  it('upserts thread scope settings using normalized main thread id', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          scope_type: 'thread',
+          channel_id: 'default',
+          thread_id: 'main',
+          router: 'default',
+          created_at: '2026-04-17T07:00:00.000Z',
+          updated_at: '2026-04-17T07:05:00.000Z',
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const setting = await upsertChatScopeSetting('u-1', {
+      scopeType: 'thread',
+      channelId: 'default',
+      threadId: null,
+      router: 'default',
+    });
+
+    expect(setting.threadId).toBe('main');
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO chat_scope_settings'),
+      ['u-1', 'thread', 'default', 'main', 'default'],
+    );
+  });
+
+  it('deletes channel scope settings with empty storage thread id', async () => {
+    queryMock.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const result = await deleteChatScopeSetting('u-1', {
+      scopeType: 'channel',
+      channelId: 'default',
+      threadId: null,
+    });
+
+    expect(result.deleted).toBe(true);
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM chat_scope_settings'),
+      ['u-1', 'channel', 'default', ''],
+    );
+  });
+
+  it('falls back to default router when no explicit setting exists', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const router = await resolveChatRouter('u-1', {
+      channelId: 'default',
+      threadId: 'main',
+    });
+
+    expect(router).toBe(CHAT_ROUTER_DEFAULT);
+  });
+});

--- a/apps/node_backend/src/services/chatRouterService.ts
+++ b/apps/node_backend/src/services/chatRouterService.ts
@@ -1,0 +1,135 @@
+import pool from '../db/index.js';
+
+export const CHAT_ROUTER_DEFAULT = 'default';
+export const CHAT_ROUTER_OPENCLAW = 'openclaw';
+
+export type ChatRouter = typeof CHAT_ROUTER_DEFAULT | typeof CHAT_ROUTER_OPENCLAW;
+export type ChatScopeType = 'channel' | 'thread';
+
+interface ChatScopeSettingRow {
+  scope_type: ChatScopeType;
+  channel_id: string;
+  thread_id: string;
+  router: ChatRouter;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ChatScopeSetting {
+  scopeType: ChatScopeType;
+  channelId: string;
+  threadId: string | null;
+  router: ChatRouter;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChatScopeSelector {
+  channelId: string;
+  threadId?: string | null;
+}
+
+export interface ChatScopeSettingInput extends ChatScopeSelector {
+  scopeType: ChatScopeType;
+  router: ChatRouter;
+}
+
+export function normalizeChatThreadId(threadId: string | null | undefined): string {
+  const trimmed = threadId?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : 'main';
+}
+
+function toStorageThreadId(scopeType: ChatScopeType, threadId?: string | null): string {
+  if (scopeType === 'channel') return '';
+  return normalizeChatThreadId(threadId);
+}
+
+function toDto(row: ChatScopeSettingRow): ChatScopeSetting {
+  return {
+    scopeType: row.scope_type,
+    channelId: row.channel_id,
+    threadId: row.scope_type === 'thread' ? row.thread_id : null,
+    router: row.router,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function buildChatSessionId(channelId: string, threadId?: string | null): string {
+  return `session:${channelId}:${normalizeChatThreadId(threadId)}`;
+}
+
+export async function listChatScopeSettings(userId: string): Promise<ChatScopeSetting[]> {
+  const result = await pool.query<ChatScopeSettingRow>(
+    `SELECT scope_type, channel_id, thread_id, router, created_at, updated_at
+       FROM chat_scope_settings
+      WHERE user_id = $1
+      ORDER BY channel_id ASC, scope_type ASC, thread_id ASC`,
+    [userId],
+  );
+  return result.rows.map(toDto);
+}
+
+export async function upsertChatScopeSetting(
+  userId: string,
+  input: ChatScopeSettingInput,
+): Promise<ChatScopeSetting> {
+  const threadId = toStorageThreadId(input.scopeType, input.threadId);
+  const result = await pool.query<ChatScopeSettingRow>(
+    `INSERT INTO chat_scope_settings (
+        user_id,
+        scope_type,
+        channel_id,
+        thread_id,
+        router
+      ) VALUES ($1, $2, $3, $4, $5)
+      ON CONFLICT (user_id, scope_type, channel_id, thread_id)
+      DO UPDATE SET
+        router = EXCLUDED.router,
+        updated_at = CURRENT_TIMESTAMP
+      RETURNING scope_type, channel_id, thread_id, router, created_at, updated_at`,
+    [userId, input.scopeType, input.channelId, threadId, input.router],
+  );
+
+  return toDto(result.rows[0]);
+}
+
+export async function deleteChatScopeSetting(
+  userId: string,
+  input: Pick<ChatScopeSettingInput, 'scopeType' | 'channelId' | 'threadId'>,
+): Promise<{ deleted: boolean }> {
+  const threadId = toStorageThreadId(input.scopeType, input.threadId);
+  const result = await pool.query(
+    `DELETE FROM chat_scope_settings
+      WHERE user_id = $1
+        AND scope_type = $2
+        AND channel_id = $3
+        AND thread_id = $4`,
+    [userId, input.scopeType, input.channelId, threadId],
+  );
+
+  return { deleted: (result.rowCount ?? 0) > 0 };
+}
+
+export async function resolveChatRouter(
+  userId: string,
+  selector: ChatScopeSelector,
+): Promise<ChatRouter> {
+  const threadId = normalizeChatThreadId(selector.threadId);
+  const result = await pool.query<{ router: ChatRouter }>(
+    `SELECT router
+       FROM chat_scope_settings
+      WHERE user_id = $1
+        AND channel_id = $2
+        AND (
+          (scope_type = 'thread' AND thread_id = $3)
+          OR
+          (scope_type = 'channel' AND thread_id = '')
+        )
+      ORDER BY CASE scope_type WHEN 'thread' THEN 0 ELSE 1 END
+      LIMIT 1`,
+    [userId, selector.channelId, threadId],
+  );
+
+  return result.rows[0]?.router ?? CHAT_ROUTER_DEFAULT;
+}

--- a/apps/node_backend/src/services/platformIntegrationService.test.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryMock, upsertMessagesMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  upsertMessagesMock: vi.fn(async () => ({ lastSeqId: 99 })),
+}));
+
+vi.mock('../db/index.js', () => ({
+  default: {
+    query: queryMock,
+  },
+}));
+
+vi.mock('./chatAsyncTransportService.js', () => ({
+  upsertMessages: upsertMessagesMock,
+}));
+
+import {
+  createPlatformMessage,
+  listPlatformEvents,
+  patchPlatformMessage,
+} from './platformIntegrationService.js';
+
+describe('platformIntegrationService', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    upsertMessagesMock.mockClear();
+  });
+
+  it('lists only OpenClaw-ready user events with pending assistant metadata', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          write_seq: 5,
+          message_id: 'msg-user-1',
+          user_id: 'u-1',
+          channel_id: 'default',
+          session_id: 'session:default:main',
+          thread_id: null,
+          role: 'user',
+          content: 'hello',
+          created_at: '2026-04-17T07:00:00.000Z',
+          metadata: JSON.stringify({
+            pendingAssistantMessageId: 'msg-assistant-1',
+          }),
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const response = await listPlatformEvents({ cursor: 'cur_0', userId: 'u-1' });
+
+    expect(response.nextCursor).toBe('cur_5');
+    expect(response.events).toHaveLength(1);
+    expect(response.events[0].payload.metadata).toMatchObject({
+      pendingAssistantMessageId: 'msg-assistant-1',
+    });
+  });
+
+  it('marks assistant creates as dispatched', async () => {
+    const result = await createPlatformMessage({
+      userId: 'u-1',
+      conversationId: 'session:default:main',
+      channelId: 'default',
+      role: 'assistant',
+      text: 'processing',
+      clientToken: 'msg-assistant-1',
+    });
+
+    expect(result.messageId).toBe('msg-assistant-1');
+    expect(upsertMessagesMock).toHaveBeenCalledWith(
+      'u-1',
+      expect.arrayContaining([
+        expect.objectContaining({
+          messageId: 'msg-assistant-1',
+          taskState: 'dispatched',
+        }),
+      ]),
+    );
+  });
+
+  it('marks assistant patches as completed', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          message_id: 'msg-assistant-1',
+          user_id: 'u-1',
+          channel_id: 'default',
+          session_id: 'session:default:main',
+          thread_id: null,
+          role: 'assistant',
+          content: 'processing',
+          metadata: JSON.stringify({ source: 'platform.messages.create' }),
+          created_at: '2026-04-17T07:00:00.000Z',
+          updated_at: '2026-04-17T07:00:01.000Z',
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const result = await patchPlatformMessage({
+      userId: 'u-1',
+      messageId: 'msg-assistant-1',
+      text: 'done',
+    });
+
+    expect(result).toEqual({ messageId: 'msg-assistant-1', updated: true });
+    expect(upsertMessagesMock).toHaveBeenCalledWith(
+      'u-1',
+      expect.arrayContaining([
+        expect.objectContaining({
+          messageId: 'msg-assistant-1',
+          taskState: 'completed',
+          content: 'done',
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/node_backend/src/services/platformIntegrationService.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.ts
@@ -11,6 +11,7 @@ type ChatMessageEventRow = {
   role: string;
   content: string;
   created_at: string;
+  metadata: unknown;
 };
 
 type ExistingMessageRow = {
@@ -39,9 +40,10 @@ export interface PlatformEvent {
       userId: string;
       displayName: string;
     };
-    text: string;
-    attachments: unknown[];
-  };
+       text: string;
+       attachments: unknown[];
+       metadata?: Record<string, unknown>;
+     };
 }
 
 function cursorToSeq(cursor?: string): number {
@@ -85,14 +87,27 @@ export async function listPlatformEvents(params: {
   const afterSeq = cursorToSeq(params.cursor);
   const workspaceId = params.workspaceId ?? process.env.BRICKS_PLATFORM_WORKSPACE_ID ?? 'ws_local';
 
-  const baseSelect = `SELECT write_seq, message_id, user_id, channel_id, session_id, thread_id, role, content, created_at
-       FROM chat_messages`;
+  const baseSelect = `SELECT
+         msg.write_seq,
+         msg.message_id,
+         msg.user_id,
+         msg.channel_id,
+         msg.session_id,
+         msg.thread_id,
+         msg.role,
+         msg.content,
+         msg.created_at,
+         msg.metadata
+       FROM chat_messages msg`;
   const queryParams: unknown[] = [afterSeq, limit];
-  const userFilter = params.userId ? ` AND user_id = $${queryParams.push(params.userId)}` : '';
+  const userFilter = params.userId ? ` AND msg.user_id = $${queryParams.push(params.userId)}` : '';
   const result = await pool.query<ChatMessageEventRow>(
     `${baseSelect}
-      WHERE write_seq > $1${userFilter}
-      ORDER BY write_seq ASC
+      WHERE msg.write_seq > $1${userFilter}
+        AND msg.role = 'user'
+        AND msg.task_state = 'dispatched'
+        AND CAST(msg.metadata AS TEXT) LIKE '%pendingAssistantMessageId%'
+      ORDER BY msg.write_seq ASC
       LIMIT $2`,
     queryParams,
   );
@@ -112,10 +127,14 @@ export async function listPlatformEvents(params: {
       },
       text: row.content,
       attachments: [],
+      metadata: parseMetadata(row.metadata) ?? undefined,
     },
   }));
 
-  const nextSeq = result.rows.length > 0 ? result.rows[result.rows.length - 1].write_seq : afterSeq;
+  const nextSeq =
+    result.rows.length > 0
+      ? result.rows[result.rows.length - 1].write_seq
+      : afterSeq;
   return {
     nextCursor: seqToCursor(nextSeq),
     events,
@@ -169,7 +188,7 @@ export async function createPlatformMessage(input: {
       threadId: input.threadId ?? null,
       role: input.role,
       content: input.text,
-      taskState: null,
+      taskState: input.role === 'assistant' ? 'dispatched' : null,
       checkpointCursor: null,
       metadata: input.metadata ?? { source: 'platform.messages.create' },
       createdAt: null,
@@ -232,7 +251,7 @@ export async function patchPlatformMessage(input: {
       threadId: row.thread_id,
       role: row.role,
       content: input.text ?? row.content,
-      taskState: null,
+      taskState: row.role === 'assistant' ? 'completed' : null,
       checkpointCursor: null,
       metadata: mergedMetadata,
       createdAt: row.created_at,

--- a/apps/node_backend/src/services/platformIntegrationService.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.ts
@@ -1,0 +1,303 @@
+import pool from '../db/index.js';
+import { upsertMessages } from './chatAsyncTransportService.js';
+
+type ChatMessageEventRow = {
+  write_seq: number;
+  message_id: string;
+  user_id: string;
+  channel_id: string;
+  session_id: string;
+  thread_id: string | null;
+  role: string;
+  content: string;
+  created_at: string;
+};
+
+type ExistingMessageRow = {
+  message_id: string;
+  user_id: string;
+  channel_id: string;
+  session_id: string;
+  thread_id: string | null;
+  role: string;
+  content: string;
+  metadata: unknown;
+  created_at: string;
+  updated_at: string;
+};
+
+export interface PlatformEvent {
+  eventId: string;
+  eventType: 'message.created';
+  workspaceId: string;
+  conversationId: string;
+  rawId: string;
+  occurredAt: string;
+  payload: {
+    messageId: string;
+    sender: {
+      userId: string;
+      displayName: string;
+    };
+    text: string;
+    attachments: unknown[];
+  };
+}
+
+function cursorToSeq(cursor?: string): number {
+  if (!cursor) return 0;
+  const m = /^cur_(\d+)$/.exec(cursor.trim());
+  if (!m) {
+    throw new Error('INVALID_CURSOR');
+  }
+  return Number.parseInt(m[1], 10);
+}
+
+function seqToCursor(seq: number): string {
+  return `cur_${Math.max(0, seq)}`;
+}
+
+function toRawId(channelId: string, threadId: string | null): string {
+  if (threadId && threadId.trim().length > 0) {
+    return `channel:${channelId}/thread:${threadId}`;
+  }
+  return `channel:${channelId}`;
+}
+
+function displayNameFromRole(role: string): string {
+  switch (role) {
+    case 'assistant':
+      return 'assistant';
+    case 'system':
+      return 'system';
+    default:
+      return 'user';
+  }
+}
+
+export async function listPlatformEvents(params: {
+  cursor?: string;
+  limit?: number;
+  workspaceId?: string;
+}): Promise<{ nextCursor: string; events: PlatformEvent[] }> {
+  const limit = Math.min(200, Math.max(1, params.limit ?? 50));
+  const afterSeq = cursorToSeq(params.cursor);
+  const workspaceId = params.workspaceId ?? process.env.BRICKS_PLATFORM_WORKSPACE_ID ?? 'ws_local';
+
+  const result = await pool.query<ChatMessageEventRow>(
+    `SELECT write_seq, message_id, user_id, channel_id, session_id, thread_id, role, content, created_at
+       FROM chat_messages
+      WHERE write_seq > $1
+      ORDER BY write_seq ASC
+      LIMIT $2`,
+    [afterSeq, limit],
+  );
+
+  const events = result.rows.map((row) => ({
+    eventId: `evt_msg_${row.message_id}_${row.write_seq}`,
+    eventType: 'message.created' as const,
+    workspaceId,
+    conversationId: row.session_id,
+    rawId: toRawId(row.channel_id, row.thread_id),
+    occurredAt: row.created_at,
+    payload: {
+      messageId: row.message_id,
+      sender: {
+        userId: row.user_id,
+        displayName: displayNameFromRole(row.role),
+      },
+      text: row.content,
+      attachments: [],
+    },
+  }));
+
+  const nextSeq = result.rows.length > 0 ? result.rows[result.rows.length - 1].write_seq : afterSeq;
+  return {
+    nextCursor: seqToCursor(nextSeq),
+    events,
+  };
+}
+
+export async function ackPlatformEvents(_params: {
+  pluginId: string;
+  cursor: string;
+  ackedEventIds: string[];
+}): Promise<{ ok: true }> {
+  // ACK is idempotent by contract. Current MVP does not persist ack state yet.
+  return { ok: true };
+}
+
+function generateMessageId(clientToken?: string): string {
+  if (clientToken && clientToken.trim().length > 0) {
+    return clientToken.trim().slice(0, 255);
+  }
+  return `msg_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export async function createPlatformMessage(input: {
+  userId: string;
+  conversationId: string;
+  channelId: string;
+  threadId?: string | null;
+  role: string;
+  text: string;
+  clientToken?: string;
+  metadata?: Record<string, unknown>;
+}): Promise<{ messageId: string; conversationId: string }> {
+  const messageId = generateMessageId(input.clientToken);
+
+  await upsertMessages(input.userId, [
+    {
+      messageId,
+      taskId: null,
+      channelId: input.channelId,
+      sessionId: input.conversationId,
+      threadId: input.threadId ?? null,
+      role: input.role,
+      content: input.text,
+      taskState: null,
+      checkpointCursor: null,
+      metadata: input.metadata ?? { source: 'platform.messages.create' },
+      createdAt: null,
+    },
+  ]);
+
+  return {
+    messageId,
+    conversationId: input.conversationId,
+  };
+}
+
+function parseMetadata(raw: unknown): Record<string, unknown> | null {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return null;
+    }
+  }
+  if (typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  return null;
+}
+
+export async function patchPlatformMessage(input: {
+  userId: string;
+  messageId: string;
+  text?: string;
+  metadata?: Record<string, unknown>;
+}): Promise<{ messageId: string; updated: true } | null> {
+  const existing = await pool.query<ExistingMessageRow>(
+    `SELECT message_id, user_id, channel_id, session_id, thread_id, role, content, metadata, created_at, updated_at
+       FROM chat_messages
+      WHERE user_id = $1 AND message_id = $2
+      LIMIT 1`,
+    [input.userId, input.messageId],
+  );
+  const row = existing.rows[0];
+  if (!row) return null;
+
+  const mergedMetadata = {
+    ...(parseMetadata(row.metadata) ?? {}),
+    ...(input.metadata ?? {}),
+    source: 'platform.messages.patch',
+  };
+
+  await upsertMessages(input.userId, [
+    {
+      messageId: row.message_id,
+      taskId: null,
+      channelId: row.channel_id,
+      sessionId: row.session_id,
+      threadId: row.thread_id,
+      role: row.role,
+      content: input.text ?? row.content,
+      taskState: null,
+      checkpointCursor: null,
+      metadata: mergedMetadata,
+      createdAt: row.created_at,
+    },
+  ]);
+
+  return {
+    messageId: row.message_id,
+    updated: true,
+  };
+}
+
+export async function resolveConversation(params: {
+  conversationId?: string;
+  rawId?: string;
+}): Promise<
+  | {
+      conversationId: string;
+      rawId: string;
+      channelId: string;
+      threadId: string | null;
+    }
+  | null
+> {
+  if (params.conversationId && params.conversationId.trim().length > 0) {
+    const byConversation = await pool.query<{
+      session_id: string;
+      channel_id: string;
+      thread_id: string | null;
+    }>(
+      `SELECT session_id, channel_id, thread_id
+         FROM chat_messages
+        WHERE session_id = $1
+        ORDER BY write_seq DESC
+        LIMIT 1`,
+      [params.conversationId.trim()],
+    );
+
+    const row = byConversation.rows[0];
+    if (!row) return null;
+    return {
+      conversationId: row.session_id,
+      channelId: row.channel_id,
+      threadId: row.thread_id,
+      rawId: toRawId(row.channel_id, row.thread_id),
+    };
+  }
+
+  if (!params.rawId || params.rawId.trim().length === 0) {
+    return null;
+  }
+
+  const raw = params.rawId.trim();
+  const parsed = /^channel:([^/]+)(?:\/thread:(.+))?$/.exec(raw);
+  if (!parsed) return null;
+
+  const channelId = parsed[1];
+  const threadId = parsed[2] ?? null;
+
+  const byRawId = await pool.query<{
+    session_id: string;
+    channel_id: string;
+    thread_id: string | null;
+  }>(
+    `SELECT session_id, channel_id, thread_id
+       FROM chat_messages
+      WHERE channel_id = $1
+        AND (($2 IS NULL AND thread_id IS NULL) OR thread_id = $2)
+      ORDER BY write_seq DESC
+      LIMIT 1`,
+    [channelId, threadId],
+  );
+
+  const row = byRawId.rows[0];
+  if (!row) return null;
+
+  return {
+    conversationId: row.session_id,
+    channelId: row.channel_id,
+    threadId: row.thread_id,
+    rawId: toRawId(row.channel_id, row.thread_id),
+  };
+}

--- a/apps/node_backend/src/services/platformIntegrationService.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.ts
@@ -79,18 +79,22 @@ export async function listPlatformEvents(params: {
   cursor?: string;
   limit?: number;
   workspaceId?: string;
+  userId?: string;
 }): Promise<{ nextCursor: string; events: PlatformEvent[] }> {
   const limit = Math.min(200, Math.max(1, params.limit ?? 50));
   const afterSeq = cursorToSeq(params.cursor);
   const workspaceId = params.workspaceId ?? process.env.BRICKS_PLATFORM_WORKSPACE_ID ?? 'ws_local';
 
+  const baseSelect = `SELECT write_seq, message_id, user_id, channel_id, session_id, thread_id, role, content, created_at
+       FROM chat_messages`;
+  const queryParams: unknown[] = [afterSeq, limit];
+  const userFilter = params.userId ? ` AND user_id = $${queryParams.push(params.userId)}` : '';
   const result = await pool.query<ChatMessageEventRow>(
-    `SELECT write_seq, message_id, user_id, channel_id, session_id, thread_id, role, content, created_at
-       FROM chat_messages
-      WHERE write_seq > $1
+    `${baseSelect}
+      WHERE write_seq > $1${userFilter}
       ORDER BY write_seq ASC
       LIMIT $2`,
-    [afterSeq, limit],
+    queryParams,
   );
 
   const events = result.rows.map((row) => ({
@@ -118,12 +122,22 @@ export async function listPlatformEvents(params: {
   };
 }
 
-export async function ackPlatformEvents(_params: {
+export async function ackPlatformEvents(params: {
   pluginId: string;
   cursor: string;
   ackedEventIds: string[];
 }): Promise<{ ok: true }> {
-  // ACK is idempotent by contract. Current MVP does not persist ack state yet.
+  // Validate inputs even though ACK persistence is intentionally deferred in the MVP.
+  // This keeps the endpoint idempotent while surfacing client-side protocol bugs.
+  cursorToSeq(params.cursor);
+  if (!Array.isArray(params.ackedEventIds)) {
+    throw new Error('INVALID_ACKED_EVENT_IDS');
+  }
+  for (const eventId of params.ackedEventIds) {
+    if (typeof eventId !== 'string' || eventId.trim().length === 0) {
+      throw new Error('INVALID_ACKED_EVENT_IDS');
+    }
+  }
   return { ok: true };
 }
 
@@ -143,7 +157,7 @@ export async function createPlatformMessage(input: {
   text: string;
   clientToken?: string;
   metadata?: Record<string, unknown>;
-}): Promise<{ messageId: string; conversationId: string }> {
+}): Promise<{ messageId: string; conversationId: string; revision: number }> {
   const messageId = generateMessageId(input.clientToken);
 
   await upsertMessages(input.userId, [
@@ -165,6 +179,7 @@ export async function createPlatformMessage(input: {
   return {
     messageId,
     conversationId: input.conversationId,
+    revision: 1,
   };
 }
 
@@ -230,9 +245,16 @@ export async function patchPlatformMessage(input: {
   };
 }
 
+/** Returns a SQL filter clause and appends the userId to queryParams when provided. */
+function appendUserIdFilter(userId: string | undefined, queryParams: unknown[]): string {
+  if (!userId) return '';
+  return ` AND user_id = $${queryParams.push(userId)}`;
+}
+
 export async function resolveConversation(params: {
   conversationId?: string;
   rawId?: string;
+  userId?: string;
 }): Promise<
   | {
       conversationId: string;
@@ -243,6 +265,9 @@ export async function resolveConversation(params: {
   | null
 > {
   if (params.conversationId && params.conversationId.trim().length > 0) {
+    const queryParams: unknown[] = [params.conversationId.trim()];
+    const userFilter = appendUserIdFilter(params.userId, queryParams);
+
     const byConversation = await pool.query<{
       session_id: string;
       channel_id: string;
@@ -250,10 +275,10 @@ export async function resolveConversation(params: {
     }>(
       `SELECT session_id, channel_id, thread_id
          FROM chat_messages
-        WHERE session_id = $1
+        WHERE session_id = $1${userFilter}
         ORDER BY write_seq DESC
         LIMIT 1`,
-      [params.conversationId.trim()],
+      queryParams,
     );
 
     const row = byConversation.rows[0];
@@ -277,6 +302,9 @@ export async function resolveConversation(params: {
   const channelId = parsed[1];
   const threadId = parsed[2] ?? null;
 
+  const rawQueryParams: unknown[] = [channelId, threadId];
+  const rawUserFilter = appendUserIdFilter(params.userId, rawQueryParams);
+
   const byRawId = await pool.query<{
     session_id: string;
     channel_id: string;
@@ -285,10 +313,10 @@ export async function resolveConversation(params: {
     `SELECT session_id, channel_id, thread_id
        FROM chat_messages
       WHERE channel_id = $1
-        AND (($2 IS NULL AND thread_id IS NULL) OR thread_id = $2)
+        AND (($2 IS NULL AND thread_id IS NULL) OR thread_id = $2)${rawUserFilter}
       ORDER BY write_seq DESC
       LIMIT 1`,
-    [channelId, threadId],
+    rawQueryParams,
   );
 
   const row = byRawId.rows[0];

--- a/apps/node_openclaw_plugin/.gitignore
+++ b/apps/node_openclaw_plugin/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/apps/node_openclaw_plugin/README.md
+++ b/apps/node_openclaw_plugin/README.md
@@ -31,5 +31,5 @@ npm run dev
 
 - ACK body 仅包含 `cursor` 与 `ackedEventIds`，不发送 `pluginId` 字段。
 - 启动阶段会校验 JWT claims：`typ=platform_plugin`、`pluginId` 与 `BRICKS_PLUGIN_ID` 一致、且必须包含 `userId`。
-- 收到 `message.created` 时会写入一条 streaming 消息并 patch 为 completed。
+- 收到 `message.created` 时会先写入一条 streaming 消息，随后通过 PATCH 更新消息的 `text`/`metadata`；当前不会将 `status` patch 为 `completed`。
 - 收到 `conversation.binding_changed` 时当前仅记录日志（MVP noop）。

--- a/apps/node_openclaw_plugin/README.md
+++ b/apps/node_openclaw_plugin/README.md
@@ -21,7 +21,7 @@ openclaw plugins install -l ./apps/node_openclaw_plugin
 openclaw gateway restart
 ```
 
-## 2) onboarding / configure 自动写入 channel 配置
+## 2) 作为真实 channel plugin 写入 `channels.dev-askman-bricks`
 
 安装后运行：
 
@@ -51,9 +51,19 @@ openclaw configure
 }
 ```
 
+如果只想改 Bricks 这一项，不想重新跑整套 onboarding，也可以直接写 channel 配置：
+
+```bash
+openclaw config set channels.dev-askman-bricks.BRICKS_BASE_URL https://your-bricks-api.example.com
+openclaw config set channels.dev-askman-bricks.BRICKS_PLUGIN_ID dev-askman-bricks
+openclaw config set channels.dev-askman-bricks.BRICKS_PLATFORM_TOKEN 'your-jwt-token'
+openclaw config validate
+openclaw gateway restart
+```
+
 ### 注意
 
-`openclaw plugins install` 会使用 `npm install --ignore-scripts`，因此不要依赖 npm `postinstall` 写配置；应使用 onboarding hook 进行交互配置。
+`openclaw plugins install` 会使用 `npm install --ignore-scripts`，因此不要依赖 npm `postinstall` 写配置；应使用 channel setup/onboarding 或 `openclaw config set channels.dev-askman-bricks.*` 完成配置。
 
 ## 3) 本地 pull-only 运行时（独立示例）
 

--- a/apps/node_openclaw_plugin/README.md
+++ b/apps/node_openclaw_plugin/README.md
@@ -1,13 +1,70 @@
-# node_openclaw_plugin
+# @bricks/node-openclaw-plugin
 
-`node_openclaw_plugin` 是一个基于 Node.js 的 OpenClaw pull-only 插件运行时实现，用于对接 Bricks 平台 API：
+`@bricks/node-openclaw-plugin` 是一个 Node.js 的 Bricks/OpenClaw 集成插件，包含两部分能力：
+
+1. **OpenClaw 插件安装 + onboarding 配置**（channel id: `dev-askman-bricks`）
+2. **pull-only 运行时示例**（轮询 `events`、ACK、消息回写）
+
+## 1) 作为 OpenClaw 插件安装（子目录安装）
+
+> 本仓库场景下，插件在子目录 `apps/node_openclaw_plugin`。
+
+```bash
+openclaw plugins install ./apps/node_openclaw_plugin
+openclaw gateway restart
+```
+
+也可使用链接安装（便于开发联调）：
+
+```bash
+openclaw plugins install -l ./apps/node_openclaw_plugin
+openclaw gateway restart
+```
+
+## 2) onboarding / configure 自动写入 channel 配置
+
+安装后运行：
+
+```bash
+openclaw onboard
+# 或
+openclaw configure
+```
+
+在向导中选择 `dev-askman-bricks`（Bricks）后，插件会提示输入：
+
+- `BRICKS_BASE_URL`
+- `BRICKS_PLUGIN_ID`
+- `BRICKS_PLATFORM_TOKEN`
+
+完成后会自动写入 `~/.openclaw/openclaw.json` 的：
+
+```json
+{
+  "channels": {
+    "dev-askman-bricks": {
+      "BRICKS_BASE_URL": "https://your-bricks-api.example.com",
+      "BRICKS_PLUGIN_ID": "dev-askman-bricks",
+      "BRICKS_PLATFORM_TOKEN": "<JWT token>"
+    }
+  }
+}
+```
+
+### 注意
+
+`openclaw plugins install` 会使用 `npm install --ignore-scripts`，因此不要依赖 npm `postinstall` 写配置；应使用 onboarding hook 进行交互配置。
+
+## 3) 本地 pull-only 运行时（独立示例）
+
+该目录仍提供独立运行时示例，用于对接 Bricks 平台 API：
 
 1. 轮询 `GET /api/v1/platform/events`
 2. 本地按 `eventId` 去重
 3. 调用 `POST /api/v1/platform/events/ack` 进行 ACK
 4. 通过 `POST/PATCH /api/v1/platform/messages` 回写响应消息
 
-## 环境变量
+### 环境变量
 
 | 变量 | 必填 | 说明 |
 |---|---|---|
@@ -19,7 +76,7 @@
 | `OPENCLAW_PLUGIN_STATE_FILE` | 否 | 本地状态文件路径，默认 `~/.bricks/node_openclaw_plugin_state.json` |
 | `OPENCLAW_PLUGIN_ASSISTANT_NAME` | 否 | 回写消息中的助手名，默认 `Node OpenClaw Plugin` |
 
-## 本地运行
+### 本地运行
 
 ```bash
 cd apps/node_openclaw_plugin
@@ -27,7 +84,7 @@ npm install
 npm run dev
 ```
 
-## 说明
+## 行为说明
 
 - ACK body 仅包含 `cursor` 与 `ackedEventIds`，不发送 `pluginId` 字段。
 - 启动阶段会校验 JWT claims：`typ=platform_plugin`、`pluginId` 与 `BRICKS_PLUGIN_ID` 一致、且必须包含 `userId`。

--- a/apps/node_openclaw_plugin/README.md
+++ b/apps/node_openclaw_plugin/README.md
@@ -1,0 +1,35 @@
+# node_openclaw_plugin
+
+`node_openclaw_plugin` 是一个基于 Node.js 的 OpenClaw pull-only 插件运行时实现，用于对接 Bricks 平台 API：
+
+1. 轮询 `GET /api/v1/platform/events`
+2. 本地按 `eventId` 去重
+3. 调用 `POST /api/v1/platform/events/ack` 进行 ACK
+4. 通过 `POST/PATCH /api/v1/platform/messages` 回写响应消息
+
+## 环境变量
+
+| 变量 | 必填 | 说明 |
+|---|---|---|
+| `BRICKS_BASE_URL` | 是 | Bricks API 基地址（例如 `http://localhost:8787`） |
+| `BRICKS_PLATFORM_TOKEN` | 是 | 从 `/api/config/platform-token` 获取的 **JWT platform token**（仅支持 JWT） |
+| `BRICKS_PLUGIN_ID` | 是 | 与请求头 `X-Bricks-Plugin-Id` 一致的插件标识 |
+| `OPENCLAW_PLUGIN_POLL_INTERVAL_MS` | 否 | 轮询间隔，默认 `2000` |
+| `OPENCLAW_PLUGIN_DEFAULT_CURSOR` | 否 | 初始游标，默认 `cur_0` |
+| `OPENCLAW_PLUGIN_STATE_FILE` | 否 | 本地状态文件路径，默认 `~/.bricks/node_openclaw_plugin_state.json` |
+| `OPENCLAW_PLUGIN_ASSISTANT_NAME` | 否 | 回写消息中的助手名，默认 `Node OpenClaw Plugin` |
+
+## 本地运行
+
+```bash
+cd apps/node_openclaw_plugin
+npm install
+npm run dev
+```
+
+## 说明
+
+- ACK body 仅包含 `cursor` 与 `ackedEventIds`，不发送 `pluginId` 字段。
+- 启动阶段会校验 JWT claims：`typ=platform_plugin`、`pluginId` 与 `BRICKS_PLUGIN_ID` 一致、且必须包含 `userId`。
+- 收到 `message.created` 时会写入一条 streaming 消息并 patch 为 completed。
+- 收到 `conversation.binding_changed` 时当前仅记录日志（MVP noop）。

--- a/apps/node_openclaw_plugin/openclaw.plugin.json
+++ b/apps/node_openclaw_plugin/openclaw.plugin.json
@@ -1,0 +1,62 @@
+{
+  "id": "dev-askman-bricks",
+  "name": "Bricks OpenClaw Plugin",
+  "description": "Bricks pull-only OpenClaw channel plugin with interactive onboarding.",
+  "version": "0.1.0",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  },
+  "channelEnvVars": {
+    "dev-askman-bricks": [
+      "BRICKS_BASE_URL",
+      "BRICKS_PLUGIN_ID",
+      "BRICKS_PLATFORM_TOKEN"
+    ]
+  },
+  "channelConfigs": {
+    "dev-askman-bricks": {
+      "label": "Bricks",
+      "description": "Bricks platform API channel settings.",
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "BRICKS_BASE_URL",
+          "BRICKS_PLUGIN_ID",
+          "BRICKS_PLATFORM_TOKEN"
+        ],
+        "properties": {
+          "BRICKS_BASE_URL": {
+            "type": "string",
+            "minLength": 1
+          },
+          "BRICKS_PLUGIN_ID": {
+            "type": "string",
+            "minLength": 1
+          },
+          "BRICKS_PLATFORM_TOKEN": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "uiHints": {
+        "BRICKS_BASE_URL": {
+          "label": "Bricks Base URL",
+          "placeholder": "https://api.example.com"
+        },
+        "BRICKS_PLUGIN_ID": {
+          "label": "Bricks Plugin ID",
+          "placeholder": "dev-askman-bricks"
+        },
+        "BRICKS_PLATFORM_TOKEN": {
+          "label": "Bricks Platform Token",
+          "sensitive": true,
+          "placeholder": "paste your JWT platform token"
+        }
+      }
+    }
+  }
+}

--- a/apps/node_openclaw_plugin/openclaw.plugin.json
+++ b/apps/node_openclaw_plugin/openclaw.plugin.json
@@ -1,5 +1,9 @@
 {
   "id": "dev-askman-bricks",
+  "kind": "channel",
+  "channels": [
+    "dev-askman-bricks"
+  ],
   "name": "Bricks OpenClaw Plugin",
   "description": "Bricks pull-only OpenClaw channel plugin with interactive onboarding.",
   "version": "0.1.0",
@@ -22,11 +26,6 @@
       "schema": {
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "BRICKS_BASE_URL",
-          "BRICKS_PLUGIN_ID",
-          "BRICKS_PLATFORM_TOKEN"
-        ],
         "properties": {
           "BRICKS_BASE_URL": {
             "type": "string",

--- a/apps/node_openclaw_plugin/package-lock.json
+++ b/apps/node_openclaw_plugin/package-lock.json
@@ -1,0 +1,1825 @@
+{
+  "name": "@bricks/node-openclaw-plugin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@bricks/node-openclaw-plugin",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.10.6",
+        "tsx": "^4.20.6",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/apps/node_openclaw_plugin/package.json
+++ b/apps/node_openclaw_plugin/package.json
@@ -24,7 +24,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./src/openclawExtension.ts"
+      "./dist/openclawExtension.js"
     ],
     "channel": {
       "id": "dev-askman-bricks",
@@ -40,7 +40,6 @@
     },
     "install": {
       "localPath": "apps/node_openclaw_plugin",
-      "npmSpec": "@bricks/node-openclaw-plugin",
       "defaultChoice": "local"
     }
   }

--- a/apps/node_openclaw_plugin/package.json
+++ b/apps/node_openclaw_plugin/package.json
@@ -26,6 +26,7 @@
     "extensions": [
       "./dist/openclawExtension.js"
     ],
+    "setupEntry": "./dist/openclawSetupEntry.js",
     "channel": {
       "id": "dev-askman-bricks",
       "label": "Bricks",

--- a/apps/node_openclaw_plugin/package.json
+++ b/apps/node_openclaw_plugin/package.json
@@ -21,5 +21,27 @@
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "vitest": "^4.1.2"
+  },
+  "openclaw": {
+    "extensions": [
+      "./src/openclawExtension.ts"
+    ],
+    "channel": {
+      "id": "dev-askman-bricks",
+      "label": "Bricks",
+      "selectionLabel": "Bricks Platform",
+      "docsPath": "/channels/dev-askman-bricks",
+      "docsLabel": "dev-askman-bricks",
+      "blurb": "Bricks platform pull-only channel with onboarding wizard.",
+      "order": 70,
+      "aliases": [
+        "bricks"
+      ]
+    },
+    "install": {
+      "localPath": "apps/node_openclaw_plugin",
+      "npmSpec": "@bricks/node-openclaw-plugin",
+      "defaultChoice": "local"
+    }
   }
 }

--- a/apps/node_openclaw_plugin/package.json
+++ b/apps/node_openclaw_plugin/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bricks/node-openclaw-plugin",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Reference pull-only OpenClaw plugin runtime for Bricks platform APIs",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "type-check": "tsc --noEmit -p tsconfig.json"
+  },
+  "engines": {
+    "node": ">=20.19.0"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.10.6",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.2"
+  }
+}

--- a/apps/node_openclaw_plugin/src/bricksChannelPlugin.ts
+++ b/apps/node_openclaw_plugin/src/bricksChannelPlugin.ts
@@ -1,0 +1,441 @@
+export const CHANNEL_ID = 'dev-askman-bricks';
+export const CHANNEL_NAME = 'Bricks OpenClaw Plugin';
+export const CHANNEL_DESCRIPTION = 'Bricks pull-only OpenClaw channel plugin with interactive onboarding.';
+export const DEFAULT_ACCOUNT_ID = 'default';
+
+type BricksConfigKey = 'BRICKS_BASE_URL' | 'BRICKS_PLUGIN_ID' | 'BRICKS_PLATFORM_TOKEN';
+type JsonObject = Record<string, unknown>;
+type WizardCredentialValues = Partial<Record<string, string>>;
+
+export interface OpenClawConfig extends JsonObject {
+  channels?: Record<string, unknown>;
+}
+
+interface ChannelSetupInput extends JsonObject {
+  BRICKS_BASE_URL?: unknown;
+  BRICKS_PLUGIN_ID?: unknown;
+  BRICKS_PLATFORM_TOKEN?: unknown;
+}
+
+interface BricksStoredConfig {
+  BRICKS_BASE_URL?: string;
+  BRICKS_PLUGIN_ID?: string;
+  BRICKS_PLATFORM_TOKEN?: string;
+}
+
+interface BricksResolvedAccount {
+  accountId: string;
+  enabled: boolean;
+  configured: boolean;
+  config: BricksStoredConfig;
+}
+
+interface ChannelConfigSchema {
+  schema: JsonObject;
+  uiHints?: Record<string, JsonObject>;
+}
+
+interface ChannelMeta {
+  id: string;
+  label: string;
+  selectionLabel?: string;
+  docsPath?: string;
+  docsLabel?: string;
+  blurb?: string;
+  order?: number;
+  aliases?: string[];
+}
+
+interface ChannelCapabilities {
+  chatTypes?: string[];
+  media?: boolean;
+}
+
+interface ChannelSetupAdapter {
+  resolveAccountId?: (params: { cfg: OpenClawConfig; accountId?: string; input?: ChannelSetupInput }) => string;
+  applyAccountConfig: (params: { cfg: OpenClawConfig; accountId: string; input: ChannelSetupInput }) => OpenClawConfig;
+  validateInput?: (params: { cfg: OpenClawConfig; accountId: string; input: ChannelSetupInput }) => string | null;
+}
+
+interface ChannelConfigAdapter {
+  listAccountIds: (cfg: OpenClawConfig) => string[];
+  resolveAccount: (cfg: OpenClawConfig, accountId?: string | null) => BricksResolvedAccount;
+  defaultAccountId?: (cfg: OpenClawConfig) => string;
+  inspectAccount?: (cfg: OpenClawConfig, accountId?: string | null) => JsonObject;
+  isConfigured?: (account: BricksResolvedAccount, cfg: OpenClawConfig) => boolean;
+  describeAccount?: (account: BricksResolvedAccount, cfg: OpenClawConfig) => JsonObject;
+}
+
+interface ChannelSetupWizardStatus {
+  configuredLabel: string;
+  unconfiguredLabel: string;
+  configuredHint?: string;
+  unconfiguredHint?: string;
+  configuredScore?: number;
+  unconfiguredScore?: number;
+  resolveConfigured: (params: { cfg: OpenClawConfig; accountId?: string }) => boolean | Promise<boolean>;
+  resolveSelectionHint?: (params: {
+    cfg: OpenClawConfig;
+    accountId?: string;
+    configured: boolean;
+  }) => string | undefined | Promise<string | undefined>;
+}
+
+interface ChannelSetupWizardCredentialState {
+  accountConfigured: boolean;
+  hasConfiguredValue: boolean;
+  resolvedValue?: string;
+}
+
+interface ChannelSetupWizardCredential {
+  inputKey: keyof ChannelSetupInput;
+  providerHint: string;
+  credentialLabel: string;
+  envPrompt: string;
+  keepPrompt: string;
+  inputPrompt: string;
+  inspect: (params: { cfg: OpenClawConfig; accountId: string }) => ChannelSetupWizardCredentialState;
+  applySet?: (params: {
+    cfg: OpenClawConfig;
+    accountId: string;
+    credentialValues: WizardCredentialValues;
+    value: unknown;
+    resolvedValue: string;
+  }) => OpenClawConfig | Promise<OpenClawConfig>;
+}
+
+interface ChannelSetupWizardTextInput {
+  inputKey: keyof ChannelSetupInput;
+  message: string;
+  placeholder?: string;
+  required?: boolean;
+  currentValue?: (params: {
+    cfg: OpenClawConfig;
+    accountId: string;
+    credentialValues: WizardCredentialValues;
+  }) => string | undefined | Promise<string | undefined>;
+  validate?: (params: {
+    value: string;
+    cfg: OpenClawConfig;
+    accountId: string;
+    credentialValues: WizardCredentialValues;
+  }) => string | undefined;
+  normalizeValue?: (params: {
+    value: string;
+    cfg: OpenClawConfig;
+    accountId: string;
+    credentialValues: WizardCredentialValues;
+  }) => string | Promise<string>;
+  applySet?: (params: {
+    cfg: OpenClawConfig;
+    accountId: string;
+    credentialValues: WizardCredentialValues;
+    value: string;
+  }) => OpenClawConfig | Promise<OpenClawConfig>;
+}
+
+interface ChannelSetupWizard {
+  channel: string;
+  status: ChannelSetupWizardStatus;
+  stepOrder?: 'credentials-first' | 'text-first';
+  credentials: ChannelSetupWizardCredential[];
+  textInputs?: ChannelSetupWizardTextInput[];
+}
+
+export interface BricksChannelPlugin {
+  id: string;
+  meta: ChannelMeta;
+  capabilities: ChannelCapabilities;
+  reload: { configPrefixes: string[] };
+  configSchema: ChannelConfigSchema;
+  config: ChannelConfigAdapter;
+  setup: ChannelSetupAdapter;
+  setupWizard: ChannelSetupWizard;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readStoredChannelConfig(cfg: OpenClawConfig): BricksStoredConfig {
+  const channels = isRecord(cfg.channels) ? cfg.channels : {};
+  const rawChannelConfig = channels[CHANNEL_ID];
+  const channelConfig = isRecord(rawChannelConfig) ? rawChannelConfig : {};
+
+  return {
+    BRICKS_BASE_URL: readOptionalString(channelConfig.BRICKS_BASE_URL),
+    BRICKS_PLUGIN_ID: readOptionalString(channelConfig.BRICKS_PLUGIN_ID),
+    BRICKS_PLATFORM_TOKEN: readOptionalString(channelConfig.BRICKS_PLATFORM_TOKEN),
+  };
+}
+
+function hasStoredChannelSection(cfg: OpenClawConfig): boolean {
+  const channels = isRecord(cfg.channels) ? cfg.channels : {};
+  return isRecord(channels[CHANNEL_ID]);
+}
+
+function isBricksChannelConfigured(config: BricksStoredConfig): boolean {
+  return Boolean(config.BRICKS_BASE_URL && config.BRICKS_PLUGIN_ID && config.BRICKS_PLATFORM_TOKEN);
+}
+
+function readInputValue(input: ChannelSetupInput, key: BricksConfigKey): string | undefined {
+  return readOptionalString(input[key]);
+}
+
+function validateRequiredValue(key: BricksConfigKey, value: string | undefined): string | null {
+  return value ? null : `${key} is required`;
+}
+
+function mergeChannelConfig(cfg: OpenClawConfig, patch: Partial<Record<BricksConfigKey, string>>): OpenClawConfig {
+  const channels = isRecord(cfg.channels) ? cfg.channels : {};
+  const existingChannelConfig = isRecord(channels[CHANNEL_ID]) ? channels[CHANNEL_ID] : {};
+  const nextChannelConfig: Record<string, unknown> = { ...existingChannelConfig };
+
+  for (const [key, value] of Object.entries(patch)) {
+    if (value !== undefined) {
+      nextChannelConfig[key] = value;
+    }
+  }
+
+  return {
+    ...cfg,
+    channels: {
+      ...channels,
+      [CHANNEL_ID]: nextChannelConfig,
+    },
+  };
+}
+
+function resolveConfiguredValue(
+  input: ChannelSetupInput,
+  existingConfig: BricksStoredConfig,
+  key: BricksConfigKey,
+): string {
+  const value = readInputValue(input, key) ?? existingConfig[key];
+  if (!value) {
+    throw new Error(`${key} is required`);
+  }
+
+  return value;
+}
+
+function applySingleField(
+  cfg: OpenClawConfig,
+  key: BricksConfigKey,
+  value: unknown,
+): OpenClawConfig {
+  const resolvedValue = readOptionalString(value);
+  if (!resolvedValue) {
+    throw new Error(`${key} is required`);
+  }
+
+  return mergeChannelConfig(cfg, { [key]: resolvedValue });
+}
+
+export const BRICKS_CHANNEL_CONFIG_SCHEMA: ChannelConfigSchema = {
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      BRICKS_BASE_URL: {
+        type: 'string',
+        minLength: 1,
+      },
+      BRICKS_PLUGIN_ID: {
+        type: 'string',
+        minLength: 1,
+      },
+      BRICKS_PLATFORM_TOKEN: {
+        type: 'string',
+        minLength: 1,
+      },
+    },
+  },
+  uiHints: {
+    BRICKS_BASE_URL: {
+      label: 'Bricks Base URL',
+      placeholder: 'https://api.example.com',
+    },
+    BRICKS_PLUGIN_ID: {
+      label: 'Bricks Plugin ID',
+      placeholder: CHANNEL_ID,
+    },
+    BRICKS_PLATFORM_TOKEN: {
+      label: 'Bricks Platform Token',
+      sensitive: true,
+      placeholder: 'paste your JWT platform token',
+    },
+  },
+};
+
+const bricksConfigAdapter: ChannelConfigAdapter = {
+  listAccountIds(cfg) {
+    return hasStoredChannelSection(cfg) ? [DEFAULT_ACCOUNT_ID] : [];
+  },
+  resolveAccount(cfg, accountId) {
+    const resolvedAccountId = readOptionalString(accountId) ?? DEFAULT_ACCOUNT_ID;
+    const config = readStoredChannelConfig(cfg);
+
+    return {
+      accountId: resolvedAccountId,
+      enabled: true,
+      configured: isBricksChannelConfigured(config),
+      config,
+    };
+  },
+  defaultAccountId() {
+    return DEFAULT_ACCOUNT_ID;
+  },
+  inspectAccount(cfg, accountId) {
+    const account = this.resolveAccount(cfg, accountId);
+    return {
+      enabled: account.enabled,
+      configured: account.configured,
+      tokenStatus: account.config.BRICKS_PLATFORM_TOKEN ? 'available' : 'missing',
+      pluginId: account.config.BRICKS_PLUGIN_ID ?? null,
+      baseUrl: account.config.BRICKS_BASE_URL ?? null,
+    };
+  },
+  isConfigured(account) {
+    return account.configured;
+  },
+  describeAccount(account) {
+    return {
+      accountId: account.accountId,
+      enabled: account.enabled,
+      configured: account.configured,
+      extra: {
+        baseUrl: account.config.BRICKS_BASE_URL ?? null,
+        pluginId: account.config.BRICKS_PLUGIN_ID ?? null,
+      },
+    };
+  },
+};
+
+const bricksSetupAdapter: ChannelSetupAdapter = {
+  resolveAccountId() {
+    return DEFAULT_ACCOUNT_ID;
+  },
+  validateInput({ cfg, input }) {
+    const existingConfig = readStoredChannelConfig(cfg);
+    const baseUrlError = validateRequiredValue(
+      'BRICKS_BASE_URL',
+      readInputValue(input, 'BRICKS_BASE_URL') ?? existingConfig.BRICKS_BASE_URL,
+    );
+    if (baseUrlError) {
+      return baseUrlError;
+    }
+
+    const pluginIdError = validateRequiredValue(
+      'BRICKS_PLUGIN_ID',
+      readInputValue(input, 'BRICKS_PLUGIN_ID') ?? existingConfig.BRICKS_PLUGIN_ID,
+    );
+    if (pluginIdError) {
+      return pluginIdError;
+    }
+
+    return validateRequiredValue(
+      'BRICKS_PLATFORM_TOKEN',
+      readInputValue(input, 'BRICKS_PLATFORM_TOKEN') ?? existingConfig.BRICKS_PLATFORM_TOKEN,
+    );
+  },
+  applyAccountConfig({ cfg, input }) {
+    const existingConfig = readStoredChannelConfig(cfg);
+    return mergeChannelConfig(cfg, {
+      BRICKS_BASE_URL: resolveConfiguredValue(input, existingConfig, 'BRICKS_BASE_URL'),
+      BRICKS_PLUGIN_ID: resolveConfiguredValue(input, existingConfig, 'BRICKS_PLUGIN_ID'),
+      BRICKS_PLATFORM_TOKEN: resolveConfiguredValue(input, existingConfig, 'BRICKS_PLATFORM_TOKEN'),
+    });
+  },
+};
+
+const bricksSetupWizard: ChannelSetupWizard = {
+  channel: CHANNEL_ID,
+  stepOrder: 'text-first',
+  status: {
+    configuredLabel: 'configured',
+    unconfiguredLabel: 'needs BRICKS_* config',
+    configuredHint: 'configured',
+    unconfiguredHint: 'requires Bricks base URL, plugin id, and platform token',
+    configuredScore: 1,
+    unconfiguredScore: 0,
+    resolveConfigured: ({ cfg }) => isBricksChannelConfigured(readStoredChannelConfig(cfg)),
+    resolveSelectionHint: ({ configured }) =>
+      configured ? 'configured' : 'Bricks pull-only platform channel',
+  },
+  credentials: [
+    {
+      inputKey: 'BRICKS_PLATFORM_TOKEN',
+      providerHint: CHANNEL_ID,
+      credentialLabel: 'Bricks Platform Token',
+      envPrompt: '',
+      keepPrompt: 'Bricks Platform Token already configured. Keep it?',
+      inputPrompt: 'Enter Bricks BRICKS_PLATFORM_TOKEN (JWT)',
+      inspect: ({ cfg }) => {
+        const config = readStoredChannelConfig(cfg);
+        return {
+          accountConfigured: isBricksChannelConfigured(config),
+          hasConfiguredValue: Boolean(config.BRICKS_PLATFORM_TOKEN),
+        };
+      },
+      applySet: ({ cfg, resolvedValue }) =>
+        applySingleField(cfg, 'BRICKS_PLATFORM_TOKEN', resolvedValue),
+    },
+  ],
+  textInputs: [
+    {
+      inputKey: 'BRICKS_BASE_URL',
+      message: 'Bricks Base URL',
+      placeholder: 'https://api.example.com',
+      required: true,
+      currentValue: ({ cfg }) => readStoredChannelConfig(cfg).BRICKS_BASE_URL,
+      validate: ({ value }) => validateRequiredValue('BRICKS_BASE_URL', readOptionalString(value)) ?? undefined,
+      normalizeValue: ({ value }) => value.trim(),
+      applySet: ({ cfg, value }) => applySingleField(cfg, 'BRICKS_BASE_URL', value),
+    },
+    {
+      inputKey: 'BRICKS_PLUGIN_ID',
+      message: 'Bricks Plugin ID',
+      placeholder: CHANNEL_ID,
+      required: true,
+      currentValue: ({ cfg }) => readStoredChannelConfig(cfg).BRICKS_PLUGIN_ID,
+      validate: ({ value }) => validateRequiredValue('BRICKS_PLUGIN_ID', readOptionalString(value)) ?? undefined,
+      normalizeValue: ({ value }) => value.trim(),
+      applySet: ({ cfg, value }) => applySingleField(cfg, 'BRICKS_PLUGIN_ID', value),
+    },
+  ],
+};
+
+export const bricksChannelPlugin: BricksChannelPlugin = {
+  id: CHANNEL_ID,
+  meta: {
+    id: CHANNEL_ID,
+    label: 'Bricks',
+    selectionLabel: 'Bricks Platform',
+    docsPath: '/channels/dev-askman-bricks',
+    docsLabel: CHANNEL_ID,
+    blurb: 'Bricks platform pull-only channel with onboarding wizard.',
+    order: 70,
+    aliases: ['bricks'],
+  },
+  capabilities: {
+    chatTypes: ['direct'],
+    media: false,
+  },
+  reload: {
+    configPrefixes: [`channels.${CHANNEL_ID}`],
+  },
+  configSchema: BRICKS_CHANNEL_CONFIG_SCHEMA,
+  config: bricksConfigAdapter,
+  setup: bricksSetupAdapter,
+  setupWizard: bricksSetupWizard,
+};

--- a/apps/node_openclaw_plugin/src/index.ts
+++ b/apps/node_openclaw_plugin/src/index.ts
@@ -42,4 +42,7 @@ async function main(): Promise<void> {
   await runner.runForever();
 }
 
-void main();
+main().catch((error) => {
+  console.error('Failed to start node_openclaw_plugin:', error);
+  process.exitCode = 1;
+});

--- a/apps/node_openclaw_plugin/src/index.ts
+++ b/apps/node_openclaw_plugin/src/index.ts
@@ -1,0 +1,45 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { parseAndValidatePlatformTokenClaims } from './jwtClaims.js';
+import { NodeOpenClawPluginRunner } from './pluginRunner.js';
+import type { PluginRuntimeConfig } from './types.js';
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required env: ${name}`);
+  }
+  return value;
+}
+
+function loadConfig(): PluginRuntimeConfig {
+  const pollIntervalMs = Number(process.env.OPENCLAW_PLUGIN_POLL_INTERVAL_MS ?? '2000');
+  if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+    throw new Error('OPENCLAW_PLUGIN_POLL_INTERVAL_MS must be a positive number');
+  }
+
+  const token = requiredEnv('BRICKS_PLATFORM_TOKEN');
+  const pluginId = requiredEnv('BRICKS_PLUGIN_ID');
+  const tokenClaims = parseAndValidatePlatformTokenClaims(token, pluginId);
+
+  return {
+    baseUrl: requiredEnv('BRICKS_BASE_URL'),
+    token,
+    pluginId,
+    tokenUserId: tokenClaims.userId,
+    pollIntervalMs,
+    defaultCursor: process.env.OPENCLAW_PLUGIN_DEFAULT_CURSOR?.trim() || 'cur_0',
+    stateFilePath:
+      process.env.OPENCLAW_PLUGIN_STATE_FILE?.trim() ||
+      join(homedir(), '.bricks', 'node_openclaw_plugin_state.json'),
+    assistantName: process.env.OPENCLAW_PLUGIN_ASSISTANT_NAME?.trim() || 'Node OpenClaw Plugin',
+  };
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const runner = new NodeOpenClawPluginRunner(config);
+  await runner.runForever();
+}
+
+void main();

--- a/apps/node_openclaw_plugin/src/jwtClaims.ts
+++ b/apps/node_openclaw_plugin/src/jwtClaims.ts
@@ -1,0 +1,52 @@
+export interface PlatformTokenClaims {
+  typ: string;
+  pluginId: string;
+  userId: string;
+  exp?: number;
+}
+
+function decodeBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4);
+  return Buffer.from(padded, 'base64').toString('utf8');
+}
+
+function readClaims(token: string): Record<string, unknown> {
+  const segments = token.split('.');
+  if (segments.length !== 3) {
+    throw new Error('BRICKS_PLATFORM_TOKEN must be a JWT with 3 segments');
+  }
+
+  try {
+    return JSON.parse(decodeBase64Url(segments[1])) as Record<string, unknown>;
+  } catch {
+    throw new Error('BRICKS_PLATFORM_TOKEN payload is not valid JSON');
+  }
+}
+
+export function parseAndValidatePlatformTokenClaims(token: string, pluginId: string): PlatformTokenClaims {
+  const claims = readClaims(token);
+  const typ = typeof claims.typ === 'string' ? claims.typ : '';
+  const claimPluginId = typeof claims.pluginId === 'string' ? claims.pluginId : '';
+  const userId = typeof claims.userId === 'string' ? claims.userId : '';
+  const exp = typeof claims.exp === 'number' ? claims.exp : undefined;
+
+  if (typ !== 'platform_plugin') {
+    throw new Error('BRICKS_PLATFORM_TOKEN typ must equal platform_plugin');
+  }
+  if (!claimPluginId) {
+    throw new Error('BRICKS_PLATFORM_TOKEN must include pluginId claim');
+  }
+  if (claimPluginId !== pluginId) {
+    throw new Error('BRICKS_PLATFORM_TOKEN pluginId claim does not match BRICKS_PLUGIN_ID');
+  }
+  if (!userId) {
+    throw new Error('BRICKS_PLATFORM_TOKEN must include userId claim');
+  }
+
+  if (exp && exp <= Math.floor(Date.now() / 1000)) {
+    throw new Error('BRICKS_PLATFORM_TOKEN has expired');
+  }
+
+  return { typ, pluginId: claimPluginId, userId, exp };
+}

--- a/apps/node_openclaw_plugin/src/jwtClaims.ts
+++ b/apps/node_openclaw_plugin/src/jwtClaims.ts
@@ -44,7 +44,7 @@ export function parseAndValidatePlatformTokenClaims(token: string, pluginId: str
     throw new Error('BRICKS_PLATFORM_TOKEN must include userId claim');
   }
 
-  if (exp && exp <= Math.floor(Date.now() / 1000)) {
+  if (exp !== undefined && exp <= Math.floor(Date.now() / 1000)) {
     throw new Error('BRICKS_PLATFORM_TOKEN has expired');
   }
 

--- a/apps/node_openclaw_plugin/src/openclawExtension.ts
+++ b/apps/node_openclaw_plugin/src/openclawExtension.ts
@@ -1,95 +1,30 @@
-const CHANNEL_ID = 'dev-askman-bricks';
+import {
+  BRICKS_CHANNEL_CONFIG_SCHEMA,
+  CHANNEL_DESCRIPTION,
+  CHANNEL_ID,
+  CHANNEL_NAME,
+  bricksChannelPlugin,
+} from './bricksChannelPlugin.js';
 
-interface PromptApi {
-  input(options: { message: string; default?: string }): Promise<string>;
+interface ChannelRegistrationApi {
+  registrationMode?: string;
+  registerChannel(params: { plugin: typeof bricksChannelPlugin }): void;
 }
 
-interface OnboardingContext {
-  configured: boolean;
-  label?: string;
-  config?: Record<string, unknown>;
-  prompter?: PromptApi;
-}
-
-interface OnboardingResult {
-  cfg: Record<string, string>;
-  accountId?: string;
-}
-
-function readExistingConfigValue(config: OnboardingContext['config'], key: string): string | undefined {
-  const value = config?.[key];
-  if (typeof value !== 'string') {
-    return undefined;
-  }
-
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
-async function promptRequired(
-  ctx: OnboardingContext,
-  key: 'BRICKS_BASE_URL' | 'BRICKS_PLUGIN_ID' | 'BRICKS_PLATFORM_TOKEN',
-  promptMessage: string,
-  fallback?: string,
-): Promise<string> {
-  if (!ctx.prompter?.input) {
-    throw new Error(`Missing onboarding prompter; please set channels.${CHANNEL_ID}.${key} manually.`);
-  }
-
-  const existing = readExistingConfigValue(ctx.config, key) ?? fallback;
-  const entered = (await ctx.prompter.input({
-    message: promptMessage,
-    default: existing,
-  }))?.trim();
-
-  if (!entered) {
-    throw new Error(`${key} is required.`);
-  }
-
-  return entered;
-}
-
-const plugin = {
+const pluginEntry = {
   id: CHANNEL_ID,
-  name: 'Bricks OpenClaw Plugin',
-  configSchema: {
-    type: 'object',
-    additionalProperties: false,
-    properties: {
-      BRICKS_BASE_URL: {
-        type: 'string',
-      },
-      BRICKS_PLUGIN_ID: {
-        type: 'string',
-      },
-      BRICKS_PLATFORM_TOKEN: {
-        type: 'string',
-      },
-    },
-    required: ['BRICKS_BASE_URL', 'BRICKS_PLUGIN_ID', 'BRICKS_PLATFORM_TOKEN'],
-  },
-  onboarding: {
-    async configureInteractive(ctx: OnboardingContext): Promise<OnboardingResult> {
-      const label = ctx.label ?? 'Bricks';
+  name: CHANNEL_NAME,
+  description: CHANNEL_DESCRIPTION,
+  configSchema: BRICKS_CHANNEL_CONFIG_SCHEMA,
+  register(api: ChannelRegistrationApi) {
+    if (api.registrationMode === 'cli-metadata') {
+      return;
+    }
 
-      const baseUrl = await promptRequired(ctx, 'BRICKS_BASE_URL', `Enter ${label} BRICKS_BASE_URL`);
-      const pluginId = await promptRequired(ctx, 'BRICKS_PLUGIN_ID', `Enter ${label} BRICKS_PLUGIN_ID`, CHANNEL_ID);
-      const token = await promptRequired(ctx, 'BRICKS_PLATFORM_TOKEN', `Enter ${label} BRICKS_PLATFORM_TOKEN (JWT)`);
-
-      return {
-        cfg: {
-          BRICKS_BASE_URL: baseUrl,
-          BRICKS_PLUGIN_ID: pluginId,
-          BRICKS_PLATFORM_TOKEN: token,
-        },
-        accountId: pluginId,
-      };
-    },
+    api.registerChannel({ plugin: bricksChannelPlugin });
   },
-  register() {
-    // Runtime behavior is implemented in src/index.ts for standalone pull-only runner.
-    // This extension focuses on OpenClaw discovery + onboarding config wiring.
-  },
+  channelPlugin: bricksChannelPlugin,
 };
 
-export default plugin;
+export default pluginEntry;
+export { BRICKS_CHANNEL_CONFIG_SCHEMA, CHANNEL_ID, DEFAULT_ACCOUNT_ID, bricksChannelPlugin } from './bricksChannelPlugin.js';

--- a/apps/node_openclaw_plugin/src/openclawExtension.ts
+++ b/apps/node_openclaw_plugin/src/openclawExtension.ts
@@ -1,0 +1,84 @@
+const CHANNEL_ID = 'dev-askman-bricks';
+
+interface PromptApi {
+  input(options: { message: string; default?: string }): Promise<string>;
+}
+
+interface OnboardingContext {
+  configured: boolean;
+  label?: string;
+  config?: Record<string, unknown>;
+  prompter?: PromptApi;
+}
+
+interface OnboardingResult {
+  cfg: Record<string, string>;
+  accountId?: string;
+}
+
+function readExistingConfigValue(config: OnboardingContext['config'], key: string): string | undefined {
+  const value = config?.[key];
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+async function promptRequired(
+  ctx: OnboardingContext,
+  key: 'BRICKS_BASE_URL' | 'BRICKS_PLUGIN_ID' | 'BRICKS_PLATFORM_TOKEN',
+  promptMessage: string,
+  fallback?: string,
+): Promise<string> {
+  if (!ctx.prompter?.input) {
+    throw new Error(`Missing onboarding prompter; please set channels.${CHANNEL_ID}.${key} manually.`);
+  }
+
+  const existing = readExistingConfigValue(ctx.config, key) ?? fallback;
+  const entered = (await ctx.prompter.input({
+    message: promptMessage,
+    default: existing,
+  }))?.trim();
+
+  if (!entered) {
+    throw new Error(`${key} is required.`);
+  }
+
+  return entered;
+}
+
+const plugin = {
+  id: CHANNEL_ID,
+  name: 'Bricks OpenClaw Plugin',
+  configSchema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {},
+  },
+  onboarding: {
+    async configureInteractive(ctx: OnboardingContext): Promise<OnboardingResult> {
+      const label = ctx.label ?? 'Bricks';
+
+      const baseUrl = await promptRequired(ctx, 'BRICKS_BASE_URL', `Enter ${label} BRICKS_BASE_URL`);
+      const pluginId = await promptRequired(ctx, 'BRICKS_PLUGIN_ID', `Enter ${label} BRICKS_PLUGIN_ID`, CHANNEL_ID);
+      const token = await promptRequired(ctx, 'BRICKS_PLATFORM_TOKEN', `Enter ${label} BRICKS_PLATFORM_TOKEN (JWT)`);
+
+      return {
+        cfg: {
+          BRICKS_BASE_URL: baseUrl,
+          BRICKS_PLUGIN_ID: pluginId,
+          BRICKS_PLATFORM_TOKEN: token,
+        },
+        accountId: pluginId,
+      };
+    },
+  },
+  register() {
+    // Runtime behavior is implemented in src/index.ts for standalone pull-only runner.
+    // This extension focuses on OpenClaw discovery + onboarding config wiring.
+  },
+};
+
+export default plugin;

--- a/apps/node_openclaw_plugin/src/openclawExtension.ts
+++ b/apps/node_openclaw_plugin/src/openclawExtension.ts
@@ -55,7 +55,18 @@ const plugin = {
   configSchema: {
     type: 'object',
     additionalProperties: false,
-    properties: {},
+    properties: {
+      BRICKS_BASE_URL: {
+        type: 'string',
+      },
+      BRICKS_PLUGIN_ID: {
+        type: 'string',
+      },
+      BRICKS_PLATFORM_TOKEN: {
+        type: 'string',
+      },
+    },
+    required: ['BRICKS_BASE_URL', 'BRICKS_PLUGIN_ID', 'BRICKS_PLATFORM_TOKEN'],
   },
   onboarding: {
     async configureInteractive(ctx: OnboardingContext): Promise<OnboardingResult> {

--- a/apps/node_openclaw_plugin/src/openclawSetupEntry.ts
+++ b/apps/node_openclaw_plugin/src/openclawSetupEntry.ts
@@ -1,0 +1,7 @@
+import { bricksChannelPlugin } from './bricksChannelPlugin.js';
+
+const setupEntry = {
+  plugin: bricksChannelPlugin,
+};
+
+export default setupEntry;

--- a/apps/node_openclaw_plugin/src/platformClient.ts
+++ b/apps/node_openclaw_plugin/src/platformClient.ts
@@ -1,0 +1,103 @@
+import type {
+  CreateMessageRequest,
+  CreateMessageResponse,
+  GetEventsResponse,
+  PatchMessageRequest,
+  ResolveConversationResponse,
+} from './types.js';
+
+export class PlatformHttpError extends Error {
+  readonly status: number;
+  readonly code?: string;
+  readonly retryable?: boolean;
+
+  constructor(status: number, message: string, code?: string, retryable?: boolean) {
+    super(message);
+    this.name = 'PlatformHttpError';
+    this.status = status;
+    this.code = code;
+    this.retryable = retryable;
+  }
+}
+
+export class PlatformClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly token: string,
+    private readonly pluginId: string,
+  ) {}
+
+  async getEvents(cursor: string, limit = 50): Promise<GetEventsResponse> {
+    const params = new URLSearchParams({ cursor, limit: String(limit) });
+    return this.request<GetEventsResponse>(`/api/v1/platform/events?${params.toString()}`);
+  }
+
+  async ackEvents(cursor: string, ackedEventIds: string[]): Promise<{ ok: boolean }> {
+    return this.request<{ ok: boolean }>('/api/v1/platform/events/ack', {
+      method: 'POST',
+      body: JSON.stringify({ cursor, ackedEventIds }),
+    });
+  }
+
+  async resolveConversation(args: {
+    conversationId?: string;
+    rawId?: string;
+  }): Promise<ResolveConversationResponse> {
+    const params = new URLSearchParams();
+    if (args.conversationId) params.set('conversationId', args.conversationId);
+    if (args.rawId) params.set('rawId', args.rawId);
+    return this.request<ResolveConversationResponse>(`/api/v1/platform/conversations/resolve?${params.toString()}`);
+  }
+
+  async createMessage(payload: CreateMessageRequest): Promise<CreateMessageResponse> {
+    return this.request<CreateMessageResponse>('/api/v1/platform/messages', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async patchMessage(messageId: string, payload: PatchMessageRequest): Promise<{ ok: boolean }> {
+    return this.request<{ ok: boolean }>(`/api/v1/platform/messages/${encodeURIComponent(messageId)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    });
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(new URL(path, this.baseUrl), {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'X-Bricks-Plugin-Id': this.pluginId,
+        'Content-Type': 'application/json',
+        ...init?.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const message = `Platform request failed: ${response.status} ${response.statusText}`;
+      try {
+        const body = (await response.json()) as {
+          error?: { code?: string; message?: string; retryable?: boolean };
+        };
+        throw new PlatformHttpError(
+          response.status,
+          body.error?.message ?? message,
+          body.error?.code,
+          body.error?.retryable,
+        );
+      } catch (error) {
+        if (error instanceof PlatformHttpError) {
+          throw error;
+        }
+        throw new PlatformHttpError(response.status, message);
+      }
+    }
+
+    if (response.status === 204) {
+      return {} as T;
+    }
+
+    return (await response.json()) as T;
+  }
+}

--- a/apps/node_openclaw_plugin/src/pluginRunner.ts
+++ b/apps/node_openclaw_plugin/src/pluginRunner.ts
@@ -107,7 +107,7 @@ export class NodeOpenClawPluginRunner {
       console.warn('[node_openclaw_plugin] skip event without conversation identity', event.eventId);
       return;
     }
-    if (!shouldProcessEvent(event, this.config.tokenUserId)) {
+    if (!shouldProcessEvent(event)) {
       return;
     }
 
@@ -175,8 +175,7 @@ export function extractIncomingText(payload?: PlatformEvent['payload']): string 
   return '[empty message]';
 }
 
-export function shouldProcessEvent(event: PlatformEvent, tokenUserId: string): boolean {
-  void tokenUserId;
+export function shouldProcessEvent(event: PlatformEvent): boolean {
   if (event.eventType !== 'message.created') {
     return true;
   }

--- a/apps/node_openclaw_plugin/src/pluginRunner.ts
+++ b/apps/node_openclaw_plugin/src/pluginRunner.ts
@@ -1,0 +1,191 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+import { PlatformClient, PlatformHttpError } from './platformClient.js';
+import { FileStateStore } from './stateStore.js';
+import type {
+  CreateMessageRequest,
+  PlatformEvent,
+  PluginPersistentState,
+  PluginRuntimeConfig,
+} from './types.js';
+
+export class NodeOpenClawPluginRunner {
+  private readonly client: PlatformClient;
+  private readonly stateStore: FileStateStore;
+  private state: PluginPersistentState;
+
+  constructor(private readonly config: PluginRuntimeConfig) {
+    this.client = new PlatformClient(config.baseUrl, config.token, config.pluginId);
+    this.stateStore = new FileStateStore(config.stateFilePath, config.defaultCursor);
+    this.state = {
+      cursor: config.defaultCursor,
+      processedEventIds: [],
+      clientTokenMessageMap: {},
+      pendingAck: null,
+    };
+  }
+
+  async runForever(): Promise<void> {
+    this.state = await this.stateStore.load();
+    console.log('[node_openclaw_plugin] started with cursor:', this.state.cursor);
+
+    for (;;) {
+      try {
+        await this.tick();
+      } catch (error) {
+        console.error('[node_openclaw_plugin] tick failed:', error);
+      }
+      await sleep(this.config.pollIntervalMs);
+    }
+  }
+
+  async tick(): Promise<void> {
+    await this.flushPendingAck();
+
+    const response = await this.client.getEvents(this.state.cursor, 50);
+    const receivedEventIds = response.events
+      .map((event) => event.eventId)
+      .filter((eventId) => eventId.trim().length > 0);
+
+    for (const event of response.events) {
+      if (this.state.processedEventIds.includes(event.eventId)) {
+        continue;
+      }
+
+      await this.handleEvent(event);
+      this.state.processedEventIds.push(event.eventId);
+    }
+
+    if (receivedEventIds.length > 0) {
+      this.state.pendingAck = {
+        cursor: response.nextCursor,
+        eventIds: receivedEventIds,
+      };
+      await this.stateStore.save(this.state);
+      await this.flushPendingAck();
+      return;
+    }
+
+    this.state.cursor = response.nextCursor;
+    await this.stateStore.save(this.state);
+  }
+
+  private async flushPendingAck(): Promise<void> {
+    if (!this.state.pendingAck) {
+      return;
+    }
+
+    await this.client.ackEvents(this.state.pendingAck.cursor, this.state.pendingAck.eventIds);
+    this.state.cursor = this.state.pendingAck.cursor;
+    this.state.pendingAck = null;
+    await this.stateStore.save(this.state);
+  }
+
+  private async handleEvent(event: PlatformEvent): Promise<void> {
+    switch (event.eventType) {
+      case 'message.created':
+        await this.handleMessageCreated(event);
+        return;
+      case 'conversation.binding_changed':
+        console.log('[node_openclaw_plugin] binding_changed received', {
+          eventId: event.eventId,
+          conversationId: event.conversationId,
+        });
+        return;
+      default:
+        console.log('[node_openclaw_plugin] ignored event type', {
+          eventId: event.eventId,
+          eventType: event.eventType,
+        });
+    }
+  }
+
+  private async handleMessageCreated(event: PlatformEvent): Promise<void> {
+    if (!event.conversationId && !event.rawId) {
+      console.warn('[node_openclaw_plugin] skip event without conversation identity', event.eventId);
+      return;
+    }
+    if (!shouldProcessEvent(event, this.config.tokenUserId)) {
+      return;
+    }
+
+    const topology = await this.client.resolveConversation({
+      conversationId: event.conversationId,
+      rawId: event.rawId,
+    });
+
+    const inputText = extractIncomingText(event.payload);
+    const responseText = `收到消息：${inputText}`;
+    const clientToken = `evt:${event.eventId}`;
+
+    const createPayload: CreateMessageRequest = {
+      workspaceId: event.workspaceId,
+      conversationId: topology.conversationId,
+      channelId: topology.channelId,
+      threadId: topology.threadId,
+      role: 'assistant',
+      status: 'streaming',
+      text: `${this.config.assistantName} 正在处理...`,
+      clientToken,
+      metadata: {
+        sourceEventId: event.eventId,
+        plugin: 'node_openclaw_plugin',
+      },
+    };
+
+    let messageId = this.state.clientTokenMessageMap[clientToken];
+
+    if (!messageId) {
+      const created = await this.client.createMessage(createPayload);
+      messageId = created.messageId;
+      this.state.clientTokenMessageMap[clientToken] = messageId;
+    }
+
+    try {
+      await this.client.patchMessage(messageId, {
+        text: responseText,
+        metadata: {
+          sourceEventId: event.eventId,
+          handledBy: this.config.assistantName,
+        },
+      });
+    } catch (error) {
+      if (error instanceof PlatformHttpError && error.status === 409) {
+        console.warn('[node_openclaw_plugin] revision conflict; skipped patch', { messageId, eventId: event.eventId });
+        return;
+      }
+      throw error;
+    }
+  }
+}
+
+export function extractIncomingText(payload?: PlatformEvent['payload']): string {
+  const text = payload?.text;
+  if (typeof text === 'string' && text.trim().length > 0) {
+    return text.trim();
+  }
+
+  const nestedText = payload?.content;
+  if (typeof nestedText === 'string' && nestedText.trim().length > 0) {
+    return nestedText.trim();
+  }
+
+  return '[empty message]';
+}
+
+export function shouldProcessEvent(event: PlatformEvent, tokenUserId: string): boolean {
+  if (event.eventType !== 'message.created') {
+    return true;
+  }
+
+  const sender = event.payload?.sender;
+  if (!sender) return true;
+
+  if (sender.userId && sender.userId === tokenUserId) {
+    return false;
+  }
+  if (sender.displayName && ['assistant', 'system'].includes(sender.displayName.toLowerCase())) {
+    return false;
+  }
+
+  return true;
+}

--- a/apps/node_openclaw_plugin/src/pluginRunner.ts
+++ b/apps/node_openclaw_plugin/src/pluginRunner.ts
@@ -176,6 +176,7 @@ export function extractIncomingText(payload?: PlatformEvent['payload']): string 
 }
 
 export function shouldProcessEvent(event: PlatformEvent, tokenUserId: string): boolean {
+  void tokenUserId;
   if (event.eventType !== 'message.created') {
     return true;
   }
@@ -183,9 +184,6 @@ export function shouldProcessEvent(event: PlatformEvent, tokenUserId: string): b
   const sender = event.payload?.sender;
   if (!sender) return true;
 
-  if (sender.userId && sender.userId === tokenUserId) {
-    return false;
-  }
   if (sender.displayName && ['assistant', 'system'].includes(sender.displayName.toLowerCase())) {
     return false;
   }

--- a/apps/node_openclaw_plugin/src/pluginRunner.ts
+++ b/apps/node_openclaw_plugin/src/pluginRunner.ts
@@ -118,7 +118,7 @@ export class NodeOpenClawPluginRunner {
 
     const inputText = extractIncomingText(event.payload);
     const responseText = `收到消息：${inputText}`;
-    const clientToken = `evt:${event.eventId}`;
+    const clientToken = assistantClientTokenForEvent(event);
 
     const createPayload: CreateMessageRequest = {
       workspaceId: event.workspaceId,
@@ -188,4 +188,20 @@ export function shouldProcessEvent(event: PlatformEvent): boolean {
   }
 
   return true;
+}
+
+export function assistantClientTokenForEvent(event: PlatformEvent): string {
+  const metadata = event.payload?.metadata;
+  if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
+    const pendingAssistantMessageId =
+        (metadata as Record<string, unknown>)['pendingAssistantMessageId'];
+    if (
+      typeof pendingAssistantMessageId === 'string' &&
+      pendingAssistantMessageId.trim().length > 0
+    ) {
+      return pendingAssistantMessageId.trim();
+    }
+  }
+
+  return `evt:${event.eventId}`;
 }

--- a/apps/node_openclaw_plugin/src/pluginRunner.ts
+++ b/apps/node_openclaw_plugin/src/pluginRunner.ts
@@ -1,6 +1,6 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 import { PlatformClient, PlatformHttpError } from './platformClient.js';
-import { FileStateStore } from './stateStore.js';
+import { DEFAULT_MAX_PROCESSED_EVENTS, FileStateStore } from './stateStore.js';
 import type {
   CreateMessageRequest,
   PlatformEvent,
@@ -54,6 +54,9 @@ export class NodeOpenClawPluginRunner {
       await this.handleEvent(event);
       this.state.processedEventIds.push(event.eventId);
     }
+
+    // Keep in-memory array bounded to prevent unbounded growth during long runs
+    this.state.processedEventIds = this.state.processedEventIds.slice(-DEFAULT_MAX_PROCESSED_EVENTS);
 
     if (receivedEventIds.length > 0) {
       this.state.pendingAck = {

--- a/apps/node_openclaw_plugin/src/stateStore.ts
+++ b/apps/node_openclaw_plugin/src/stateStore.ts
@@ -1,0 +1,57 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import type { PluginPersistentState } from './types.js';
+
+export const DEFAULT_MAX_PROCESSED_EVENTS = 5000;
+
+export function createDefaultState(defaultCursor: string): PluginPersistentState {
+  return {
+    cursor: defaultCursor,
+    processedEventIds: [],
+    clientTokenMessageMap: {},
+    pendingAck: null,
+  };
+}
+
+export class FileStateStore {
+  constructor(
+    private readonly filePath: string,
+    private readonly defaultCursor: string,
+    private readonly maxProcessedEvents = DEFAULT_MAX_PROCESSED_EVENTS,
+  ) {}
+
+  async load(): Promise<PluginPersistentState> {
+    try {
+      const raw = await readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(raw) as PluginPersistentState;
+      return {
+        cursor: parsed.cursor || this.defaultCursor,
+        processedEventIds: Array.isArray(parsed.processedEventIds) ? parsed.processedEventIds : [],
+        clientTokenMessageMap: parsed.clientTokenMessageMap ?? {},
+        pendingAck:
+          parsed.pendingAck &&
+          typeof parsed.pendingAck === 'object' &&
+          typeof parsed.pendingAck.cursor === 'string' &&
+          Array.isArray(parsed.pendingAck.eventIds)
+            ? {
+                cursor: parsed.pendingAck.cursor,
+                eventIds: parsed.pendingAck.eventIds.filter(
+                  (value): value is string => typeof value === 'string' && value.trim().length > 0,
+                ),
+              }
+            : null,
+      };
+    } catch {
+      return createDefaultState(this.defaultCursor);
+    }
+  }
+
+  async save(state: PluginPersistentState): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const normalized: PluginPersistentState = {
+      ...state,
+      processedEventIds: state.processedEventIds.slice(-this.maxProcessedEvents),
+    };
+    await writeFile(this.filePath, JSON.stringify(normalized, null, 2), 'utf8');
+  }
+}

--- a/apps/node_openclaw_plugin/src/types.ts
+++ b/apps/node_openclaw_plugin/src/types.ts
@@ -1,0 +1,80 @@
+export type PlatformEventType = 'message.created' | 'interaction.submitted' | 'conversation.binding_changed' | string;
+
+export interface PlatformEvent {
+  eventId: string;
+  eventType: PlatformEventType;
+  workspaceId?: string;
+  conversationId?: string;
+  rawId?: string;
+  occurredAt?: string;
+  payload?: {
+    text?: string;
+    content?: string;
+    sender?: {
+      userId?: string;
+      displayName?: string;
+    };
+    [key: string]: unknown;
+  };
+}
+
+export interface GetEventsResponse {
+  nextCursor: string;
+  events: PlatformEvent[];
+}
+
+export interface ResolveConversationResponse {
+  conversationId: string;
+  channelId?: string;
+  threadId?: string;
+  sessionId?: string;
+  rawId?: string;
+}
+
+export interface CreateMessageRequest {
+  workspaceId?: string;
+  conversationId: string;
+  channelId?: string;
+  threadId?: string;
+  text?: string;
+  content?: string;
+  role?: string;
+  author?: string;
+  status?: 'streaming' | 'completed' | string;
+  clientToken?: string;
+  userId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateMessageResponse {
+  messageId: string;
+  revision?: number;
+}
+
+export interface PatchMessageRequest {
+  text?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PendingAckState {
+  cursor: string;
+  eventIds: string[];
+}
+
+export interface PluginPersistentState {
+  cursor: string;
+  processedEventIds: string[];
+  clientTokenMessageMap: Record<string, string>;
+  pendingAck: PendingAckState | null;
+}
+
+export interface PluginRuntimeConfig {
+  baseUrl: string;
+  token: string;
+  pluginId: string;
+  tokenUserId: string;
+  pollIntervalMs: number;
+  defaultCursor: string;
+  stateFilePath: string;
+  assistantName: string;
+}

--- a/apps/node_openclaw_plugin/src/types.ts
+++ b/apps/node_openclaw_plugin/src/types.ts
@@ -25,9 +25,8 @@ export interface GetEventsResponse {
 
 export interface ResolveConversationResponse {
   conversationId: string;
-  channelId?: string;
+  channelId: string;
   threadId?: string;
-  sessionId?: string;
   rawId?: string;
 }
 

--- a/apps/node_openclaw_plugin/test/jwtClaims.test.ts
+++ b/apps/node_openclaw_plugin/test/jwtClaims.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { parseAndValidatePlatformTokenClaims } from '../src/jwtClaims.js';
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.signature`;
+}
+
+describe('parseAndValidatePlatformTokenClaims', () => {
+  it('parses required claims', () => {
+    const token = makeJwt({
+      typ: 'platform_plugin',
+      pluginId: 'plugin_local_main',
+      userId: 'user_1',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    const claims = parseAndValidatePlatformTokenClaims(token, 'plugin_local_main');
+    expect(claims.userId).toBe('user_1');
+  });
+
+  it('rejects plugin mismatch and missing required claims', () => {
+    const mismatchPlugin = makeJwt({ typ: 'platform_plugin', pluginId: 'another_plugin', userId: 'user_1' });
+    expect(() => parseAndValidatePlatformTokenClaims(mismatchPlugin, 'plugin_local_main')).toThrow(
+      'pluginId claim does not match BRICKS_PLUGIN_ID',
+    );
+
+    const missingUser = makeJwt({ typ: 'platform_plugin', pluginId: 'plugin_local_main' });
+    expect(() => parseAndValidatePlatformTokenClaims(missingUser, 'plugin_local_main')).toThrow(
+      'must include userId claim',
+    );
+  });
+});

--- a/apps/node_openclaw_plugin/test/openclawExtension.test.ts
+++ b/apps/node_openclaw_plugin/test/openclawExtension.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import plugin from '../src/openclawExtension.js';
+
+function makePrompter(responses: string[]) {
+  let call = 0;
+  return {
+    input: vi.fn(async (_opts: { message: string; default?: string }) => responses[call++] ?? ''),
+  };
+}
+
+describe('openclawExtension plugin', () => {
+  describe('configSchema', () => {
+    it('declares all required BRICKS_* keys', () => {
+      const { configSchema } = plugin;
+      expect(configSchema.required).toEqual(
+        expect.arrayContaining(['BRICKS_BASE_URL', 'BRICKS_PLUGIN_ID', 'BRICKS_PLATFORM_TOKEN']),
+      );
+      expect(configSchema.properties).toHaveProperty('BRICKS_BASE_URL');
+      expect(configSchema.properties).toHaveProperty('BRICKS_PLUGIN_ID');
+      expect(configSchema.properties).toHaveProperty('BRICKS_PLATFORM_TOKEN');
+    });
+
+    it('has additionalProperties set to false', () => {
+      expect(plugin.configSchema.additionalProperties).toBe(false);
+    });
+  });
+
+  describe('configureInteractive', () => {
+    it('collects BRICKS_* values from prompter and returns cfg + accountId', async () => {
+      const prompter = makePrompter(['https://api.example.com', 'my-plugin-id', 'jwt-token']);
+      const result = await plugin.onboarding.configureInteractive({ configured: false, prompter });
+
+      expect(result.cfg).toEqual({
+        BRICKS_BASE_URL: 'https://api.example.com',
+        BRICKS_PLUGIN_ID: 'my-plugin-id',
+        BRICKS_PLATFORM_TOKEN: 'jwt-token',
+      });
+      expect(result.accountId).toBe('my-plugin-id');
+    });
+
+    it('uses existing config values as defaults', async () => {
+      const prompter = makePrompter(['', '', '']);
+      prompter.input = vi.fn(async (opts: { message: string; default?: string }) => opts.default ?? '');
+
+      const result = await plugin.onboarding.configureInteractive({
+        configured: true,
+        prompter,
+        config: {
+          BRICKS_BASE_URL: 'https://stored.example.com',
+          BRICKS_PLUGIN_ID: 'stored-plugin',
+          BRICKS_PLATFORM_TOKEN: 'stored-token',
+        },
+      });
+
+      expect(result.cfg.BRICKS_BASE_URL).toBe('https://stored.example.com');
+      expect(result.cfg.BRICKS_PLUGIN_ID).toBe('stored-plugin');
+      expect(result.cfg.BRICKS_PLATFORM_TOKEN).toBe('stored-token');
+    });
+
+    it('trims whitespace from entered values', async () => {
+      const prompter = makePrompter(['  https://api.example.com  ', '  plugin-id  ', '  token  ']);
+      const result = await plugin.onboarding.configureInteractive({ configured: false, prompter });
+
+      expect(result.cfg.BRICKS_BASE_URL).toBe('https://api.example.com');
+      expect(result.cfg.BRICKS_PLUGIN_ID).toBe('plugin-id');
+      expect(result.cfg.BRICKS_PLATFORM_TOKEN).toBe('token');
+    });
+
+    it('throws when prompter is missing', async () => {
+      await expect(plugin.onboarding.configureInteractive({ configured: false })).rejects.toThrow(
+        'Missing onboarding prompter',
+      );
+    });
+
+    it('throws when a required value is empty after trim', async () => {
+      const prompter = makePrompter(['', '', '']);
+      await expect(plugin.onboarding.configureInteractive({ configured: false, prompter })).rejects.toThrow(
+        'BRICKS_BASE_URL is required',
+      );
+    });
+  });
+});

--- a/apps/node_openclaw_plugin/test/openclawExtension.test.ts
+++ b/apps/node_openclaw_plugin/test/openclawExtension.test.ts
@@ -1,82 +1,133 @@
 import { describe, expect, it, vi } from 'vitest';
-import plugin from '../src/openclawExtension.js';
+import pluginEntry, {
+  BRICKS_CHANNEL_CONFIG_SCHEMA,
+  CHANNEL_ID,
+  DEFAULT_ACCOUNT_ID,
+  bricksChannelPlugin,
+} from '../src/openclawExtension.js';
 
-function makePrompter(responses: string[]) {
-  let call = 0;
-  return {
-    input: vi.fn(async (_opts: { message: string; default?: string }) => responses[call++] ?? ''),
-  };
-}
+describe('openclawExtension channel entry', () => {
+  it('reuses the Bricks channel config schema', () => {
+    expect(pluginEntry.configSchema).toEqual(BRICKS_CHANNEL_CONFIG_SCHEMA);
+    expect(pluginEntry.configSchema.schema).toMatchObject({
+      additionalProperties: false,
+    });
+    expect(pluginEntry.configSchema.schema).not.toHaveProperty('required');
+  });
 
-describe('openclawExtension plugin', () => {
-  describe('configSchema', () => {
-    it('declares all required BRICKS_* keys', () => {
-      const { configSchema } = plugin;
-      expect(configSchema.required).toEqual(
-        expect.arrayContaining(['BRICKS_BASE_URL', 'BRICKS_PLUGIN_ID', 'BRICKS_PLATFORM_TOKEN']),
-      );
-      expect(configSchema.properties).toHaveProperty('BRICKS_BASE_URL');
-      expect(configSchema.properties).toHaveProperty('BRICKS_PLUGIN_ID');
-      expect(configSchema.properties).toHaveProperty('BRICKS_PLATFORM_TOKEN');
+  it('registers the Bricks channel plugin outside cli-metadata mode', () => {
+    const registerChannel = vi.fn();
+
+    pluginEntry.register({ registrationMode: 'full', registerChannel });
+
+    expect(registerChannel).toHaveBeenCalledWith({ plugin: bricksChannelPlugin });
+  });
+
+  it('skips channel registration in cli-metadata mode', () => {
+    const registerChannel = vi.fn();
+
+    pluginEntry.register({ registrationMode: 'cli-metadata', registerChannel });
+
+    expect(registerChannel).not.toHaveBeenCalled();
+  });
+});
+
+describe('bricksChannelPlugin setup', () => {
+  it('writes channel config into channels.dev-askman-bricks', () => {
+    const cfg = bricksChannelPlugin.setup.applyAccountConfig({
+      cfg: {},
+      accountId: DEFAULT_ACCOUNT_ID,
+      input: {
+        BRICKS_BASE_URL: '  https://api.example.com  ',
+        BRICKS_PLUGIN_ID: '  plugin-id  ',
+        BRICKS_PLATFORM_TOKEN: '  jwt-token  ',
+      },
     });
 
-    it('has additionalProperties set to false', () => {
-      expect(plugin.configSchema.additionalProperties).toBe(false);
+    expect(cfg.channels?.[CHANNEL_ID]).toEqual({
+      BRICKS_BASE_URL: 'https://api.example.com',
+      BRICKS_PLUGIN_ID: 'plugin-id',
+      BRICKS_PLATFORM_TOKEN: 'jwt-token',
     });
   });
 
-  describe('configureInteractive', () => {
-    it('collects BRICKS_* values from prompter and returns cfg + accountId', async () => {
-      const prompter = makePrompter(['https://api.example.com', 'my-plugin-id', 'jwt-token']);
-      const result = await plugin.onboarding.configureInteractive({ configured: false, prompter });
-
-      expect(result.cfg).toEqual({
-        BRICKS_BASE_URL: 'https://api.example.com',
-        BRICKS_PLUGIN_ID: 'my-plugin-id',
-        BRICKS_PLATFORM_TOKEN: 'jwt-token',
-      });
-      expect(result.accountId).toBe('my-plugin-id');
-    });
-
-    it('uses existing config values as defaults', async () => {
-      const prompter = makePrompter(['', '', '']);
-      prompter.input = vi.fn(async (opts: { message: string; default?: string }) => opts.default ?? '');
-
-      const result = await plugin.onboarding.configureInteractive({
-        configured: true,
-        prompter,
-        config: {
+  it('preserves stored values when re-validating partial updates', () => {
+    const cfg = {
+      channels: {
+        [CHANNEL_ID]: {
           BRICKS_BASE_URL: 'https://stored.example.com',
           BRICKS_PLUGIN_ID: 'stored-plugin',
           BRICKS_PLATFORM_TOKEN: 'stored-token',
         },
-      });
+      },
+    };
 
-      expect(result.cfg.BRICKS_BASE_URL).toBe('https://stored.example.com');
-      expect(result.cfg.BRICKS_PLUGIN_ID).toBe('stored-plugin');
-      expect(result.cfg.BRICKS_PLATFORM_TOKEN).toBe('stored-token');
+    const validationError = bricksChannelPlugin.setup.validateInput?.({
+      cfg,
+      accountId: DEFAULT_ACCOUNT_ID,
+      input: {
+        BRICKS_BASE_URL: 'https://updated.example.com',
+      },
     });
 
-    it('trims whitespace from entered values', async () => {
-      const prompter = makePrompter(['  https://api.example.com  ', '  plugin-id  ', '  token  ']);
-      const result = await plugin.onboarding.configureInteractive({ configured: false, prompter });
+    expect(validationError).toBeNull();
+  });
 
-      expect(result.cfg.BRICKS_BASE_URL).toBe('https://api.example.com');
-      expect(result.cfg.BRICKS_PLUGIN_ID).toBe('plugin-id');
-      expect(result.cfg.BRICKS_PLATFORM_TOKEN).toBe('token');
+  it('requires missing BRICKS_* values when neither input nor stored config provides them', () => {
+    const validationError = bricksChannelPlugin.setup.validateInput?.({
+      cfg: {},
+      accountId: DEFAULT_ACCOUNT_ID,
+      input: {},
     });
 
-    it('throws when prompter is missing', async () => {
-      await expect(plugin.onboarding.configureInteractive({ configured: false })).rejects.toThrow(
-        'Missing onboarding prompter',
-      );
+    expect(validationError).toBe('BRICKS_BASE_URL is required');
+  });
+});
+
+describe('bricksChannelPlugin config and wizard', () => {
+  it('reports configured state from stored channel config', async () => {
+    const cfg = {
+      channels: {
+        [CHANNEL_ID]: {
+          BRICKS_BASE_URL: 'https://api.example.com',
+          BRICKS_PLUGIN_ID: 'plugin-id',
+          BRICKS_PLATFORM_TOKEN: 'jwt-token',
+        },
+      },
+    };
+
+    expect(bricksChannelPlugin.config.listAccountIds(cfg)).toEqual([DEFAULT_ACCOUNT_ID]);
+    expect(bricksChannelPlugin.config.resolveAccount(cfg).configured).toBe(true);
+    expect(await bricksChannelPlugin.setupWizard.status.resolveConfigured({ cfg })).toBe(true);
+  });
+
+  it('stores wizard text and credential fields through channel config helpers', async () => {
+    const afterBaseUrl = await bricksChannelPlugin.setupWizard.textInputs?.[0].applySet?.({
+      cfg: {},
+      accountId: DEFAULT_ACCOUNT_ID,
+      credentialValues: {},
+      value: ' https://api.example.com ',
     });
 
-    it('throws when a required value is empty after trim', async () => {
-      const prompter = makePrompter(['', '', '']);
-      await expect(plugin.onboarding.configureInteractive({ configured: false, prompter })).rejects.toThrow(
-        'BRICKS_BASE_URL is required',
-      );
+    const afterPluginId = await bricksChannelPlugin.setupWizard.textInputs?.[1].applySet?.({
+      cfg: afterBaseUrl ?? {},
+      accountId: DEFAULT_ACCOUNT_ID,
+      credentialValues: {},
+      value: ' dev-askman-bricks ',
+    });
+
+    const afterToken = await bricksChannelPlugin.setupWizard.credentials[0].applySet?.({
+      cfg: afterPluginId ?? {},
+      accountId: DEFAULT_ACCOUNT_ID,
+      credentialValues: {},
+      value: 'jwt-token',
+      resolvedValue: ' jwt-token ',
+    });
+
+    expect(afterToken?.channels?.[CHANNEL_ID]).toEqual({
+      BRICKS_BASE_URL: 'https://api.example.com',
+      BRICKS_PLUGIN_ID: 'dev-askman-bricks',
+      BRICKS_PLATFORM_TOKEN: 'jwt-token',
     });
   });
 });

--- a/apps/node_openclaw_plugin/test/pluginRunner.test.ts
+++ b/apps/node_openclaw_plugin/test/pluginRunner.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { extractIncomingText, shouldProcessEvent } from '../src/pluginRunner.js';
+
+describe('extractIncomingText', () => {
+  it('returns top-level text first', () => {
+    expect(extractIncomingText({ text: ' hello ' })).toBe('hello');
+  });
+
+  it('falls back to content when text is missing', () => {
+    expect(extractIncomingText({ content: ' world ' })).toBe('world');
+  });
+
+  it('returns placeholder for empty payload', () => {
+    expect(extractIncomingText()).toBe('[empty message]');
+  });
+});
+
+describe('shouldProcessEvent', () => {
+  it('skips assistant/system events and same-user events', () => {
+    expect(
+      shouldProcessEvent(
+        {
+          eventId: 'evt_1',
+          eventType: 'message.created',
+          payload: { sender: { userId: 'u_1', displayName: 'user' } },
+        },
+        'u_1',
+      ),
+    ).toBe(false);
+
+    expect(
+      shouldProcessEvent(
+        {
+          eventId: 'evt_2',
+          eventType: 'message.created',
+          payload: { sender: { userId: 'u_2', displayName: 'assistant' } },
+        },
+        'u_1',
+      ),
+    ).toBe(false);
+  });
+
+  it('keeps user-created events from other users', () => {
+    expect(
+      shouldProcessEvent(
+        {
+          eventId: 'evt_3',
+          eventType: 'message.created',
+          payload: { sender: { userId: 'u_2', displayName: 'user' } },
+        },
+        'u_1',
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/node_openclaw_plugin/test/pluginRunner.test.ts
+++ b/apps/node_openclaw_plugin/test/pluginRunner.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { extractIncomingText, shouldProcessEvent } from '../src/pluginRunner.js';
+import {
+  assistantClientTokenForEvent,
+  extractIncomingText,
+  shouldProcessEvent,
+} from '../src/pluginRunner.js';
 
 describe('extractIncomingText', () => {
   it('returns top-level text first', () => {
@@ -58,5 +62,30 @@ describe('shouldProcessEvent', () => {
         },
       ),
     ).toBe(true);
+  });
+});
+
+describe('assistantClientTokenForEvent', () => {
+  it('prefers pending assistant message id from payload metadata', () => {
+    expect(
+      assistantClientTokenForEvent({
+        eventId: 'evt_1',
+        eventType: 'message.created',
+        payload: {
+          metadata: {
+            pendingAssistantMessageId: 'msg-assistant-1',
+          },
+        },
+      }),
+    ).toBe('msg-assistant-1');
+  });
+
+  it('falls back to event-derived client token', () => {
+    expect(
+      assistantClientTokenForEvent({
+        eventId: 'evt_2',
+        eventType: 'message.created',
+      }),
+    ).toBe('evt:evt_2');
   });
 });

--- a/apps/node_openclaw_plugin/test/pluginRunner.test.ts
+++ b/apps/node_openclaw_plugin/test/pluginRunner.test.ts
@@ -16,13 +16,13 @@ describe('extractIncomingText', () => {
 });
 
 describe('shouldProcessEvent', () => {
-  it('skips assistant/system events and same-user events', () => {
+  it('skips assistant/system events', () => {
     expect(
       shouldProcessEvent(
         {
           eventId: 'evt_1',
           eventType: 'message.created',
-          payload: { sender: { userId: 'u_1', displayName: 'user' } },
+          payload: { sender: { userId: 'u_1', displayName: 'assistant' } },
         },
         'u_1',
       ),
@@ -40,13 +40,13 @@ describe('shouldProcessEvent', () => {
     ).toBe(false);
   });
 
-  it('keeps user-created events from other users', () => {
+  it('keeps user-created events even when sender userId equals token userId', () => {
     expect(
       shouldProcessEvent(
         {
           eventId: 'evt_3',
           eventType: 'message.created',
-          payload: { sender: { userId: 'u_2', displayName: 'user' } },
+          payload: { sender: { userId: 'u_1', displayName: 'user' } },
         },
         'u_1',
       ),

--- a/apps/node_openclaw_plugin/test/pluginRunner.test.ts
+++ b/apps/node_openclaw_plugin/test/pluginRunner.test.ts
@@ -24,7 +24,6 @@ describe('shouldProcessEvent', () => {
           eventType: 'message.created',
           payload: { sender: { userId: 'u_1', displayName: 'assistant' } },
         },
-        'u_1',
       ),
     ).toBe(false);
 
@@ -35,7 +34,16 @@ describe('shouldProcessEvent', () => {
           eventType: 'message.created',
           payload: { sender: { userId: 'u_2', displayName: 'assistant' } },
         },
-        'u_1',
+      ),
+    ).toBe(false);
+
+    expect(
+      shouldProcessEvent(
+        {
+          eventId: 'evt_2b',
+          eventType: 'message.created',
+          payload: { sender: { userId: 'u_2', displayName: 'system' } },
+        },
       ),
     ).toBe(false);
   });
@@ -48,7 +56,6 @@ describe('shouldProcessEvent', () => {
           eventType: 'message.created',
           payload: { sender: { userId: 'u_1', displayName: 'user' } },
         },
-        'u_1',
       ),
     ).toBe(true);
   });

--- a/apps/node_openclaw_plugin/test/stateStore.test.ts
+++ b/apps/node_openclaw_plugin/test/stateStore.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDefaultState, FileStateStore } from '../src/stateStore.js';
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop();
+    if (path) {
+      await rm(path, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('FileStateStore', () => {
+  it('returns default state when file does not exist', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'node-openclaw-test-'));
+    cleanupPaths.push(root);
+
+    const store = new FileStateStore(join(root, 'state.json'), 'cur_0');
+    const loaded = await store.load();
+    expect(loaded).toEqual(createDefaultState('cur_0'));
+  });
+
+  it('persists cursor and processed event list', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'node-openclaw-test-'));
+    cleanupPaths.push(root);
+
+    const store = new FileStateStore(join(root, 'state.json'), 'cur_0', 3);
+    await store.save({
+      cursor: 'cur_12',
+      processedEventIds: ['evt_1', 'evt_2', 'evt_3', 'evt_4'],
+      clientTokenMessageMap: {
+        'evt:evt_4': 'msg_4',
+      },
+      pendingAck: {
+        cursor: 'cur_12',
+        eventIds: ['evt_3', 'evt_4'],
+      },
+    });
+
+    const loaded = await store.load();
+    expect(loaded.cursor).toBe('cur_12');
+    expect(loaded.processedEventIds).toEqual(['evt_2', 'evt_3', 'evt_4']);
+    expect(loaded.clientTokenMessageMap['evt:evt_4']).toBe('msg_4');
+    expect(loaded.pendingAck).toEqual({ cursor: 'cur_12', eventIds: ['evt_3', 'evt_4'] });
+  });
+});

--- a/apps/node_openclaw_plugin/tsconfig.json
+++ b/apps/node_openclaw_plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: feature_map
 owner: bricks
-last_updated: 2026-04-10
+last_updated: 2026-04-14
 purpose: >
   为人类测试员和 AI 测试员提供产品功能清单与进入路径，作为回归测试与变更影响评估的入口索引。
 
@@ -46,7 +46,7 @@ products:
 
       - feature_id: model_settings
         name: 模型与提供商配置
-        user_value: 用户可选择可用模型并保存默认配置。
+        user_value: 用户可选择可用模型并保存默认配置，并可快速复制 API URL 与 API Key。
         entry_paths:
           - screen: ModelSettingsScreen
             route_hint: apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
@@ -55,6 +55,8 @@ products:
         smoke_checks:
           - 进入模型设置并保存配置。
           - 重新进入页面后配置保持一致。
+          - 点击 Base URL 右侧复制按钮后可复制 API URL。
+          - 点击 API Key 右侧复制按钮时，非空 key 可被复制，空值会提示不可复制。
 
       - feature_id: workspace_resources
         name: Workspace / Projects / Skills / Resources 管理

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -141,9 +141,13 @@ products:
         route: plugin runtime main
     features:
       - feature_id: node_openclaw_pull_loop
-        name: OpenClaw Pull-only 插件运行时
-        user_value: 远端插件可轮询 Bricks 平台事件并执行 ACK 与消息回写闭环。
+        name: OpenClaw Pull-only 插件运行时与 Onboarding 配置
+        user_value: 远端插件可在 OpenClaw onboarding 中完成 channel 配置，并轮询 Bricks 平台事件执行 ACK 与消息回写闭环。
         entry_paths:
+          - setup: onboarding.configureInteractive
+            route_hint: apps/node_openclaw_plugin/src/openclawExtension.ts
+          - manifest: channelConfigs.dev-askman-bricks
+            route_hint: apps/node_openclaw_plugin/openclaw.plugin.json
           - runtime: NodeOpenClawPluginRunner
             route_hint: apps/node_openclaw_plugin/src/pluginRunner.ts
           - client: PlatformClient
@@ -151,6 +155,7 @@ products:
           - state: FileStateStore
             route_hint: apps/node_openclaw_plugin/src/stateStore.ts
         smoke_checks:
+          - 安装插件后执行 `openclaw onboard` 可提示输入 BRICKS_BASE_URL / BRICKS_PLUGIN_ID / BRICKS_PLATFORM_TOKEN 并写入 `channels.dev-askman-bricks`。
           - 设置 BRICKS_BASE_URL / BRICKS_PLATFORM_TOKEN / BRICKS_PLUGIN_ID 后可启动插件轮询。
           - 非 JWT token 或 claims 不完整时插件启动应失败（JWT-only）。
           - 插件可调用 `/api/v1/platform/events` 拉取事件并以 `X-Bricks-Plugin-Id` 发送请求。

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -131,3 +131,28 @@ products:
           - provider 配置缺失时给出明确错误。
           - 使用 API Key + X-Bricks-Plugin-Id 可访问 `/api/v1/platform/events` 并获取 `nextCursor`。
           - `/api/v1/platform/events/ack` 禁止 body 中传 `pluginId`，合法 ACK 可重复调用并返回成功。
+
+  - product_id: node_openclaw_plugin
+    name: Node OpenClaw Plugin
+    platform:
+      - nodejs
+    entry_points:
+      - path: apps/node_openclaw_plugin/src/index.ts
+        route: plugin runtime main
+    features:
+      - feature_id: node_openclaw_pull_loop
+        name: OpenClaw Pull-only 插件运行时
+        user_value: 远端插件可轮询 Bricks 平台事件并执行 ACK 与消息回写闭环。
+        entry_paths:
+          - runtime: NodeOpenClawPluginRunner
+            route_hint: apps/node_openclaw_plugin/src/pluginRunner.ts
+          - client: PlatformClient
+            route_hint: apps/node_openclaw_plugin/src/platformClient.ts
+          - state: FileStateStore
+            route_hint: apps/node_openclaw_plugin/src/stateStore.ts
+        smoke_checks:
+          - 设置 BRICKS_BASE_URL / BRICKS_PLATFORM_TOKEN / BRICKS_PLUGIN_ID 后可启动插件轮询。
+          - 非 JWT token 或 claims 不完整时插件启动应失败（JWT-only）。
+          - 插件可调用 `/api/v1/platform/events` 拉取事件并以 `X-Bricks-Plugin-Id` 发送请求。
+          - 插件 ACK body 仅包含 `cursor` 与 `ackedEventIds` 且可推进本地 cursor。
+          - 收到 `message.created` 事件后可执行 create + patch 消息回写。

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -46,7 +46,7 @@ products:
 
       - feature_id: model_settings
         name: 模型与提供商配置
-        user_value: 用户可选择可用模型并保存默认配置，并可快速复制 API URL、API Key 与小龙虾/OpenClaw 对接 Token。
+        user_value: 用户可选择可用模型并保存默认配置，并可快速复制 API URL 与 API Key。
         entry_paths:
           - screen: ModelSettingsScreen
             route_hint: apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
@@ -57,7 +57,21 @@ products:
           - 重新进入页面后配置保持一致。
           - 点击 Base URL 右侧复制按钮后可复制 API URL。
           - 点击 API Key 右侧复制按钮时，非空 key 可被复制，空值会提示不可复制。
-          - 点击 “Get Xiaolongxia Token” 后可展示 plugin/baseUrl/scopes，并复制 Token。
+
+      - feature_id: openclaw_token_settings
+        name: OpenClaw Token 配置
+        user_value: 用户可在设置页生成并复制 Openclaw Token，用于插件对接。
+        entry_paths:
+          - screen: SettingsScreen
+            route_hint: apps/mobile_chat_app/lib/features/settings/settings_screen.dart
+          - screen: OpenclawTokenSettingsScreen
+            route_hint: apps/mobile_chat_app/lib/features/settings/openclaw_token_settings_screen.dart
+          - service: LlmConfigService.fetchPlatformToken
+            route_hint: apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
+        smoke_checks:
+          - 在设置页可看到并进入 “Openclaw Token” 设置项。
+          - 点击 “Openclaw Token” 按钮后可生成 token 信息。
+          - 生成后可复制 Openclaw Token 到剪贴板。
 
       - feature_id: workspace_resources
         name: Workspace / Projects / Skills / Resources 管理

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: feature_map
 owner: bricks
-last_updated: 2026-04-14
+last_updated: 2026-04-16
 purpose: >
   为人类测试员和 AI 测试员提供产品功能清单与进入路径，作为回归测试与变更影响评估的入口索引。
 
@@ -46,7 +46,7 @@ products:
 
       - feature_id: model_settings
         name: 模型与提供商配置
-        user_value: 用户可选择可用模型并保存默认配置，并可快速复制 API URL 与 API Key。
+        user_value: 用户可选择可用模型并保存默认配置，并可快速复制 API URL、API Key 与小龙虾/OpenClaw 对接 Token。
         entry_paths:
           - screen: ModelSettingsScreen
             route_hint: apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
@@ -57,6 +57,7 @@ products:
           - 重新进入页面后配置保持一致。
           - 点击 Base URL 右侧复制按钮后可复制 API URL。
           - 点击 API Key 右侧复制按钮时，非空 key 可被复制，空值会提示不可复制。
+          - 点击 “Get Xiaolongxia Token” 后可展示 plugin/baseUrl/scopes，并复制 Token。
 
       - feature_id: workspace_resources
         name: Workspace / Projects / Skills / Resources 管理
@@ -99,14 +100,20 @@ products:
 
       - feature_id: backend_chat_llm
         name: Chat 与 LLM 调用
-        user_value: 服务端可处理聊天请求并路由到模型提供商。
+        user_value: 服务端可处理聊天请求并路由到模型提供商，并向远端小龙虾/OpenClaw 提供 pull-only 平台接口。
         entry_paths:
           - route: /api/chat
             route_hint: apps/node_backend/src/routes/chat.ts
           - route: /api/llm
             route_hint: apps/node_backend/src/routes/llm.ts
+          - route: /api/v1/platform/*
+            route_hint: apps/node_backend/src/routes/platform.ts
+          - route: /api/config/platform-token
+            route_hint: apps/node_backend/src/routes/config.ts
           - service: LlmService
             route_hint: apps/node_backend/src/llm/llm_service.ts
         smoke_checks:
           - 调用 chat 接口时返回结构化响应。
           - provider 配置缺失时给出明确错误。
+          - 使用 API Key + X-Bricks-Plugin-Id 可访问 `/api/v1/platform/events` 并获取 `nextCursor`。
+          - `/api/v1/platform/events/ack` 禁止 body 中传 `pluginId`，合法 ACK 可重复调用并返回成功。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: logic_map
 owner: bricks
-last_updated: 2026-04-10
+last_updated: 2026-04-14
 purpose: >
   为人类测试员、AI 测试员与 AI 工程师提供“功能 -> 代码/文档/关键词”映射，
   用于影响面分析、回归测试设计与遗留逻辑清理。
@@ -82,6 +82,7 @@ index:
     doc_index:
       - docs/model_settings_plan.md
       - docs/architecture.md
+      - docs/openclaw_pull_only_integration_dev_doc.md
     test_index:
       - apps/mobile_chat_app/test/model_settings_screen_test.dart
     keywords:
@@ -90,6 +91,9 @@ index:
       - is_default
       - config
       - save
+      - copy
+      - api key
+      - api url
     change_risks:
       - 字段格式变化导致保存后读取失败。
       - 后端默认模型与前端选择策略不一致。
@@ -149,6 +153,7 @@ index:
       - apps/node_backend/src/llm/providers/google_ai_studio_adapter.ts
     doc_index:
       - docs/architecture.md
+      - docs/openclaw_pull_only_integration_dev_doc.md
     test_index: []
     keywords:
       - chat

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -199,8 +199,9 @@ index:
 
 
   - feature_id: node_openclaw_pull_loop
-    capability: Node OpenClaw pull-only 事件消费与消息回写
+    capability: Node OpenClaw onboarding 配置 + pull-only 事件消费与消息回写
     code_index:
+      - apps/node_openclaw_plugin/src/openclawExtension.ts
       - apps/node_openclaw_plugin/src/index.ts
       - apps/node_openclaw_plugin/src/jwtClaims.ts
       - apps/node_openclaw_plugin/src/pluginRunner.ts
@@ -211,6 +212,7 @@ index:
       - docs/openclaw_pull_only_integration_dev_doc.md
       - docs/plugin_development_architecture.md
       - apps/node_openclaw_plugin/README.md
+      - apps/node_openclaw_plugin/openclaw.plugin.json
     test_index:
       - apps/node_openclaw_plugin/test/jwtClaims.test.ts
       - apps/node_openclaw_plugin/test/stateStore.test.ts
@@ -218,6 +220,8 @@ index:
     keywords:
       - openclaw
       - plugin
+      - onboarding
+      - configureInteractive
       - pull-only
       - events
       - ack
@@ -225,6 +229,7 @@ index:
       - messages
       - jwt
     change_risks:
+      - onboarding hook 字段名与 manifest schema 不一致会导致向导写入后校验失败。
       - cursor 持久化失败会导致重复消费或漏消费。
       - ACK 与本地去重顺序错误可能造成事件堆积或错误跳过。
       - 上游接口字段变化可能导致回写消息失败。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -94,12 +94,29 @@ index:
       - copy
       - api key
       - api url
-      - xiaolongxia token
-      - openclaw token
     change_risks:
       - 字段格式变化导致保存后读取失败。
       - 后端默认模型与前端选择策略不一致。
-      - token 颁发与平台鉴权策略不一致会导致远端插件无法连接。
+
+  - feature_id: openclaw_token_settings
+    capability: 设置页 Openclaw Token 生成与复制
+    code_index:
+      - apps/mobile_chat_app/lib/features/settings/settings_screen.dart
+      - apps/mobile_chat_app/lib/features/settings/openclaw_token_settings_screen.dart
+      - apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
+      - apps/node_backend/src/routes/config.ts
+    doc_index:
+      - docs/openclaw_pull_only_integration_dev_doc.md
+    test_index:
+      - apps/mobile_chat_app/test/openclaw_token_settings_screen_test.dart
+    keywords:
+      - settings
+      - openclaw token
+      - platform token
+      - copy
+    change_risks:
+      - 设置入口位置变化后，用户可能无法在预期页面找到 token 生成功能。
+      - token 展示与复制反馈文案不一致时，可能导致配置操作误判。
 
   - feature_id: workspace_resources
     capability: Workspace / Projects / Skills / Resources 导航

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -172,6 +172,7 @@ index:
       - apps/node_backend/src/routes/config.ts
       - apps/node_backend/src/middleware/platformAuth.ts
       - apps/node_backend/src/services/platformIntegrationService.ts
+      - apps/node_openclaw_plugin/src/pluginRunner.ts
       - apps/node_backend/src/llm/llm_service.ts
       - apps/node_backend/src/llm/providers/anthropic_adapter.ts
       - apps/node_backend/src/llm/providers/google_ai_studio_adapter.ts
@@ -180,6 +181,7 @@ index:
       - docs/openclaw_pull_only_integration_dev_doc.md
     test_index:
       - apps/node_backend/src/routes/platform.test.ts
+      - apps/node_openclaw_plugin/test/pluginRunner.test.ts
     keywords:
       - chat
       - llm
@@ -196,6 +198,7 @@ index:
       - 流式响应格式变化导致前端解析出错。
       - 平台 API key 或 scope 变更导致远端插件鉴权失败。
       - cursor 语义变化导致插件重复消费或漏消费消息事件。
+      - 平台 JWT 中 pluginId 约束变化可能导致插件隔离失效或合法请求被拒绝。
 
 
   - feature_id: node_openclaw_pull_loop

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -197,6 +197,38 @@ index:
       - 平台 API key 或 scope 变更导致远端插件鉴权失败。
       - cursor 语义变化导致插件重复消费或漏消费消息事件。
 
+
+  - feature_id: node_openclaw_pull_loop
+    capability: Node OpenClaw pull-only 事件消费与消息回写
+    code_index:
+      - apps/node_openclaw_plugin/src/index.ts
+      - apps/node_openclaw_plugin/src/jwtClaims.ts
+      - apps/node_openclaw_plugin/src/pluginRunner.ts
+      - apps/node_openclaw_plugin/src/platformClient.ts
+      - apps/node_openclaw_plugin/src/stateStore.ts
+      - apps/node_openclaw_plugin/src/types.ts
+    doc_index:
+      - docs/openclaw_pull_only_integration_dev_doc.md
+      - docs/plugin_development_architecture.md
+      - apps/node_openclaw_plugin/README.md
+    test_index:
+      - apps/node_openclaw_plugin/test/jwtClaims.test.ts
+      - apps/node_openclaw_plugin/test/stateStore.test.ts
+      - apps/node_openclaw_plugin/test/pluginRunner.test.ts
+    keywords:
+      - openclaw
+      - plugin
+      - pull-only
+      - events
+      - ack
+      - cursor
+      - messages
+      - jwt
+    change_risks:
+      - cursor 持久化失败会导致重复消费或漏消费。
+      - ACK 与本地去重顺序错误可能造成事件堆积或错误跳过。
+      - 上游接口字段变化可能导致回写消息失败。
+
 maintenance_rules:
   update_required_when:
     - 新增、删除或重命名用户可见功能入口。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: logic_map
 owner: bricks
-last_updated: 2026-04-14
+last_updated: 2026-04-16
 purpose: >
   为人类测试员、AI 测试员与 AI 工程师提供“功能 -> 代码/文档/关键词”映射，
   用于影响面分析、回归测试设计与遗留逻辑清理。
@@ -94,9 +94,12 @@ index:
       - copy
       - api key
       - api url
+      - xiaolongxia token
+      - openclaw token
     change_risks:
       - 字段格式变化导致保存后读取失败。
       - 后端默认模型与前端选择策略不一致。
+      - token 颁发与平台鉴权策略不一致会导致远端插件无法连接。
 
   - feature_id: workspace_resources
     capability: Workspace / Projects / Skills / Resources 导航
@@ -148,13 +151,18 @@ index:
     code_index:
       - apps/node_backend/src/routes/chat.ts
       - apps/node_backend/src/routes/llm.ts
+      - apps/node_backend/src/routes/platform.ts
+      - apps/node_backend/src/routes/config.ts
+      - apps/node_backend/src/middleware/platformAuth.ts
+      - apps/node_backend/src/services/platformIntegrationService.ts
       - apps/node_backend/src/llm/llm_service.ts
       - apps/node_backend/src/llm/providers/anthropic_adapter.ts
       - apps/node_backend/src/llm/providers/google_ai_studio_adapter.ts
     doc_index:
       - docs/architecture.md
       - docs/openclaw_pull_only_integration_dev_doc.md
-    test_index: []
+    test_index:
+      - apps/node_backend/src/routes/platform.test.ts
     keywords:
       - chat
       - llm
@@ -162,9 +170,15 @@ index:
       - stream
       - anthropic
       - google
+      - platform events
+      - openclaw
+      - x-bricks-plugin-id
+      - events ack
     change_risks:
       - provider 适配器接口变动导致 LLM 调用失败。
       - 流式响应格式变化导致前端解析出错。
+      - 平台 API key 或 scope 变更导致远端插件鉴权失败。
+      - cursor 语义变化导致插件重复消费或漏消费消息事件。
 
 maintenance_rules:
   update_required_when:

--- a/docs/openclaw_pull_only_integration_dev_doc.md
+++ b/docs/openclaw_pull_only_integration_dev_doc.md
@@ -211,6 +211,7 @@ Success response:
 - `cursor` is the `nextCursor` received from the latest successful `GET /events` response whose events are being acknowledged.
 - ACK is idempotent: re-sending already-acked `eventId`s must still return success.
 - Unknown `eventId`s should be ignored (no hard failure) and reported in metrics/audit logs.
+- Request body fields are `ackedEventIds` and `cursor` only.
 
 Request:
 ```json

--- a/docs/openclaw_pull_only_integration_dev_doc.md
+++ b/docs/openclaw_pull_only_integration_dev_doc.md
@@ -80,22 +80,48 @@ For multi-user Bricks workspaces, plugin should default to granular DM scoping (
 
 ---
 
-## 5. Authentication model (API key only)
+## 5. Authentication model (JWT platform token + optional static key)
 
 ### 5.1 Principle
-Only plugin->Bricks requests exist in pull-only topology. Therefore, API key bearer auth is sufficient.
+Plugin->Bricks requests use bearer auth. Current implementation supports:
+1. Preferred mode: scoped JWT platform token (`typ=platform_plugin`) issued by `GET /api/config/platform-token`
+2. Compatibility mode: static environment API key (`BRICKS_PLATFORM_API_KEY`)
+
+Security boundary:
+- JWT mode is user-scoped and plugin-scoped (`userId` + `pluginId` claim)
+- `X-Bricks-Plugin-Id` header must match JWT `pluginId` claim exactly
+- Static key mode is shared and should be treated as less granular fallback for controlled environments
 
 ### 5.2 Required headers
 All plugin calls include:
 
 ```http
-Authorization: Bearer <BRICKS_API_KEY>
+Authorization: Bearer <PLATFORM_JWT_OR_STATIC_API_KEY>
 Content-Type: application/json
 X-Bricks-Plugin-Id: <plugin_id>
 X-Bricks-Client-Version: <plugin_version>
 ```
 
-### 5.3 API key storage model (Bricks)
+### 5.3 JWT token profile (current)
+`GET /api/config/platform-token` currently returns:
+
+```json
+{
+  "token": "<jwt>",
+  "pluginId": "plugin_local_main",
+  "scopes": ["events:read", "events:ack", "messages:write", "conversations:read"],
+  "baseUrl": "https://bricks.askman.dev",
+  "expiresIn": "30d"
+}
+```
+
+JWT payload requirements:
+- `typ` must be `platform_plugin`
+- `userId` is required
+- `pluginId` is required and must match request header `X-Bricks-Plugin-Id`
+- `scopes` controls route-level authorization
+
+### 5.4 Static API key storage model (fallback recommendation)
 Recommended minimum persisted fields:
 
 ```json
@@ -117,7 +143,7 @@ Security requirements:
 - Key scoped to workspace/tenant
 - Support revoke/rotate/audit trail
 
-### 5.4 Scope profile
+### 5.5 Scope profile
 MVP minimum:
 - `events:read`
 - `events:ack`
@@ -188,7 +214,7 @@ Success response:
       "eventType": "message.created",
       "workspaceId": "ws_123",
       "conversationId": "conv_1001",
-      "rawId": "discord:channel:123/thread:456",
+      "rawId": "channel:123/thread:456",
       "occurredAt": "2026-04-14T10:00:00Z",
       "payload": {
         "messageId": "msg_u_001",
@@ -249,24 +275,24 @@ Status codes:
 - `5xx`: transient platform failure
 
 ### 7.3 `POST /api/v1/platform/messages`
-- Idempotent create by `clientToken`.
+- Creates (or idempotently reuses) a platform message.
+- Required in static-key mode: `userId`, `conversationId`, `channelId`, and one of `text`/`content`.
+- In JWT mode, `userId` may be omitted and is resolved from token payload.
+- `role` defaults to `assistant` when omitted.
 
 Request:
 ```json
 {
-  "workspaceId": "ws_123",
+  "userId": "user_01",
   "conversationId": "conv_1001",
-  "author": {
-    "type": "agent",
-    "agentId": "agent_reviewer",
-    "displayName": "Reviewer"
-  },
+  "channelId": "channel_123",
+  "threadId": "thread_456",
+  "role": "assistant",
   "clientToken": "out_001",
-  "content": {
-    "format": "markdown",
-    "text": "我先看一下这段代码的结构。"
-  },
-  "status": "streaming"
+  "text": "我先看一下这段代码的结构。",
+  "metadata": {
+    "sourceEventId": "evt_001"
+  }
 }
 ```
 
@@ -274,63 +300,64 @@ Response:
 ```json
 {
   "messageId": "msg_a_9001",
+  "conversationId": "conv_1001",
   "revision": 1
 }
 ```
 
 Status codes:
 - `200 OK`/`201 CREATED`: message created
-- `200 OK`: idempotent replay by existing `clientToken`
-- `400 BAD REQUEST`: malformed payload
+- `200 OK`: idempotent replay by existing `clientToken`/message identity
+- `400 BAD REQUEST`: malformed payload or missing required fields
 - `401 UNAUTHORIZED`: missing/invalid API key
 - `403 FORBIDDEN`: key lacks `messages:write`
-- `409 CONFLICT`: `clientToken` reused with non-equivalent payload
-- `422 UNPROCESSABLE ENTITY`: semantic validation failure
 - `429 TOO MANY REQUESTS`: rate limited
 - `5xx`: transient platform failure
 
 ### 7.4 `PATCH /api/v1/platform/messages/{messageId}`
-- `revision` must increase monotonically.
-- Reject stale updates (`<= current revision`) with `409 CONFLICT`.
-- Exactly one of `append` or `replace` must be provided; requests with both or neither are rejected with `400 BAD REQUEST`.
+- Current MVP patch shape accepts partial updates for:
+  - `text` (full text replacement)
+  - `metadata` (shallow merge over existing metadata)
+- Request must contain at least one of `text` or `metadata`, otherwise `400 BAD REQUEST`.
+- `userId` resolution follows section 7.3 rules (JWT token user is canonical).
 
-Streaming patch:
+Patch text:
 ```json
 {
-  "revision": 2,
-  "append": "\n\n发现一个明显问题：异常分支没有释放资源。",
-  "status": "streaming"
+  "userId": "user_01",
+  "text": "发现一个明显问题：异常分支没有释放资源。"
 }
 ```
 
-Completed patch:
+Patch metadata only:
 ```json
 {
-  "revision": 3,
-  "replace": "发现一个明显问题：异常分支没有释放资源，可能导致连接泄漏。",
-  "status": "completed"
+  "userId": "user_01",
+  "metadata": {
+    "handledBy": "Reviewer",
+    "sourceEventId": "evt_001"
+  }
 }
 ```
 
 Invalid patch examples (`400 BAD REQUEST`):
 ```json
-{ "revision": 4, "append": "a", "replace": "b", "status": "streaming" }
+{ "userId": "user_01" }
 ```
 ```json
-{ "revision": 4, "status": "streaming" }
+{ "text": "hello" }
 ```
-Valid examples are shown above in "Streaming patch" and "Completed patch".
 
 Status codes:
 - `200 OK`: patch applied
-- `400 BAD REQUEST`: invalid patch shape (including append/replace rule violations)
+- `400 BAD REQUEST`: invalid payload (`messageId` param/userId missing, or both text and metadata missing)
 - `401 UNAUTHORIZED`: missing/invalid API key
 - `403 FORBIDDEN`: key lacks `messages:write`
 - `404 NOT FOUND`: message does not exist
-- `409 CONFLICT`: stale or non-monotonic revision
-- `422 UNPROCESSABLE ENTITY`: semantic validation failure
 - `429 TOO MANY REQUESTS`: rate limited
 - `5xx`: transient platform failure
+
+> Future version note: revision-based `append`/`replace` streaming patch semantics are a target contract, not the currently implemented MVP route behavior.
 
 ### 7.5 `GET /api/v1/platform/conversations/resolve`
 - Converts Bricks topology object into session-grammar input for plugin mapping.
@@ -396,7 +423,8 @@ Plugin must persist:
 Use `clientToken` idempotency key.
 
 ### 11.3 Streaming updates
-Use `revision` sequencing.
+Current MVP uses full-text replace updates (`text`) via `PATCH /messages/{id}`.
+Revision sequencing is a future contract target for incremental streaming patch semantics.
 
 ### 11.4 Retry policy
 - `GET /events` timeout: immediate reconnect
@@ -410,8 +438,9 @@ Use `revision` sequencing.
 
 ### 12.0 Alignment with current Bricks implementation
 - Current backend async chat transport already uses a **single** `chat_messages` table keyed by message identity and role; this matches the "unified message storage" direction in this document.
-- Current backend does **not** yet expose the OpenClaw pull-only `platform_events`/outbox APIs described above; this document defines the target contract for that integration work.
-- During implementation, evolve the existing unified message model (do not split by source) and add delivery-event/outbox persistence as a separate concern.
+- Current backend **already exposes** MVP pull-only platform APIs: `/api/v1/platform/events`, `/api/v1/platform/events/ack`, `/api/v1/platform/messages`, `/api/v1/platform/messages/:messageId`, `/api/v1/platform/conversations/resolve`.
+- Current `/events/ack` endpoint is intentionally idempotent but does not yet persist durable ACK/outbox state; delivery-event persistence remains future work.
+- Continue evolving the existing unified message model (do not split by source) while adding delivery-event/outbox persistence as a separate concern.
 
 ### 12.1 Bricks tables
 - `conversations`

--- a/docs/openclaw_pull_only_integration_dev_doc.md
+++ b/docs/openclaw_pull_only_integration_dev_doc.md
@@ -226,6 +226,15 @@ Request:
 }
 ```
 
+Invalid request example (must be rejected with `400 BAD REQUEST`):
+```json
+{
+  "pluginId": "plugin_local_main",
+  "ackedEventIds": ["evt_001"],
+  "cursor": "cur_000124"
+}
+```
+
 Response:
 ```json
 { "ok": true }
@@ -301,6 +310,14 @@ Completed patch:
   "replace": "发现一个明显问题：异常分支没有释放资源，可能导致连接泄漏。",
   "status": "completed"
 }
+```
+
+Invalid patch examples (`400 BAD REQUEST`):
+```json
+{ "revision": 4, "append": "a", "replace": "b", "status": "streaming" }
+```
+```json
+{ "revision": 4, "status": "streaming" }
 ```
 
 Status codes:

--- a/docs/openclaw_pull_only_integration_dev_doc.md
+++ b/docs/openclaw_pull_only_integration_dev_doc.md
@@ -212,6 +212,7 @@ Success response:
 - ACK is idempotent: re-sending already-acked `eventId`s must still return success.
 - Unknown `eventId`s should be ignored (no hard failure) and reported in metrics/audit logs.
 - Request body fields are `ackedEventIds` and `cursor` only.
+- Required request header: `X-Bricks-Plugin-Id: <plugin_id>`.
 
 Request:
 ```json

--- a/docs/openclaw_pull_only_integration_dev_doc.md
+++ b/docs/openclaw_pull_only_integration_dev_doc.md
@@ -408,6 +408,11 @@ Use `revision` sequencing.
 
 ## 12. Data model recommendations
 
+### 12.0 Alignment with current Bricks implementation
+- Current backend async chat transport already uses a **single** `chat_messages` table keyed by message identity and role; this matches the "unified message storage" direction in this document.
+- Current backend does **not** yet expose the OpenClaw pull-only `platform_events`/outbox APIs described above; this document defines the target contract for that integration work.
+- During implementation, evolve the existing unified message model (do not split by source) and add delivery-event/outbox persistence as a separate concern.
+
 ### 12.1 Bricks tables
 - `conversations`
 - `messages` (single source-of-truth table for `user` / `agent` / `system` roles, including fields such as `status`, `revision`, `client_token`; do not split by message producer)

--- a/docs/openclaw_pull_only_integration_dev_doc.md
+++ b/docs/openclaw_pull_only_integration_dev_doc.md
@@ -410,8 +410,8 @@ Use `revision` sequencing.
 
 ### 12.1 Bricks tables
 - `conversations`
-- `messages`
-- `platform_events`
+- `messages` (single source-of-truth table for `user` / `agent` / `system` roles, including fields such as `status`, `revision`, `client_token`; do not split by message producer)
+- `platform_events` (or outbox-equivalent table) for plugin pull, ACK, retry, and cursor/idempotency handling
 - `conversation_bindings`
 - `api_keys`
 

--- a/docs/openclaw_pull_only_integration_dev_doc.md
+++ b/docs/openclaw_pull_only_integration_dev_doc.md
@@ -148,11 +148,35 @@ Base URL: `{BRICKS_BASE_URL}` (example: `https://bricks.askman.dev`)
 
 ## 7. Contract details
 
+### 7.0 Canonical error response
+All non-2xx responses should use the same body shape:
+
+```json
+{
+  "error": {
+    "code": "INVALID_CURSOR",
+    "message": "cursor is malformed",
+    "retryable": false
+  },
+  "requestId": "req_01JZ..."
+}
+```
+
+`code` must be stable and machine-readable. `message` is human-readable. `retryable` indicates whether automatic retry is recommended.
+
 ### 7.1 `GET /api/v1/platform/events`
 - Purpose: pull pending events.
 - Query: `cursor`, `limit`
 - Delivery: at-least-once
 - Ordering: stable per cursor window, not global exactly-once
+
+Status codes:
+- `200 OK`: events returned (possibly empty list)
+- `400 BAD REQUEST`: invalid `cursor` or `limit`
+- `401 UNAUTHORIZED`: missing/invalid API key
+- `403 FORBIDDEN`: key lacks `events:read`
+- `429 TOO MANY REQUESTS`: rate limited
+- `5xx`: transient platform failure
 
 Success response:
 ```json
@@ -182,11 +206,15 @@ Success response:
 
 ### 7.2 `POST /api/v1/platform/events/ack`
 - ACK only after plugin dedup state persisted and event enqueued into OpenClaw Core input queue.
+- Plugin identity is canonical from required header `X-Bricks-Plugin-Id`.
+- Request body must not include `pluginId`; if provided, backend should reject with `400 BAD REQUEST`.
+- `cursor` is the `nextCursor` received from the latest successful `GET /events` response whose events are being acknowledged.
+- ACK is idempotent: re-sending already-acked `eventId`s must still return success.
+- Unknown `eventId`s should be ignored (no hard failure) and reported in metrics/audit logs.
 
 Request:
 ```json
 {
-  "pluginId": "plugin_local_main",
   "ackedEventIds": ["evt_001", "evt_002"],
   "cursor": "cur_000124"
 }
@@ -196,6 +224,14 @@ Response:
 ```json
 { "ok": true }
 ```
+
+Status codes:
+- `200 OK`: ACK applied (including idempotent re-ACKs)
+- `400 BAD REQUEST`: malformed body, invalid cursor semantics, or forbidden `pluginId` body field
+- `401 UNAUTHORIZED`: missing/invalid API key
+- `403 FORBIDDEN`: key lacks `events:ack`
+- `429 TOO MANY REQUESTS`: rate limited
+- `5xx`: transient platform failure
 
 ### 7.3 `POST /api/v1/platform/messages`
 - Idempotent create by `clientToken`.
@@ -227,9 +263,23 @@ Response:
 }
 ```
 
+Status codes:
+- `200 OK`/`201 CREATED`: message created
+- `200 OK`: idempotent replay by existing `clientToken`
+- `400 BAD REQUEST`: malformed payload
+- `401 UNAUTHORIZED`: missing/invalid API key
+- `403 FORBIDDEN`: key lacks `messages:write`
+- `409 CONFLICT`: `clientToken` reused with non-equivalent payload
+- `422 UNPROCESSABLE ENTITY`: semantic validation failure
+- `429 TOO MANY REQUESTS`: rate limited
+- `5xx`: transient platform failure
+
 ### 7.4 `PATCH /api/v1/platform/messages/{messageId}`
 - `revision` must increase monotonically.
 - Reject stale updates (`<= current revision`) with `409 CONFLICT`.
+- Exactly one of `append` or `replace` is required.
+- If both are provided, return `400 BAD REQUEST`.
+- If neither is provided, return `400 BAD REQUEST`.
 
 Streaming patch:
 ```json
@@ -249,8 +299,28 @@ Completed patch:
 }
 ```
 
+Status codes:
+- `200 OK`: patch applied
+- `400 BAD REQUEST`: invalid patch shape (including append/replace rule violations)
+- `401 UNAUTHORIZED`: missing/invalid API key
+- `403 FORBIDDEN`: key lacks `messages:write`
+- `404 NOT FOUND`: message does not exist
+- `409 CONFLICT`: stale or non-monotonic revision
+- `422 UNPROCESSABLE ENTITY`: semantic validation failure
+- `429 TOO MANY REQUESTS`: rate limited
+- `5xx`: transient platform failure
+
 ### 7.5 `GET /api/v1/platform/conversations/resolve`
 - Converts Bricks topology object into session-grammar input for plugin mapping.
+
+Status codes:
+- `200 OK`: topology resolved
+- `400 BAD REQUEST`: malformed query
+- `401 UNAUTHORIZED`: missing/invalid API key
+- `403 FORBIDDEN`: key lacks `conversations:read`
+- `404 NOT FOUND`: conversation not found/inaccessible
+- `429 TOO MANY REQUESTS`: rate limited
+- `5xx`: transient platform failure
 
 ### 7.6 Optional metadata/access APIs
 - `GET /conversations/{conversationId}` for metadata
@@ -362,4 +432,3 @@ Before production rollout:
 - [ ] Revision conflict (`409`) metrics exported
 - [ ] Structured audit logs include plugin ID, key ID, workspace ID
 - [ ] End-to-end replay test validates at-least-once + dedup resilience
-

--- a/docs/openclaw_pull_only_integration_dev_doc.md
+++ b/docs/openclaw_pull_only_integration_dev_doc.md
@@ -207,7 +207,7 @@ Success response:
 ### 7.2 `POST /api/v1/platform/events/ack`
 - ACK only after plugin dedup state persisted and event enqueued into OpenClaw Core input queue.
 - Plugin identity is canonical from required header `X-Bricks-Plugin-Id`.
-- Request body must not include `pluginId`; if provided, backend should reject with `400 BAD REQUEST`.
+- Request body must not include `pluginId`; if provided, backend must reject with `400 BAD REQUEST`.
 - `cursor` is the `nextCursor` received from the latest successful `GET /events` response whose events are being acknowledged.
 - ACK is idempotent: re-sending already-acked `eventId`s must still return success.
 - Unknown `eventId`s should be ignored (no hard failure) and reported in metrics/audit logs.
@@ -319,6 +319,7 @@ Invalid patch examples (`400 BAD REQUEST`):
 ```json
 { "revision": 4, "status": "streaming" }
 ```
+Valid examples are shown above in "Streaming patch" and "Completed patch".
 
 Status codes:
 - `200 OK`: patch applied

--- a/docs/openclaw_pull_only_integration_dev_doc.md
+++ b/docs/openclaw_pull_only_integration_dev_doc.md
@@ -1,0 +1,365 @@
+# Bricks × OpenClaw Pull-Only Integration Development Document
+
+## 1. Scope and objective
+This document defines an implementation-ready backend integration contract for Bricks to support OpenClaw plugin development in **pull-only** mode.
+
+Primary objective:
+- Bricks acts as the platform system of record for conversation/message/interaction/binding events.
+- OpenClaw Plugin acts as a local adapter that pulls events from Bricks and writes agent output back to Bricks.
+- OpenClaw Core continues to own runtime semantics (loop, prompt, tool orchestration, dispatch, session internals).
+
+Out of scope:
+- Webhook push from Bricks to plugin
+- Reverse tunnel / local ingress networking
+- Re-implementing OpenClaw Core runtime responsibilities in Bricks
+
+---
+
+## 2. Architecture decision
+
+### 2.1 Topology
+- Bricks exposes HTTPS APIs.
+- Plugin makes outbound HTTPS calls to Bricks.
+- Plugin/OpenClaw local runtime exposes **no inbound HTTP endpoint**.
+
+### 2.2 Rationale
+This model eliminates inbound networking dependencies and keeps platform responsibilities centralized:
+- No public IP dependency for local plugin runtime
+- No webhook reachability requirement
+- Clear platform-consumer ownership boundary
+
+---
+
+## 3. Responsibility boundaries
+
+### 3.1 Bricks product/UI layer
+Must support:
+1. Channel/thread/DM display
+2. User and agent messages display
+3. Markdown/code block/streaming/interactions rendering
+4. User interaction submission
+5. Conversation primary-agent binding edits
+
+UI principle: user actions are persisted to Bricks backend; UI does not directly talk to OpenClaw Core.
+
+### 3.2 Bricks platform API layer
+Must provide:
+1. Durable storage for conversation/message/interaction/binding
+2. Pullable event stream API
+3. Message write-back APIs
+4. Conversation topology resolve API
+5. Optional DM metadata/access checks
+6. Event ACK, cursor, idempotency primitives
+
+### 3.3 OpenClaw plugin layer
+Must provide:
+1. Event polling loop
+2. Dedup and ACK behavior
+3. Raw topology -> OpenClaw session input translation
+4. Agent output write-back
+5. Control-plane binding_changed handling
+6. DM policy / pairing / channel-level guard checks
+
+### 3.4 OpenClaw core layer
+Keeps ownership of runtime internals:
+- Agent loop, prompt ownership/wiring, dispatch
+- Shared message tools, session-key shape, thread bookkeeping
+- Skill/tool orchestration
+- Approval lifecycle and token/context management
+- Sandbox/policy execution controls
+
+---
+
+## 4. Session model constraints
+
+### 4.1 Thread sessions
+Thread conversations must be treated as independent session inputs. Do not assume implicit inheritance of short-term parent context.
+
+### 4.2 DM sessions
+For multi-user Bricks workspaces, plugin should default to granular DM scoping (recommended: `per-channel-peer`) instead of shared global DM session behavior.
+
+---
+
+## 5. Authentication model (API key only)
+
+### 5.1 Principle
+Only plugin->Bricks requests exist in pull-only topology. Therefore, API key bearer auth is sufficient.
+
+### 5.2 Required headers
+All plugin calls include:
+
+```http
+Authorization: Bearer <BRICKS_API_KEY>
+Content-Type: application/json
+X-Bricks-Plugin-Id: <plugin_id>
+X-Bricks-Client-Version: <plugin_version>
+```
+
+### 5.3 API key storage model (Bricks)
+Recommended minimum persisted fields:
+
+```json
+{
+  "keyId": "bpk_01JZ...",
+  "keyHash": "sha256(...)",
+  "workspaceId": "ws_123",
+  "pluginId": "plugin_local_main",
+  "scopes": ["events:read", "events:ack", "messages:write", "conversations:read", "dm:check"],
+  "status": "active",
+  "createdAt": "2026-04-14T10:00:00Z",
+  "lastUsedAt": "2026-04-14T10:10:00Z"
+}
+```
+
+Security requirements:
+- Store hash only, never plaintext
+- Plaintext returned once at create time
+- Key scoped to workspace/tenant
+- Support revoke/rotate/audit trail
+
+### 5.4 Scope profile
+MVP minimum:
+- `events:read`
+- `events:ack`
+- `messages:write`
+- `conversations:read`
+
+Optional (DM safety):
+- `dm:check`
+
+---
+
+## 6. API surface
+
+Base URL: `{BRICKS_BASE_URL}` (example: `https://bricks.askman.dev`)
+
+### 6.1 MVP required APIs (minimal closed loop)
+1. `GET /api/v1/platform/events`
+2. `POST /api/v1/platform/events/ack`
+3. `POST /api/v1/platform/messages`
+4. `PATCH /api/v1/platform/messages/{messageId}`
+5. `GET /api/v1/platform/conversations/resolve`
+
+### 6.2 Optional enhancement APIs
+6. `GET /api/v1/platform/conversations/{conversationId}`
+7. `POST /api/v1/platform/dm/access-check`
+
+---
+
+## 7. Contract details
+
+### 7.1 `GET /api/v1/platform/events`
+- Purpose: pull pending events.
+- Query: `cursor`, `limit`
+- Delivery: at-least-once
+- Ordering: stable per cursor window, not global exactly-once
+
+Success response:
+```json
+{
+  "nextCursor": "cur_000124",
+  "events": [
+    {
+      "eventId": "evt_001",
+      "eventType": "message.created",
+      "workspaceId": "ws_123",
+      "conversationId": "conv_1001",
+      "rawId": "discord:channel:123/thread:456",
+      "occurredAt": "2026-04-14T10:00:00Z",
+      "payload": {
+        "messageId": "msg_u_001",
+        "sender": {
+          "userId": "user_01",
+          "displayName": "Kimi"
+        },
+        "text": "帮我解释这段代码",
+        "attachments": []
+      }
+    }
+  ]
+}
+```
+
+### 7.2 `POST /api/v1/platform/events/ack`
+- ACK only after plugin dedup state persisted and event enqueued into OpenClaw Core input queue.
+
+Request:
+```json
+{
+  "pluginId": "plugin_local_main",
+  "ackedEventIds": ["evt_001", "evt_002"],
+  "cursor": "cur_000124"
+}
+```
+
+Response:
+```json
+{ "ok": true }
+```
+
+### 7.3 `POST /api/v1/platform/messages`
+- Idempotent create by `clientToken`.
+
+Request:
+```json
+{
+  "workspaceId": "ws_123",
+  "conversationId": "conv_1001",
+  "author": {
+    "type": "agent",
+    "agentId": "agent_reviewer",
+    "displayName": "Reviewer"
+  },
+  "clientToken": "out_001",
+  "content": {
+    "format": "markdown",
+    "text": "我先看一下这段代码的结构。"
+  },
+  "status": "streaming"
+}
+```
+
+Response:
+```json
+{
+  "messageId": "msg_a_9001",
+  "revision": 1
+}
+```
+
+### 7.4 `PATCH /api/v1/platform/messages/{messageId}`
+- `revision` must increase monotonically.
+- Reject stale updates (`<= current revision`) with `409 CONFLICT`.
+
+Streaming patch:
+```json
+{
+  "revision": 2,
+  "append": "\n\n发现一个明显问题：异常分支没有释放资源。",
+  "status": "streaming"
+}
+```
+
+Completed patch:
+```json
+{
+  "revision": 3,
+  "replace": "发现一个明显问题：异常分支没有释放资源，可能导致连接泄漏。",
+  "status": "completed"
+}
+```
+
+### 7.5 `GET /api/v1/platform/conversations/resolve`
+- Converts Bricks topology object into session-grammar input for plugin mapping.
+
+### 7.6 Optional metadata/access APIs
+- `GET /conversations/{conversationId}` for metadata
+- `POST /dm/access-check` for DM security gating
+
+---
+
+## 8. Event model
+MVP event types:
+1. `message.created`
+2. `interaction.submitted`
+3. `conversation.binding_changed`
+
+Control plane vs message plane:
+- `binding_changed` is control-plane event carried by event stream.
+- Message output remains message-plane via `messages` APIs.
+
+---
+
+## 9. Plugin processing loop
+Recommended fixed loop:
+1. Poll `GET /events`
+2. Dedup by `eventId`
+3. Resolve conversation topology
+4. Translate to OpenClaw input
+5. Enqueue into core queue
+6. ACK consumed events
+7. Create output message
+8. Stream patch updates until completed
+
+---
+
+## 10. Binding update flow
+1. User changes conversation primary agent in Bricks UI.
+2. Bricks persists binding as source of truth.
+3. Bricks emits `conversation.binding_changed` event.
+4. Plugin translates to OpenClaw binding config update.
+5. Plugin applies via **`config.patch`** (not full `config.apply`) so only binding delta changes.
+
+---
+
+## 11. Error handling and idempotency
+
+### 11.1 Event consumption
+Plugin must persist:
+- processed `eventId` set
+- local cursor
+- crash-recovery replay protections
+
+### 11.2 Message creation
+Use `clientToken` idempotency key.
+
+### 11.3 Streaming updates
+Use `revision` sequencing.
+
+### 11.4 Retry policy
+- `GET /events` timeout: immediate reconnect
+- `POST /events/ack` failure: short retry; do not mark complete locally until success
+- `POST /messages` failure: retry with same `clientToken`
+- `PATCH /messages/{id}` failure: reload current local revision and retry forward
+
+---
+
+## 12. Data model recommendations
+
+### 12.1 Bricks tables
+- `conversations`
+- `messages`
+- `platform_events`
+- `conversation_bindings`
+- `api_keys`
+
+### 12.2 Plugin local state
+- `lastCursor`
+- `processedEventIds`
+- `clientToken -> messageId`
+- pending write-back retry queue
+
+---
+
+## 13. Delivery phases
+
+### Phase 1 (minimal closed loop)
+Implement required 5 APIs and only `message.created`.
+
+### Phase 2 (thread + binding)
+Add `conversation.binding_changed` handling and plugin `config.patch` sync.
+
+### Phase 3 (DM + security)
+Add optional metadata/access APIs and `dmScope=per-channel-peer` policy.
+
+---
+
+## 14. Engineering constraints
+1. Bricks message payload must not carry runtime routing directives like target agent.
+2. Plugin must not bypass OpenClaw core to build prompts.
+3. Bricks must not duplicate OpenClaw session bookkeeping logic.
+4. Binding changes must flow via control-plane events.
+5. API keys must be revocable, rotatable, auditable.
+
+---
+
+## 15. Operational checklist
+Before production rollout:
+- [ ] API key lifecycle endpoints (create/revoke/rotate/list) ready
+- [ ] Rate limiting by workspace + plugin ID in place
+- [ ] Event lag and ACK lag metrics exported
+- [ ] Message write latency metrics exported
+- [ ] Revision conflict (`409`) metrics exported
+- [ ] Structured audit logs include plugin ID, key ID, workspace ID
+- [ ] End-to-end replay test validates at-least-once + dedup resilience
+

--- a/docs/openclaw_pull_only_integration_dev_doc.md
+++ b/docs/openclaw_pull_only_integration_dev_doc.md
@@ -212,7 +212,11 @@ Success response:
 - ACK is idempotent: re-sending already-acked `eventId`s must still return success.
 - Unknown `eventId`s should be ignored (no hard failure) and reported in metrics/audit logs.
 - Request body fields are `ackedEventIds` and `cursor` only.
-- Required request header: `X-Bricks-Plugin-Id: <plugin_id>`.
+
+Required header:
+```http
+X-Bricks-Plugin-Id: <plugin_id>
+```
 
 Request:
 ```json
@@ -279,9 +283,7 @@ Status codes:
 ### 7.4 `PATCH /api/v1/platform/messages/{messageId}`
 - `revision` must increase monotonically.
 - Reject stale updates (`<= current revision`) with `409 CONFLICT`.
-- Exactly one of `append` or `replace` is required.
-- If both are provided, return `400 BAD REQUEST`.
-- If neither is provided, return `400 BAD REQUEST`.
+- Exactly one of `append` or `replace` must be provided; requests with both or neither are rejected with `400 BAD REQUEST`.
 
 Streaming patch:
 ```json

--- a/docs/openclaw_pull_only_integration_dev_doc.md
+++ b/docs/openclaw_pull_only_integration_dev_doc.md
@@ -345,7 +345,7 @@ Invalid patch examples (`400 BAD REQUEST`):
 { "userId": "user_01" }
 ```
 ```json
-{ "text": "hello" }
+{ "userId": "user_01", "metadata": [] }
 ```
 
 Status codes:

--- a/docs/plans/2026-04-14-01-30-UTC-openclaw-plugin-platform-api-and-settings-copy.md
+++ b/docs/plans/2026-04-14-01-30-UTC-openclaw-plugin-platform-api-and-settings-copy.md
@@ -1,0 +1,34 @@
+# Background
+Bricks needs a production-oriented backend interface contract to support OpenClaw plugin development under a pull-only topology. The current design draft captures architectural intent, but it should be hardened into an implementation-ready development document with explicit API contracts, security boundaries, idempotency semantics, and phased delivery guidance. In parallel, the Settings experience in the mobile app should support one-click copy actions for API URL and API key values to reduce operator friction during plugin setup and debugging.
+
+# Goals
+1. Produce an improved, implementation-ready Bricks × OpenClaw pull-only integration development document.
+2. Define clear backend API boundaries (MVP-required vs optional), auth model, delivery semantics, and operational constraints.
+3. Add copy actions in settings for API URL and API key.
+4. Add/adjust automated tests for the new settings copy actions.
+5. Update code maps if feature/doc index or behavior coverage changes.
+
+# Implementation Plan (phased)
+## Phase 1: Documentation hardening
+- Create a dedicated integration doc under `docs/` for Bricks platform API + OpenClaw plugin pull-only integration.
+- Keep the architecture boundary explicit: Bricks platform vs plugin adapter vs OpenClaw core.
+- Add a normative API contract section with request/response shape, error model, idempotency rules, and status code expectations.
+- Add implementation sequence, rollout strategy, observability, and security checklist.
+
+## Phase 2: Settings copy UX
+- Update `ModelSettingsScreen` to support copying Base URL (API URL) and API key to clipboard.
+- Provide user feedback with snackbars for success/empty value cases.
+- Preserve existing API key visibility toggle behavior.
+
+## Phase 3: Validation and code-map sync
+- Run repository bootstrap command before Flutter checks: `./tools/init_dev_env.sh`.
+- Run focused widget tests for settings behavior.
+- Update `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` to reflect the new settings behavior and new integration document indexes.
+
+# Acceptance Criteria
+1. A new OpenClaw pull-only integration development document exists under `docs/` and is implementation-ready for backend/API work.
+2. Model settings UI exposes a copy action for API URL and a copy action for API key.
+3. Tapping copy actions writes expected clipboard values when present and displays user feedback.
+4. Existing settings interactions (save/delete/toggle visibility) remain functional.
+5. Relevant tests pass (at minimum: `flutter test test/model_settings_screen_test.dart` from `apps/mobile_chat_app`).
+6. Code maps are updated to include behavior/doc-index changes introduced by this task.

--- a/docs/plans/2026-04-14-03-31-UTC-address-pr-review-comments.md
+++ b/docs/plans/2026-04-14-03-31-UTC-address-pr-review-comments.md
@@ -1,5 +1,5 @@
 - [x] Review PR feedback threads and current implementation details in docs/UI tests
 - [x] Update OpenClaw integration doc to clarify PATCH semantics, ACK semantics, canonical plugin identity, and error schema/status matrices
 - [x] Add widget test for successful non-empty API key copy flow
-- [ ] Run bootstrap and targeted Flutter tests for modified areas
+- [x] Run bootstrap and targeted Flutter tests for modified areas
 - [ ] Run final validation (including parallel validation), capture screenshot, and reply to the new PR comment

--- a/docs/plans/2026-04-14-03-31-UTC-address-pr-review-comments.md
+++ b/docs/plans/2026-04-14-03-31-UTC-address-pr-review-comments.md
@@ -1,0 +1,5 @@
+- [x] Review PR feedback threads and current implementation details in docs/UI tests
+- [x] Update OpenClaw integration doc to clarify PATCH semantics, ACK semantics, canonical plugin identity, and error schema/status matrices
+- [x] Add widget test for successful non-empty API key copy flow
+- [ ] Run bootstrap and targeted Flutter tests for modified areas
+- [ ] Run final validation (including parallel validation), capture screenshot, and reply to the new PR comment

--- a/docs/plans/2026-04-15-07-21-UTC-comment-followup-unified-messages-events.md
+++ b/docs/plans/2026-04-15-07-21-UTC-comment-followup-unified-messages-events.md
@@ -1,0 +1,5 @@
+- [x] Review new PR comments and decide which need action/reply
+- [x] Confirm current CI workflow status for this PR branch
+- [x] Update integration doc to explicitly state unified messages storage + separate events/outbox
+- [x] Validate documentation-only change and run final review validation
+- [ ] Reply to actionable PR comment with commit hash and screenshot link

--- a/docs/plans/2026-04-15-16-06-UTC-implementation-doc-alignment-check.md
+++ b/docs/plans/2026-04-15-16-06-UTC-implementation-doc-alignment-check.md
@@ -1,0 +1,18 @@
+## Background
+Reviewer feedback requested checking current code implementation and ensuring the OpenClaw pull-only integration document stays aligned with actual backend behavior and boundaries.
+
+## Goals
+1. Verify whether current backend storage patterns conflict with the integration document.
+2. Update the document where needed so it clearly distinguishes current implementation status vs target OpenClaw contract.
+3. Keep changes minimal and scoped to the feedback.
+
+## Implementation Plan (phased)
+- [x] Inspect current backend chat storage schema and transport services.
+- [x] Compare current implementation with the OpenClaw integration document data-model guidance.
+- [x] Update `docs/openclaw_pull_only_integration_dev_doc.md` with explicit implementation-alignment notes.
+- [ ] Validate changed docs and reply on PR thread with commit reference.
+
+## Acceptance Criteria
+- The document explicitly states that message storage remains unified (not split by message source).
+- The document explicitly states that event/outbox persistence is an independent concern and currently a target integration contract.
+- PR thread receives a concise follow-up with the commit hash that contains the alignment update.

--- a/docs/plans/2026-04-16-05-00-UTC-openclaw-gap-audit-and-token-chain.md
+++ b/docs/plans/2026-04-16-05-00-UTC-openclaw-gap-audit-and-token-chain.md
@@ -1,0 +1,29 @@
+# OpenClaw Gap Audit and Token Chain Validation (Consolidated)
+
+## Background
+The previous iteration produced multiple short plan files and partial implementation updates. This consolidated document merges the current review context and implementation goals into a single artifact.
+
+## Goals
+1. Compare target requirements from post-main docs with current implementation status.
+2. Close critical integration gaps for remote OpenClaw/小龙虾 token flow.
+3. Ensure the user journey is end-to-end: generate token in Settings -> configure external server -> external server connects back and sends messages.
+
+## Implementation Plan (phased)
+### Phase 1: Gap audit
+- Verify target vs implementation for pull-only APIs and auth model.
+- Confirm whether Settings currently exposes OpenClaw token issuance.
+
+### Phase 2: Gap closure
+- Add backend token-issuance endpoint for authenticated users.
+- Support JWT platform tokens in platform auth middleware.
+- Wire Settings UI to request, show, and copy the OpenClaw token bundle.
+
+### Phase 3: Validation
+- Add/extend automated tests for token retrieval and copy behavior.
+- Verify backend type-check and platform route tests.
+
+## Acceptance Criteria
+- Settings page can fetch and copy a dedicated OpenClaw token.
+- External service can use that token with `X-Bricks-Plugin-Id` against `/api/v1/platform/*`.
+- Platform middleware accepts scoped JWT tokens and enforces plugin identity constraints.
+- Consolidated planning is captured in one markdown file for this iteration.

--- a/docs/plans/2026-04-16-08-47-UTC-move-openclaw-token-to-settings-item.md
+++ b/docs/plans/2026-04-16-08-47-UTC-move-openclaw-token-to-settings-item.md
@@ -1,0 +1,20 @@
+## Background
+The PR feedback requests moving the token-generation action out of Model Settings into the top-level Settings page as a dedicated settings item, and renaming the button text to "Openclaw Token".
+
+## Goals
+1. Remove token-generation UI from Model Settings.
+2. Add a dedicated "Openclaw Token" settings entry in Settings.
+3. Keep token generation/copy behavior working with updated naming.
+
+## Implementation Plan (phased)
+- [x] Locate existing token generation implementation and related widget tests.
+- [x] Move token UI/logic from `ModelSettingsScreen` into a dedicated settings flow.
+- [x] Add a new settings list item in `SettingsScreen` that navigates to Openclaw token UI.
+- [x] Update and add targeted widget tests for the new location and label.
+- [x] Run targeted Flutter tests and finalize.
+
+## Acceptance Criteria
+- "Get Xiaolongxia Token" no longer appears in Model Settings.
+- Settings page contains a new "Openclaw Token" item.
+- Entering that item allows generating a token, viewing token metadata, and copying the token.
+- Widget tests cover the new settings entry and token generation/copy flow.

--- a/docs/plans/2026-04-16-10-51-UTC-node-openclaw-plugin-implementation.md
+++ b/docs/plans/2026-04-16-10-51-UTC-node-openclaw-plugin-implementation.md
@@ -1,0 +1,33 @@
+# Background
+用户希望“根据文档实现 node_openclaw_plugin”。仓库当前已具备 Bricks 平台侧 pull-only API（`/api/v1/platform/*`）与 token 签发能力，但尚无独立的 Node.js 插件示例/运行时来执行文档中的事件拉取、ACK、消息写回闭环。
+
+# Goals
+- 新增 `apps/node_openclaw_plugin`，提供最小可运行的 Node.js/TypeScript 插件实现。
+- 按文档实现 pull-only 主循环：拉取事件、去重处理、ACK、消息回写。
+- 提供环境变量与运行说明，便于本地联调。
+- 增加基础单测，覆盖关键状态持久化与处理逻辑。
+- 同步更新代码地图索引，确保新功能可被测试与 AI 检索。
+
+# Implementation Plan (phased)
+## Phase 1: 项目骨架与客户端
+1. 创建 `apps/node_openclaw_plugin` 包（`package.json`、`tsconfig.json`、`src/`）。
+2. 实现平台 API 客户端：`events` 拉取、`events/ack`、`messages` 创建/更新、`conversations/resolve`。
+3. 定义插件内部类型与错误处理（标准化 HTTP 异常）。
+
+## Phase 2: 事件处理与状态持久化
+1. 实现文件状态仓库（`cursor`、`processedEventIds`、`clientToken->messageId` 映射）。
+2. 实现插件运行器：轮询、按 `eventId` 去重、按批 ACK、失败重试边界。
+3. 为 `message.created` 事件实现示例回写逻辑（create + patch）。
+4. 为 `conversation.binding_changed` 增加日志处理分支（MVP noop）。
+
+## Phase 3: 文档、测试与代码地图
+1. 添加插件目录 README（环境变量、运行命令、行为说明）。
+2. 编写并运行单测（状态仓库/处理流程）。
+3. 更新 `docs/code_maps/feature_map.yaml` 与 `docs/code_maps/logic_map.yaml`，纳入新插件功能索引。
+
+# Acceptance Criteria
+- 在 `apps/node_openclaw_plugin` 下可执行 `npm run build`、`npm run test` 并通过。
+- 插件主循环可根据环境变量连接 Bricks API，执行“pull -> process -> ack -> writeback”流程。
+- ACK 请求体不包含 `pluginId`，并使用请求头 `X-Bricks-Plugin-Id`。
+- 本地状态可持久化并在重启后继续使用 cursor 与去重集合。
+- 代码地图已更新，包含 `node_openclaw_plugin` 的入口、代码索引与回归风险。

--- a/docs/plans/2026-04-16-12-00-UTC-branch-db-diff-analysis.md
+++ b/docs/plans/2026-04-16-12-00-UTC-branch-db-diff-analysis.md
@@ -1,0 +1,21 @@
+# Branch vs main database delta analysis plan
+
+## Background
+A request was made to analyze what database-related changes this working branch introduced relative to `main`.
+In this container snapshot, only the `work` local branch exists, so analysis relies on commit inspection and diffs against nearby merge-base candidates.
+
+## Goals
+- Identify whether schema/migration files changed on this branch.
+- Identify whether query behavior changed without schema changes.
+- Produce a concise, evidence-based summary.
+
+## Implementation Plan (phased)
+1. Inspect available local branches and commit graph to determine compare strategy.
+2. Check for changed files under database-related paths (`apps/node_backend/src/db/**`) in branch commits.
+3. Review backend service diffs for SQL/query-level behavioral changes.
+4. Summarize findings and explicitly call out constraints (missing local `main` ref).
+
+## Acceptance Criteria
+- The response clearly states whether any new migration/schema changes exist.
+- If no schema changes exist, query-level data-access changes (if any) are listed.
+- The response includes exact commands used and file citations.

--- a/docs/plans/2026-04-16-12-20-UTC-api-feature-db-impact-recheck.md
+++ b/docs/plans/2026-04-16-12-20-UTC-api-feature-db-impact-recheck.md
@@ -1,0 +1,20 @@
+# API feature database impact re-check plan
+
+## Background
+The branch introduced platform API capabilities. We need to verify whether the earlier claim of "no database changes" is fully accurate.
+
+## Goals
+- Distinguish schema/migration changes from data-access/query behavior changes.
+- Verify changed backend files since the presumed base commit used in prior analysis.
+- Produce a correction-ready summary.
+
+## Implementation Plan (phased)
+1. Diff backend files between `5e7d966` and `HEAD` to isolate API-feature changes.
+2. Diff database migration path (`apps/node_backend/src/db/**`) over the same range.
+3. Inspect changed service code for SQL reads/writes against existing tables.
+4. Summarize as: schema impact vs behavior impact.
+
+## Acceptance Criteria
+- Explicitly states whether new migrations/schema files were added.
+- Explicitly states whether API changes read/write database tables.
+- Includes concrete command evidence and file citations.

--- a/docs/plans/2026-04-16-12-40-UTC-main-worktree-feature-logic-review.md
+++ b/docs/plans/2026-04-16-12-40-UTC-main-worktree-feature-logic-review.md
@@ -1,0 +1,21 @@
+# Main worktree comparison review plan (feature-logic oriented)
+
+## Background
+The request is to perform code review against the "main worktree" and summarize logic per changed feature.
+In this container snapshot, no separate `main` worktree exists, so we compare against commit `5e7d966` as the closest available main-line baseline.
+
+## Goals
+- Group code changes by feature capability rather than file list only.
+- Explain endpoint and UI behavior flows with security and data-access implications.
+- Provide a review-ready summary with evidence references.
+
+## Implementation Plan (phased)
+1. Enumerate changed files in `5e7d966..HEAD` and cluster by backend/mobile/test features.
+2. Review platform API auth, routing, and service logic to map request → validation → DB access → response.
+3. Review mobile settings flow for token generation/display/copy interactions.
+4. Cross-check tests that validate new logic and identify untested risk edges.
+
+## Acceptance Criteria
+- Each changed feature has a concise logic description.
+- Security boundary (auth + scopes + userId scoping) is explicitly described.
+- Database impact is explicitly separated into schema vs query/write behavior.

--- a/docs/plans/2026-04-16-13-00-UTC-plugin-development-architecture-doc.md
+++ b/docs/plans/2026-04-16-13-00-UTC-plugin-development-architecture-doc.md
@@ -1,0 +1,20 @@
+# Plugin development architecture document plan
+
+## Background
+A plugin architecture document is requested, and it must clearly show both repository code structure and practical usage.
+
+## Goals
+- Provide a readable architecture document for plugin developers.
+- Explain where backend auth/routes/services and mobile token UX live in code.
+- Include setup, auth, endpoint usage, and extension guidance.
+
+## Implementation Plan (phased)
+1. Extract plugin-related modules and flows from current backend/mobile code.
+2. Write an architecture document with code tree, request flow, and security boundaries.
+3. Add step-by-step usage examples for token issuance and platform API calls.
+4. Add extension checklist and troubleshooting notes for implementation teams.
+
+## Acceptance Criteria
+- Document includes explicit code structure mapping (path-level).
+- Document includes end-to-end usage steps with example requests.
+- Document is actionable for new plugin developers without reading all source code first.

--- a/docs/plans/2026-04-16-16-00-UTC-node-openclaw-plugin-jwt-hardening.md
+++ b/docs/plans/2026-04-16-16-00-UTC-node-openclaw-plugin-jwt-hardening.md
@@ -1,0 +1,30 @@
+# Background
+用户反馈上一版 `node_openclaw_plugin` 与目标不一致：需要明确该实现是用于 OpenClaw 对接的插件运行时（而非文档描述中的宽泛 adapter 表述），并且需要在代码层面真正收敛到 JWT token 路径，避免“文档改了但逻辑仍保留静态 key 兼容”的遗留错误资产。
+
+# Goals
+- 将 `node_openclaw_plugin` 的运行前校验与调用语义收敛为 JWT-only。
+- 修复当前插件与后端平台接口字段不一致导致的消息 patch 失效问题。
+- 修复 ACK 与本地状态持久化顺序问题，避免 ACK 成功但本地状态未落盘。
+- 同步更新 README 与架构文档，消除“adapter/bridge”歧义与静态 key 残留描述。
+
+# Implementation Plan (phased)
+## Phase 1: JWT-only 运行时约束
+1. 新增 JWT claims 解析与基础校验逻辑（typ/pluginId/userId/exp）。
+2. 在启动配置加载阶段强制校验 token，失败直接退出。
+3. 在运行时使用 token userId 执行消息过滤（避免自触发回环）。
+
+## Phase 2: 协议对齐与可靠性修复
+1. 将消息 patch 字段调整为后端当前可识别的 `text`/`metadata`。
+2. 重构 ACK 流程：先持久化 pending ACK，再发送 ACK，成功后提交 cursor。
+3. 为 pending ACK 增加重试入口，确保崩溃恢复后可继续推进 cursor。
+
+## Phase 3: 文档与测试收口
+1. 更新 `apps/node_openclaw_plugin/README.md`：明确 OpenClaw 插件运行时 + JWT-only。
+2. 更新 `docs/plugin_development_architecture.md` 代码结构，纳入新插件目录。
+3. 增加测试覆盖 JWT claims 校验与状态仓库新字段兼容。
+
+# Acceptance Criteria
+- 插件启动时若 token 非合法 JWT claims（缺 typ/pluginId/userId 或过期）会直接失败。
+- 插件向 `PATCH /api/v1/platform/messages/:id` 发送后端可识别字段并能更新文本。
+- ACK 流程具备 pending 持久化，崩溃恢复后可继续 ACK 并推进 cursor。
+- README 不再声明静态 key 支持，且语义明确为 OpenClaw 插件运行时。

--- a/docs/plans/2026-04-16-22-15-UTC-openclaw-onboarding-enable.md
+++ b/docs/plans/2026-04-16-22-15-UTC-openclaw-onboarding-enable.md
@@ -1,0 +1,29 @@
+# Background
+`apps/node_openclaw_plugin` 目前提供的是 pull-only 运行时示例，但尚未具备 OpenClaw 插件“安装后可在 onboarding/configure 向导中交互写入 channel 配置”的能力。用户希望 channel id 使用 `dev-askman-bricks`，并在配置过程中提示输入 `BRICKS_PLATFORM_TOKEN` 等必填参数，自动写入 `channels.dev-askman-bricks`。
+
+# Goals
+- 为 `apps/node_openclaw_plugin` 增加可被 OpenClaw 识别的插件元数据（manifest + package metadata）。
+- 增加 channel onboarding hook（`configureInteractive`）以提示用户输入并返回配置。
+- 在 README 中补充“子目录安装 + onboarding 配置”步骤，便于用户把说明交给 AI 自动执行。
+- 同步代码地图索引，反映新增 onboarding 能力与风险点。
+
+# Implementation Plan (phased)
+## Phase 1: 插件清单与安装发现元数据
+1. 新增 `openclaw.plugin.json`，声明 `channelConfigs.dev-askman-bricks` schema 与 `uiHints`。
+2. 在 `package.json` 中补充 `openclaw.extensions/openclaw.channel/openclaw.install` 元数据，支持子目录与 npm 安装引导。
+
+## Phase 2: onboarding 交互配置能力
+1. 新增 OpenClaw 插件入口文件，导出带 `onboarding.configureInteractive(ctx)` 的插件对象。
+2. 在 hook 中通过 `ctx.prompter.input` 询问 `BRICKS_BASE_URL`、`BRICKS_PLUGIN_ID`、`BRICKS_PLATFORM_TOKEN`。
+3. 返回 `{ cfg, accountId }` 以让 OpenClaw 自动写入 `channels.dev-askman-bricks`。
+
+## Phase 3: 文档、测试与代码地图
+1. 更新 `apps/node_openclaw_plugin/README.md`，写清子目录安装、onboard/configure 流程、非 install lifecycle 限制。
+2. 运行 TypeScript 构建与测试检查。
+3. 更新 `docs/code_maps/feature_map.yaml` 与 `docs/code_maps/logic_map.yaml`。
+
+# Acceptance Criteria
+- `apps/node_openclaw_plugin` 包含可通过 OpenClaw 发现的 `openclaw.plugin.json` 与 `openclaw.extensions` 元数据。
+- 安装插件后执行 onboarding/configure 时，向导可提示用户输入 token/base URL/plugin id，并将配置写入 `channels.dev-askman-bricks`。
+- README 明确说明子目录安装步骤与配置命令。
+- 代码地图已覆盖 onboarding 入口与回归风险。

--- a/docs/plans/2026-04-17-02-22-UTC-address-pr-review-followups.md
+++ b/docs/plans/2026-04-17-02-22-UTC-address-pr-review-followups.md
@@ -1,0 +1,22 @@
+## Background
+Recent PR review comments identified contract drift between the OpenClaw integration document and current backend implementation, plus two code issues: insufficient JWT plugin isolation in platform auth middleware and plugin-side event filtering that drops valid user messages.
+
+## Goals
+1. Align integration documentation to the currently implemented API/auth behavior.
+2. Enforce strict plugin isolation for JWT platform tokens.
+3. Ensure plugin event filtering does not skip valid user-origin events.
+4. Keep related tests and code maps synchronized.
+
+## Implementation Plan (phased)
+- [x] Inspect review comments, current backend/plugin implementation, and impacted docs/tests.
+- [x] Update integration doc sections for auth model, PATCH contract shape, rawId examples, and current implementation alignment.
+- [x] Tighten platform JWT validation to require pluginId claim and header equality.
+- [x] Adjust OpenClaw plugin event filter to avoid dropping same-user message.created events.
+- [x] Update/add targeted backend and plugin tests for new auth/filtering behavior.
+- [x] Run targeted tests and finalize.
+
+## Acceptance Criteria
+- Integration doc reflects current supported auth modes (JWT primary + optional static key fallback) and current MVP message patch contract.
+- Middleware rejects platform JWT tokens missing pluginId claim, and still rejects pluginId mismatches.
+- Plugin processes message.created events from user senders even when sender.userId equals token userId, while still ignoring assistant/system events.
+- Targeted tests pass in `apps/node_backend` and `apps/node_openclaw_plugin`.

--- a/docs/plans/2026-04-17-05-52-UTC-openclaw-channel-plugin-conversion.md
+++ b/docs/plans/2026-04-17-05-52-UTC-openclaw-channel-plugin-conversion.md
@@ -1,0 +1,29 @@
+# Background
+`apps/node_openclaw_plugin` currently exposes OpenClaw package metadata and onboarding prompts, but OpenClaw still treats it like a generic plugin instead of a true channel plugin. That leaves `channels.dev-askman-bricks.*` invalid in `openclaw config set`, which blocks narrow channel-only configuration and makes the metadata/runtime contract inconsistent.
+
+# Goals
+- Make `dev-askman-bricks` a real OpenClaw channel from manifest, package metadata, and runtime registration perspectives.
+- Keep the existing Bricks pull-only standalone runner intact.
+- Restore the intended config surface so `channels.dev-askman-bricks.*` is valid.
+- Update targeted docs/tests so the new channel contract is explicit and regression-resistant.
+
+# Implementation Plan (phased)
+## Phase 1: Channel contract alignment
+1. Update `apps/node_openclaw_plugin/openclaw.plugin.json` to declare channel ownership (`kind`, `channels`) while preserving `channelConfigs`.
+2. Add/adjust package metadata (`openclaw.setupEntry` if needed) so setup/configure surfaces can load the plugin as a channel.
+
+## Phase 2: Minimal native channel runtime
+1. Replace the current onboarding-only extension entry with a real channel entry that calls `api.registerChannel({ plugin })`.
+2. Define the smallest viable channel plugin object: metadata, config schema, and setup/config wiring for `channels.dev-askman-bricks`.
+3. Add a lightweight setup-only entry for setup/configure flows.
+
+## Phase 3: Verification and docs
+1. Update `apps/node_openclaw_plugin/README.md` to document the channel config path and command flow.
+2. Update tests to cover channel registration/config wiring instead of the old onboarding-only object shape.
+3. Run package build/tests and local OpenClaw verification, including `openclaw config set channels.dev-askman-bricks.*`.
+
+# Acceptance Criteria
+- OpenClaw accepts `channels.dev-askman-bricks.*` writes for the Bricks plugin.
+- `openclaw plugins inspect dev-askman-bricks` shows the plugin as a channel-capability plugin rather than a generic non-capability plugin.
+- `apps/node_openclaw_plugin` build/test/type-check continue to pass.
+- The README explains how to configure Bricks via the channel config path.

--- a/docs/plans/2026-04-17-07-29-UTC-openclaw-router-default-plan.md
+++ b/docs/plans/2026-04-17-07-29-UTC-openclaw-router-default-plan.md
@@ -1,0 +1,65 @@
+# Problem
+Add a per-scope message router for Bricks chat so each channel and thread can choose between:
+- `default`: messages are handled inside Bricks by `/api/chat/respond` and `generateWithUserConfig(...)`
+- `openclaw`: user messages are handed off asynchronously through the Bricks platform/OpenClaw plugin path, and plugin-side updates flow back into Bricks UI
+
+The current codebase does not persist channel/thread settings yet. Chat scopes are inferred from existing traffic, and the mobile UI still assumes `/api/chat/respond` returns assistant text immediately.
+
+# Proposed approach
+## 1. Persist scope router settings
+- Add a backend persistence model for scope settings, recommended as a new `chat_scope_settings` table keyed by `(user_id, channel_id, thread_id nullable)`.
+- Store a `router` enum/string with allowed values `default` and `openclaw`.
+- Resolve the effective router as:
+  - thread-level override
+  - else channel-level setting
+  - else implicit `default`
+- Extend chat scope APIs so the mobile app can fetch and update both channel-level and thread-level router settings.
+
+## 2. Branch backend dispatch by effective router
+- Keep `/api/chat/respond` as the main authenticated entrypoint for app-originated sends.
+- For `default`, preserve the existing synchronous flow:
+  - accept task
+  - persist the user message
+  - call `generateWithUserConfig(...)`
+  - persist the assistant message
+  - return assistant text immediately
+- For `openclaw`, change the flow to async handoff:
+  - accept task
+  - persist the user message
+  - skip internal LLM generation
+  - return an accepted/pending response shape that the UI can track
+  - let the OpenClaw plugin pull the new user message from the platform events API and write back assistant updates through `/api/v1/platform/messages`
+  - if the user's plugin/token is not currently active, keep the message pending instead of falling back to `default`
+
+## 3. Tighten the platform event bridge
+- Filter platform events so only eligible user-originated messages from `openclaw`-routed scopes are emitted to plugins.
+- Prevent replay/echo loops for plugin-authored assistant messages and platform patch updates.
+- Preserve conversation resolution through the existing `(channelId, threadId, sessionId)` mapping.
+
+## 4. Update the mobile chat UX
+- Add router controls for channels and threads in the chat UI/state managed from `chat_screen.dart`.
+- Hydrate scope settings from backend instead of treating channels/threads as traffic-derived only.
+- Keep current behavior for `default`.
+- For `openclaw`, stop assuming an immediate assistant reply:
+  - show dispatched/pending task state
+  - rely on existing chat sync/history updates to render plugin-created assistant messages when they arrive
+  - keep messages pending while OpenClaw is unavailable rather than silently rerouting them
+
+## 5. Validate end to end
+- Backend tests for router resolution, new scope settings APIs, `/api/chat/respond` branching, and platform event filtering.
+- Flutter tests for effective-router resolution and async/pending message UX.
+- Plugin tests for event handling assumptions if server-side filtering changes.
+- Run the existing package build/test commands for touched apps.
+
+# Todos
+1. Add router persistence and scope settings APIs in the backend.
+2. Branch `/api/chat/respond` into synchronous `default` handling and asynchronous `openclaw` handoff.
+3. Filter platform events and writeback behavior so only OpenClaw-routed user messages are exported and plugin updates do not loop.
+4. Add channel/thread router controls and async OpenClaw task handling in the Flutter chat UI.
+5. Add/update tests and run repository checks for the touched packages.
+
+# Notes
+- Current scope discovery is traffic-derived via `/api/chat/scopes`; there is no persisted channel/thread settings model yet.
+- `ChatHistoryApiService.respond()` and `chat_screen.dart` currently expect immediate assistant text, so OpenClaw requires a contract/UI change rather than a pure config switch.
+- Recommended precedence: thread router overrides channel router.
+- Confirmed behavior: if a scope is set to `openclaw` and the local plugin/token is not currently available, Bricks should still accept the message and leave it pending until OpenClaw becomes available. There should be no silent fallback to `default`.

--- a/docs/plugin_development_architecture.md
+++ b/docs/plugin_development_architecture.md
@@ -59,6 +59,10 @@ apps/mobile_chat_app/test/
 1. **静态 Key 模式**
    - `Authorization: Bearer <BRICKS_PLATFORM_API_KEY>`
    - 适合内网/固定服务对接
+   - ⚠️ **安全限制**：静态 Key 模式不携带用户身份（`platformUserId` 为空），导致：
+     - `/events` 和 `/conversations/resolve` 查询不做用户过滤
+     - `/messages` 写入依赖 body 中的 `userId` 字段（可任意传入）
+   - **仅适合单租户/开发/内部部署场景，不得用于多用户生产环境**
 
 2. **JWT 模式（推荐）**
    - 通过 `issuePlatformAccessToken()` 签发 `typ=platform_plugin` 的 token
@@ -124,17 +128,24 @@ Scope 控制：
 
 ## 5. 插件开发使用方法（Step-by-step）
 
-## Step 1：准备环境变量（后端）
+### Step 1：准备环境变量（后端）
 
-至少需要：
+**必须设置（至少其中一项）：**
 
-- `JWT_SECRET`（JWT 模式必需）
-- `BRICKS_PLATFORM_API_KEY`（静态 Key 模式可选）
-- `BRICKS_PLATFORM_API_SCOPES`（默认 scope 列表）
-- `BRICKS_PLATFORM_DEFAULT_PLUGIN_ID`（默认插件 ID）
-- `BRICKS_PLATFORM_BASE_URL`（返回给客户端的推荐访问地址）
+| 变量 | 是否必需 | 说明 |
+|---|---|---|
+| `JWT_SECRET` | JWT 模式必需 | 用于签发和验证 platform JWT token |
+| `BRICKS_PLATFORM_API_KEY` | 静态 Key 模式必需 | 静态共享密钥；JWT 模式下可不设置 |
 
-## Step 2：获取插件 Token
+**可选变量：**
+
+| 变量 | 默认/回退 | 说明 |
+|---|---|---|
+| `BRICKS_PLATFORM_API_SCOPES` | 无默认（服务内写死） | 逗号分隔的默认 scope 列表 |
+| `BRICKS_PLATFORM_DEFAULT_PLUGIN_ID` | 无默认 | 不传 `pluginId` 参数时使用的默认值 |
+| `BRICKS_PLATFORM_BASE_URL` | 回退到 `API_BASE_URL`，再回退为空字符串 | 返回给客户端的推荐访问地址；如果两个变量都未设置，`baseUrl` 字段将返回空字符串，移动端同样会本地回退处理 |
+
+### Step 2：获取插件 Token
 
 ### 方式 A：通过 App 设置页获取（推荐给人工调试）
 
@@ -164,7 +175,7 @@ Authorization: Bearer <user_jwt>
 }
 ```
 
-## Step 3：插件侧调用平台 API
+### Step 3：插件侧调用平台 API
 
 所有请求必须携带：
 

--- a/docs/plugin_development_architecture.md
+++ b/docs/plugin_development_architecture.md
@@ -1,0 +1,243 @@
+# 插件开发架构文档（Platform Plugin Architecture）
+
+> 面向 OpenClaw / 小龙虾 等外部插件对接方。
+> 本文档聚焦：**代码结构** + **使用方法**。
+
+## 1. 架构目标
+
+当前仓库的插件能力是“平台 API 层 + 业务服务层 + 移动端发 Token 辅助”的组合：
+
+- 后端提供统一的插件 API 前缀：`/api/v1/platform/*`
+- 插件通过 Bearer Token + `X-Bricks-Plugin-Id` 访问
+- 数据复用现有聊天存储（`chat_messages`），不引入新的插件专用消息表
+- 移动端设置页可生成并复制插件 Token，便于远端服务接入
+
+---
+
+## 2. 代码结构总览
+
+```text
+docs/
+  plugin_development_architecture.md          # 本文档
+
+apps/node_backend/src/
+  app.ts                                      # 注入 platform 路由入口
+  middleware/
+    platformAuth.ts                           # 插件鉴权、scope 校验、token 签发
+  routes/
+    platform.ts                               # 平台 API 协议层（events/ack/messages/resolve）
+    config.ts                                 # /api/config/platform-token（签发 token）
+    platform.test.ts                          # 平台路由鉴权与约束测试
+  services/
+    platformIntegrationService.ts             # 平台协议与 chat_messages 的读写映射
+
+apps/mobile_chat_app/lib/features/settings/
+  llm_config_service.dart                     # 拉取 platform token
+  model_settings_screen.dart                  # UI：生成/展示/复制 token
+
+apps/mobile_chat_app/test/
+  model_settings_screen_test.dart             # Token 交互与复制行为测试
+```
+
+---
+
+## 3. 后端分层设计
+
+### 3.1 路由入口层（`app.ts`）
+
+职责：把平台接口挂载到统一 API 树。
+
+- 新增：`app.use('/api/v1/platform', platformRoutes);`
+- 效果：插件流量进入同一 Express 生命周期（限流、错误处理、迁移保护等）
+
+### 3.2 鉴权中间件层（`platformAuth.ts`）
+
+职责：完成插件身份、插件标识和 scope 的边界校验。
+
+支持两种访问模式：
+
+1. **静态 Key 模式**
+   - `Authorization: Bearer <BRICKS_PLATFORM_API_KEY>`
+   - 适合内网/固定服务对接
+
+2. **JWT 模式（推荐）**
+   - 通过 `issuePlatformAccessToken()` 签发 `typ=platform_plugin` 的 token
+   - token 可携带：`userId`、`pluginId`、`scopes`
+   - 请求时必须带：`X-Bricks-Plugin-Id`
+
+Scope 控制：
+
+- `events:read`
+- `events:ack`
+- `messages:write`
+- `conversations:read`
+
+### 3.3 协议路由层（`platform.ts`）
+
+职责：做协议兼容、参数校验、错误码约束，再调用 service。
+
+核心接口：
+
+- `GET /api/v1/platform/events`
+  - 拉取增量事件（cursor + limit）
+- `POST /api/v1/platform/events/ack`
+  - ACK 已消费事件
+  - body 禁止传 `pluginId`
+- `POST /api/v1/platform/messages`
+  - 创建消息（兼容 `text/content` 与 `role/author` 字段）
+- `PATCH /api/v1/platform/messages/:messageId`
+  - 更新已有消息（文本或 metadata）
+- `GET /api/v1/platform/conversations/resolve`
+  - 根据 `conversationId` 或 `rawId` 解析会话归属
+
+### 3.4 业务服务层（`platformIntegrationService.ts`）
+
+职责：把“插件协议对象”映射到“聊天存储模型”。
+
+- 事件读取：按 `write_seq` 从 `chat_messages` 增量读取
+- ACK：MVP 阶段只做参数合法性校验（幂等），不做持久化
+- 创建/更新消息：通过 `upsertMessages()` 写入 `chat_messages`
+- 会话解析：支持 `session_id` 和 `channel/thread` 双向定位
+
+---
+
+## 4. 移动端辅助能力
+
+### 4.1 Token 获取服务（`llm_config_service.dart`）
+
+- `fetchPlatformToken()` 请求：`GET /api/config/platform-token`
+- 返回解析为 `PlatformTokenBundle`：
+  - `token`
+  - `pluginId`
+  - `baseUrl`
+  - `scopes`
+  - `expiresIn`
+
+### 4.2 设置页使用（`model_settings_screen.dart`）
+
+- 提供按钮：`Get Xiaolongxia Token`
+- 展示 token 基础信息（Plugin ID / Base URL / Scopes）
+- 支持一键复制 token 到剪贴板
+- 错误场景给出 Snackbar 提示
+
+---
+
+## 5. 插件开发使用方法（Step-by-step）
+
+## Step 1：准备环境变量（后端）
+
+至少需要：
+
+- `JWT_SECRET`（JWT 模式必需）
+- `BRICKS_PLATFORM_API_KEY`（静态 Key 模式可选）
+- `BRICKS_PLATFORM_API_SCOPES`（默认 scope 列表）
+- `BRICKS_PLATFORM_DEFAULT_PLUGIN_ID`（默认插件 ID）
+- `BRICKS_PLATFORM_BASE_URL`（返回给客户端的推荐访问地址）
+
+## Step 2：获取插件 Token
+
+### 方式 A：通过 App 设置页获取（推荐给人工调试）
+
+1. 打开 Model Settings
+2. 点击 `Get Xiaolongxia Token`
+3. 复制生成的 token
+
+### 方式 B：通过后端配置接口获取
+
+`GET /api/config/platform-token?pluginId=plugin_local_main`
+
+请求头：
+
+```http
+Authorization: Bearer <user_jwt>
+```
+
+返回示例：
+
+```json
+{
+  "token": "<platform_jwt>",
+  "pluginId": "plugin_local_main",
+  "scopes": ["events:read", "events:ack", "messages:write", "conversations:read"],
+  "baseUrl": "https://your-api-base",
+  "expiresIn": "30d"
+}
+```
+
+## Step 3：插件侧调用平台 API
+
+所有请求必须携带：
+
+```http
+Authorization: Bearer <platform_jwt_or_static_key>
+X-Bricks-Plugin-Id: plugin_local_main
+```
+
+### 3.1 拉取事件
+
+```http
+GET /api/v1/platform/events?cursor=cur_0&limit=50
+```
+
+### 3.2 ACK 事件
+
+```http
+POST /api/v1/platform/events/ack
+Content-Type: application/json
+
+{
+  "cursor": "cur_12",
+  "ackedEventIds": ["evt_msg_xxx_12"]
+}
+```
+
+### 3.3 写入消息
+
+```http
+POST /api/v1/platform/messages
+Content-Type: application/json
+
+{
+  "conversationId": "conv_001",
+  "channelId": "ch_001",
+  "threadId": "main",
+  "text": "hello",
+  "role": "assistant"
+}
+```
+
+### 3.4 解析会话
+
+```http
+GET /api/v1/platform/conversations/resolve?conversationId=conv_001
+```
+
+---
+
+## 6. 安全与约束建议
+
+1. **优先使用 JWT 模式**，并把 token 作用域收敛到最小必要范围。  
+2. **严格校验 `X-Bricks-Plugin-Id`**，避免跨插件复用 token。  
+3. **不要在日志里落完整 token**，仅输出前后缀。  
+4. **JWT 场景下 body 的 `userId` 不应覆盖 token 的 `userId`**（当前后端已做防护）。  
+5. 生产环境定期轮换 `JWT_SECRET` 与静态 Key。  
+
+---
+
+## 7. 扩展点（给后续插件能力预留）
+
+- ACK 持久化（用于精确投递语义）
+- 插件配额与速率策略（按 pluginId / userId）
+- 细粒度 scope（例如 `messages:patch` 与 `messages:create` 分离）
+- 插件审计日志（安全与合规）
+- 插件版本协商（v1/v2 协议演进）
+
+---
+
+## 8. 常见问题排查
+
+- **401 UNAUTHORIZED**：检查 Bearer token 是否为空/过期/签名无效  
+- **400 MISSING_PLUGIN_ID**：缺少 `X-Bricks-Plugin-Id` 请求头  
+- **403 FORBIDDEN**：scope 不足或 token 的 pluginId 与请求头不一致  
+- **INVALID_CURSOR**：游标格式不符合 `cur_<number>`
+

--- a/docs/plugin_development_architecture.md
+++ b/docs/plugin_development_architecture.md
@@ -31,6 +31,15 @@ apps/node_backend/src/
   services/
     platformIntegrationService.ts             # 平台协议与 chat_messages 的读写映射
 
+apps/node_openclaw_plugin/
+  src/
+    index.ts                                 # 插件运行时入口（JWT claims 校验 + loop 启动）
+    jwtClaims.ts                             # JWT-only claims 解析/校验
+    platformClient.ts                        # 平台 API 客户端
+    pluginRunner.ts                          # pull-only 主循环（pull/dedup/ack/writeback）
+    stateStore.ts                            # 本地状态持久化（cursor/processed/pendingAck）
+  README.md                                  # 本地运行与 JWT-only 约束说明
+
 apps/mobile_chat_app/lib/features/settings/
   llm_config_service.dart                     # 拉取 platform token
   model_settings_screen.dart                  # UI：生成/展示/复制 token
@@ -75,6 +84,8 @@ Scope 控制：
 - `events:ack`
 - `messages:write`
 - `conversations:read`
+
+> 对 `apps/node_openclaw_plugin` 参考实现：当前已收敛为 **JWT-only** 启动策略，不保留静态 key 运行路径。
 
 ### 3.3 协议路由层（`platform.ts`）
 
@@ -251,4 +262,3 @@ GET /api/v1/platform/conversations/resolve?conversationId=conv_001
 - **400 MISSING_PLUGIN_ID**：缺少 `X-Bricks-Plugin-Id` 请求头  
 - **403 FORBIDDEN**：scope 不足或 token 的 pluginId 与请求头不一致  
 - **INVALID_CURSOR**：游标格式不符合 `cur_<number>`
-


### PR DESCRIPTION
### Motivation
- Provide a concrete, implementation-ready backend API contract for Bricks × OpenClaw pull-only integration so backend work can proceed from a firm spec. 
- Improve operator UX in the mobile settings by adding one-click copy actions for the API URL and API Key to reduce setup friction. 
- Keep repository metadata (plans and code maps) in sync with feature and documentation changes per repository rules.

### Description
- Added a new implementation-ready integration document at `docs/openclaw_pull_only_integration_dev_doc.md` defining topology, auth (API key), MVP interfaces, idempotency/retry semantics, session constraints, delivery phases, and an operational checklist. 
- Added a persisted plan file at `docs/plans/2026-04-14-01-30-UTC-openclaw-plugin-platform-api-and-settings-copy.md` following the required timestamped naming convention. 
- UI change: updated `ModelSettingsScreen` to add copy buttons for Base URL (API URL) and API Key with snackbar feedback and preserved the existing show/hide API key toggle (`apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart`). 
- Tests: added widget tests to verify clipboard write behavior and empty-key feedback in `apps/mobile_chat_app/test/model_settings_screen_test.dart`. 
- Documentation/indexing: updated `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` to reflect the new settings behavior and to index the new integration document.

### Testing
- Ran `./tools/init_dev_env.sh` to bootstrap the workspace and dependencies, which completed successfully though `flutter doctor` reported environment warnings (Android SDK/Chrome/GTK) expected in container environments. 
- Ran `dart format` on the modified Dart files successfully using `dart format`. 
- Executed the focused widget tests with `cd apps/mobile_chat_app && flutter test test/model_settings_screen_test.dart`, and all tests in that file passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd97dafd98832db525b9b2ad553225)