### PR TITLE
Add OpenClaw/Xiaolongxia pull-only platform integration: backend endpoints, auth, service and front-end token flow

### DIFF
--- a/apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
+++ b/apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
@@ -205,6 +205,49 @@ class LlmConfigService {
     }
   }
 
+  Future<PlatformTokenBundle> fetchPlatformToken({
+    String pluginId = 'plugin_local_main',
+  }) async {
+    final token = await AuthService.getToken();
+    if (token == null || token.isEmpty) {
+      throw Exception('Not authenticated');
+    }
+
+    final response = await http.get(
+      _buildUri('/api/config/platform-token', {'pluginId': pluginId}),
+      headers: {
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception(
+          'Failed to fetch platform token (${response.statusCode})');
+    }
+
+    final decoded = jsonDecode(response.body);
+    if (decoded is! Map) {
+      throw Exception('Invalid platform token payload');
+    }
+    final map = Map<String, dynamic>.from(decoded);
+    final scopesRaw = map['scopes'];
+    final scopes = scopesRaw is List
+        ? scopesRaw
+            .whereType<String>()
+            .map((s) => s.trim())
+            .where((s) => s.isNotEmpty)
+            .toList()
+        : const <String>[];
+
+    return PlatformTokenBundle(
+      token: (map['token'] as String?) ?? '',
+      pluginId: (map['pluginId'] as String?) ?? pluginId,
+      baseUrl: (map['baseUrl'] as String?) ?? resolveBaseUrl(),
+      scopes: scopes,
+      expiresIn: (map['expiresIn'] as String?) ?? '',
+    );
+  }
+
   LlmConfig _fromApiConfig(Map<String, dynamic> config) {
     final rawConfig = config['config'];
     final map = rawConfig is Map
@@ -312,4 +355,20 @@ class LlmConfigService {
         return 'https://api.anthropic.com';
     }
   }
+}
+
+class PlatformTokenBundle {
+  const PlatformTokenBundle({
+    required this.token,
+    required this.pluginId,
+    required this.baseUrl,
+    required this.scopes,
+    required this.expiresIn,
+  });
+
+  final String token;
+  final String pluginId;
+  final String baseUrl;
+  final List<String> scopes;
+  final String expiresIn;
 }

--- a/apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
+++ b/apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
@@ -239,10 +239,14 @@ class LlmConfigService {
             .toList()
         : const <String>[];
 
+    final rawBaseUrl = (map['baseUrl'] as String?)?.trim();
+
     return PlatformTokenBundle(
       token: (map['token'] as String?) ?? '',
       pluginId: (map['pluginId'] as String?) ?? pluginId,
-      baseUrl: (map['baseUrl'] as String?) ?? resolveBaseUrl(),
+      baseUrl: rawBaseUrl != null && rawBaseUrl.isNotEmpty
+          ? rawBaseUrl
+          : resolveBaseUrl(),
       scopes: scopes,
       expiresIn: (map['expiresIn'] as String?) ?? '',
     );

--- a/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
+++ b/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
@@ -503,6 +503,7 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
                     ),
                     const SizedBox(height: 8),
                     TextFormField(
+                      key: ValueKey(_platformTokenBundle!.token),
                       initialValue: _platformTokenBundle!.token,
                       readOnly: true,
                       decoration: InputDecoration(

--- a/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
+++ b/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
@@ -28,6 +28,8 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
   bool _saving = false;
   bool _deleting = false;
   bool _showApiKey = false;
+  bool _loadingPlatformToken = false;
+  PlatformTokenBundle? _platformTokenBundle;
 
   @override
   void initState() {
@@ -243,18 +245,49 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
     required String emptyMessage,
     required String successMessage,
   }) async {
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+
     final text = value.trim();
+    messenger.hideCurrentSnackBar();
     if (text.isEmpty) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(emptyMessage)));
+      messenger.showSnackBar(SnackBar(content: Text(emptyMessage)));
       return;
     }
     await Clipboard.setData(ClipboardData(text: text));
     if (!mounted) return;
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(successMessage)));
+
+    final refreshedMessenger = ScaffoldMessenger.maybeOf(context);
+    if (refreshedMessenger == null) return;
+    refreshedMessenger.hideCurrentSnackBar();
+    refreshedMessenger.showSnackBar(SnackBar(content: Text(successMessage)));
+  }
+
+  Future<void> _loadPlatformToken() async {
+    if (_loadingPlatformToken) return;
+    setState(() => _loadingPlatformToken = true);
+    try {
+      final bundle = await _service.fetchPlatformToken();
+      if (!mounted) return;
+      setState(() => _platformTokenBundle = bundle);
+      final messenger = ScaffoldMessenger.maybeOf(context);
+      messenger?.hideCurrentSnackBar();
+      messenger?.showSnackBar(
+        const SnackBar(content: Text('小龙虾 Token 已生成，可复制到远端服务')),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      final messenger = ScaffoldMessenger.maybeOf(context);
+      messenger?.hideCurrentSnackBar();
+      messenger?.showSnackBar(
+        const SnackBar(content: Text('获取小龙虾 Token 失败')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _loadingPlatformToken = false);
+      }
+    }
   }
 
   Widget _buildConfigSelector() {
@@ -423,6 +456,71 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
                     'Config Slot: ${_activeSlotIdHint()}',
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
+                  const SizedBox(height: 24),
+                  const Divider(),
+                  const SizedBox(height: 12),
+                  Text(
+                    'OpenClaw / 小龙虾 对接',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      OutlinedButton.icon(
+                        onPressed:
+                            _loadingPlatformToken ? null : _loadPlatformToken,
+                        icon: _loadingPlatformToken
+                            ? const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Icon(Icons.vpn_key_outlined),
+                        label: Text(
+                          _loadingPlatformToken
+                              ? 'Generating...'
+                              : 'Get Xiaolongxia Token',
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (_platformTokenBundle != null) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      'Plugin ID: ${_platformTokenBundle!.pluginId}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      'Base URL: ${_platformTokenBundle!.baseUrl}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      'Scopes: ${_platformTokenBundle!.scopes.join(', ')}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    const SizedBox(height: 8),
+                    TextFormField(
+                      initialValue: _platformTokenBundle!.token,
+                      readOnly: true,
+                      decoration: InputDecoration(
+                        labelText: 'Xiaolongxia Token',
+                        suffixIcon: IconButton(
+                          tooltip: 'Copy Xiaolongxia Token',
+                          icon: const Icon(Icons.copy_outlined),
+                          onPressed: () {
+                            _copyToClipboard(
+                              value: _platformTokenBundle!.token,
+                              emptyMessage: 'Xiaolongxia Token is empty',
+                              successMessage: 'Xiaolongxia Token copied',
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+                  ],
                   const SizedBox(height: 24),
                   Row(
                     children: [

--- a/apps/mobile_chat_app/test/model_settings_screen_test.dart
+++ b/apps/mobile_chat_app/test/model_settings_screen_test.dart
@@ -358,6 +358,23 @@ void main() {
       expect(find.textContaining('Base URL:'), findsOneWidget);
       expect(find.widgetWithText(TextFormField, 'Xiaolongxia Token'),
           findsOneWidget);
+
+      final copyTokenFinder = find.descendant(
+        of: find.widgetWithText(TextFormField, 'Xiaolongxia Token'),
+        matching: find.byIcon(Icons.copy_outlined),
+      );
+      await _scrollUntilVisible(tester, copyTokenFinder);
+      await tester.ensureVisible(copyTokenFinder);
+      await tester.pumpAndSettle();
+      await tester.tap(copyTokenFinder);
+      await tester.pumpAndSettle();
+
+      expect(clipboardCalls, hasLength(1));
+      expect(
+        clipboardCalls.single.arguments,
+        containsPair('text', 'platform-token-123'),
+      );
+      expect(find.textContaining('copied'), findsOneWidget);
     });
   });
 }

--- a/apps/mobile_chat_app/test/model_settings_screen_test.dart
+++ b/apps/mobile_chat_app/test/model_settings_screen_test.dart
@@ -12,10 +12,18 @@ class _FakeLlmConfigService extends LlmConfigService {
   _FakeLlmConfigService({
     List<LlmConfig>? configs,
     this.deleteThrows = false,
+    this.platformTokenBundle = const PlatformTokenBundle(
+      token: 'platform-token-123',
+      pluginId: 'plugin_local_main',
+      baseUrl: 'https://bricks.askman.dev',
+      scopes: ['events:read', 'events:ack'],
+      expiresIn: '30d',
+    ),
   }) : _initialConfigs = configs ?? const [];
 
   final List<LlmConfig> _initialConfigs;
   final bool deleteThrows;
+  final PlatformTokenBundle platformTokenBundle;
 
   final List<String> deletedIds = [];
 
@@ -32,6 +40,12 @@ class _FakeLlmConfigService extends LlmConfigService {
     if (deleteThrows) throw Exception('delete failed');
     deletedIds.add(id);
   }
+
+  @override
+  Future<PlatformTokenBundle> fetchPlatformToken({
+    String pluginId = 'plugin_local_main',
+  }) async =>
+      platformTokenBundle;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,6 +84,18 @@ const _secondConfig = LlmConfig(
 Widget _buildScreen(LlmConfigService service) =>
     MaterialApp(home: ModelSettingsScreen(service: service));
 
+Future<void> _scrollUntilVisible(
+  WidgetTester tester,
+  Finder target, {
+  double delta = 300,
+}) async {
+  await tester.scrollUntilVisible(
+    target,
+    delta,
+    scrollable: find.byType(Scrollable).first,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -85,7 +111,8 @@ void main() {
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(OutlinedButton, 'Delete'));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
       expect(find.text('Delete configuration?'), findsOneWidget);
@@ -98,7 +125,8 @@ void main() {
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(OutlinedButton, 'Delete'));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
       // Dismiss via Cancel.
@@ -118,7 +146,8 @@ void main() {
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(OutlinedButton, 'Delete'));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
       // Tap the Delete button inside the AlertDialog (FilledButton).
@@ -146,7 +175,8 @@ void main() {
       await tester.pumpAndSettle();
 
       // Active config is the first (unsaved) one.
-      await tester.tap(find.widgetWithText(OutlinedButton, 'Delete'));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
       // No confirmation dialog should appear.
@@ -163,13 +193,14 @@ void main() {
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(OutlinedButton, 'Delete'));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
       // The form should still be present (blank config was auto-added).
       expect(find.byType(Form), findsOneWidget);
       // A Delete button should still be visible.
-      expect(find.widgetWithText(OutlinedButton, 'Delete'), findsOneWidget);
+      expect(find.byIcon(Icons.delete_outline), findsOneWidget);
     });
 
     testWidgets(
@@ -180,11 +211,19 @@ void main() {
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
 
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.save_outlined));
       final deleteBtn = tester.widget<OutlinedButton>(
-        find.widgetWithText(OutlinedButton, 'Delete'),
+        find.ancestor(
+          of: find.byIcon(Icons.delete_outline),
+          matching: find.byType(OutlinedButton),
+        ),
       );
       final saveBtn = tester.widget<FilledButton>(
-        find.widgetWithText(FilledButton, 'Save'),
+        find.ancestor(
+          of: find.byIcon(Icons.save_outlined),
+          matching: find.byType(FilledButton),
+        ),
       );
 
       expect(deleteBtn.onPressed, isNotNull);
@@ -201,7 +240,8 @@ void main() {
       await tester.pumpWidget(_buildScreen(service));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(OutlinedButton, 'Delete'));
+      await _scrollUntilVisible(tester, find.byIcon(Icons.delete_outline));
+      await tester.tap(find.byIcon(Icons.delete_outline));
       await tester.pumpAndSettle();
 
       await tester.tap(
@@ -255,6 +295,23 @@ void main() {
       expect(find.text('API URL copied'), findsOneWidget);
     });
 
+    testWidgets('copy api url action shows empty snackbar when field is blank',
+        (tester) async {
+      final service = _FakeLlmConfigService(configs: [_persistedConfig]);
+      await tester.pumpWidget(_buildScreen(service));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Base URL'),
+        '   ',
+      );
+      await tester.tap(find.byTooltip('Copy API URL'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardCalls, isEmpty);
+      expect(find.text('API URL is empty'), findsOneWidget);
+    });
+
     testWidgets('copy api key action shows empty snackbar when field is blank',
         (tester) async {
       final service = _FakeLlmConfigService(configs: [_persistedConfig]);
@@ -285,6 +342,22 @@ void main() {
         containsPair('text', 'test-api-key'),
       );
       expect(find.text('API Key copied'), findsOneWidget);
+    });
+
+    testWidgets('can fetch and copy xiaolongxia token', (tester) async {
+      final service = _FakeLlmConfigService(configs: [_persistedConfig]);
+      await tester.pumpWidget(_buildScreen(service));
+      await tester.pumpAndSettle();
+
+      await _scrollUntilVisible(
+          tester, find.text('Get Xiaolongxia Token').first);
+      await tester.tap(find.text('Get Xiaolongxia Token').first);
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Plugin ID:'), findsOneWidget);
+      expect(find.textContaining('Base URL:'), findsOneWidget);
+      expect(find.widgetWithText(TextFormField, 'Xiaolongxia Token'),
+          findsOneWidget);
     });
   });
 }

--- a/apps/node_backend/src/app.ts
+++ b/apps/node_backend/src/app.ts
@@ -7,6 +7,7 @@ import authRoutes from './routes/auth.js';
 import configRoutes from './routes/config.js';
 import llmRoutes from './routes/llm.js';
 import chatRoutes from './routes/chat.js';
+import platformRoutes from './routes/platform.js';
 import { runMigrations } from './db/migrate.js';
 
 // Load environment variables (no-op in Vercel production where env vars are injected directly)
@@ -93,6 +94,7 @@ app.use('/api', authRoutes);
 app.use('/api/config', configRoutes);
 app.use('/api/llm', llmRoutes);
 app.use('/api/chat', chatRoutes);
+app.use('/api/v1/platform', platformRoutes);
 
 // 404 handler
 app.use((req: Request, res: Response) => {

--- a/apps/node_backend/src/middleware/platformAuth.ts
+++ b/apps/node_backend/src/middleware/platformAuth.ts
@@ -108,8 +108,12 @@ export function authenticatePlatformApiKey(
       }
       scopedUserId = payload.userId;
       tokenScopes = Array.isArray(payload.scopes) ? payload.scopes : undefined;
-    } catch {
-      sendAuthError(res, 401, 'UNAUTHORIZED', 'invalid api key');
+    } catch (error) {
+      if (error instanceof Error && error.message === 'JWT_SECRET environment variable is not set') {
+        sendAuthError(res, 500, 'CONFIGURATION_ERROR', 'server authentication is not configured');
+        return;
+      }
+      sendAuthError(res, 401, 'UNAUTHORIZED', 'invalid bearer token');
       return;
     }
   }
@@ -126,7 +130,7 @@ export function requirePlatformScope(scope: string) {
   return (req: PlatformAuthRequest, res: Response, next: NextFunction): void => {
     const scopes = req.platformScopes;
     if (!scopes || !scopes.has(scope)) {
-      sendAuthError(res, 403, 'FORBIDDEN', `key lacks ${scope}`);
+      sendAuthError(res, 403, 'FORBIDDEN', `token lacks ${scope}`);
       return;
     }
     next();

--- a/apps/node_backend/src/middleware/platformAuth.ts
+++ b/apps/node_backend/src/middleware/platformAuth.ts
@@ -1,0 +1,134 @@
+import type { NextFunction, Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface PlatformAuthRequest extends Request {
+  platformPluginId?: string;
+  platformScopes?: Set<string>;
+  platformUserId?: string;
+}
+
+interface PlatformJwtPayload {
+  typ?: string;
+  userId?: string;
+  pluginId?: string;
+  scopes?: string[];
+  iat?: number;
+  exp?: number;
+}
+
+function parseScopes(raw: string | undefined): Set<string> {
+  const fallback = 'events:read,events:ack,messages:write,conversations:read';
+  return new Set(
+    (raw ?? fallback)
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+}
+
+function requestId(): string {
+  return `req_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getJwtSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret || secret.trim().length === 0) {
+    throw new Error('JWT_SECRET environment variable is not set');
+  }
+  return secret;
+}
+
+export function issuePlatformAccessToken(params: {
+  userId: string;
+  pluginId?: string;
+  scopes?: string[];
+  expiresIn?: string;
+}): string {
+  const payload: PlatformJwtPayload = {
+    typ: 'platform_plugin',
+    userId: params.userId,
+    pluginId: params.pluginId,
+    scopes: params.scopes,
+  };
+  return jwt.sign(payload, getJwtSecret(), {
+    expiresIn: (params.expiresIn ?? '30d') as any,
+  });
+}
+
+function sendAuthError(res: Response, code: number, errorCode: string, message: string): void {
+  res.status(code).json({
+    error: {
+      code: errorCode,
+      message,
+      retryable: false,
+    },
+    requestId: requestId(),
+  });
+}
+
+export function authenticatePlatformApiKey(
+  req: PlatformAuthRequest,
+  res: Response,
+  next: NextFunction,
+): void {
+  const configuredKey = process.env.BRICKS_PLATFORM_API_KEY?.trim();
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    sendAuthError(res, 401, 'UNAUTHORIZED', 'missing bearer token');
+    return;
+  }
+
+  const token = authHeader.slice(7).trim();
+  if (!token) {
+    sendAuthError(res, 401, 'UNAUTHORIZED', 'invalid api key');
+    return;
+  }
+
+  const pluginIdHeader = req.header('X-Bricks-Plugin-Id')?.trim();
+  if (!pluginIdHeader) {
+    sendAuthError(res, 400, 'MISSING_PLUGIN_ID', 'X-Bricks-Plugin-Id header is required');
+    return;
+  }
+
+  let scopedUserId: string | undefined;
+  let tokenScopes: string[] | undefined;
+  if (configuredKey && token === configuredKey) {
+    // Static key mode (environment-level shared token).
+  } else {
+    try {
+      const payload = jwt.verify(token, getJwtSecret()) as PlatformJwtPayload;
+      if (payload.typ !== 'platform_plugin' || !payload.userId) {
+        sendAuthError(res, 401, 'UNAUTHORIZED', 'invalid platform token payload');
+        return;
+      }
+      if (payload.pluginId && payload.pluginId !== pluginIdHeader) {
+        sendAuthError(res, 403, 'FORBIDDEN', 'token pluginId does not match header');
+        return;
+      }
+      scopedUserId = payload.userId;
+      tokenScopes = Array.isArray(payload.scopes) ? payload.scopes : undefined;
+    } catch {
+      sendAuthError(res, 401, 'UNAUTHORIZED', 'invalid api key');
+      return;
+    }
+  }
+
+  req.platformPluginId = pluginIdHeader;
+  req.platformScopes = tokenScopes
+    ? new Set(tokenScopes)
+    : parseScopes(process.env.BRICKS_PLATFORM_API_SCOPES);
+  req.platformUserId = scopedUserId;
+  next();
+}
+
+export function requirePlatformScope(scope: string) {
+  return (req: PlatformAuthRequest, res: Response, next: NextFunction): void => {
+    const scopes = req.platformScopes;
+    if (!scopes || !scopes.has(scope)) {
+      sendAuthError(res, 403, 'FORBIDDEN', `key lacks ${scope}`);
+      return;
+    }
+    next();
+  };
+}

--- a/apps/node_backend/src/routes/config.ts
+++ b/apps/node_backend/src/routes/config.ts
@@ -7,6 +7,7 @@ import {
   updateApiConfig,
   deleteApiConfig,
 } from '../services/configService.js';
+import { issuePlatformAccessToken } from '../middleware/platformAuth.js';
 
 const router = express.Router();
 const ALLOWED_PROVIDERS = new Set(['anthropic', 'google_ai_studio']);
@@ -129,6 +130,49 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     res.json(configs.map(sanitizeConfigForResponse));
   } catch (error) {
     console.error('Get configs error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /config/platform-token
+ * Issue a scoped pull-only platform token for remote OpenClaw/小龙虾 adapters.
+ */
+router.get('/platform-token', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.userId;
+
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const pluginId =
+      (typeof req.query.pluginId === 'string' ? req.query.pluginId : null) ??
+      process.env.BRICKS_PLATFORM_DEFAULT_PLUGIN_ID ??
+      'plugin_local_main';
+    const scopes = (process.env.BRICKS_PLATFORM_API_SCOPES ??
+            'events:read,events:ack,messages:write,conversations:read')
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+
+    const token = issuePlatformAccessToken({
+      userId,
+      pluginId,
+      scopes,
+      expiresIn: '30d',
+    });
+
+    res.json({
+      token,
+      pluginId,
+      scopes,
+      baseUrl: process.env.BRICKS_PLATFORM_BASE_URL?.trim() || process.env.API_BASE_URL?.trim() || '',
+      expiresIn: '30d',
+    });
+  } catch (error) {
+    console.error('Get platform token error:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/apps/node_backend/src/routes/platform.test.ts
+++ b/apps/node_backend/src/routes/platform.test.ts
@@ -1,0 +1,135 @@
+import express from 'express';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
+import { issuePlatformAccessToken } from '../middleware/platformAuth.js';
+
+vi.mock('../services/platformIntegrationService.js', () => ({
+  listPlatformEvents: vi.fn(async () => ({ nextCursor: 'cur_0', events: [] })),
+  ackPlatformEvents: vi.fn(async () => ({ ok: true })),
+  createPlatformMessage: vi.fn(),
+  patchPlatformMessage: vi.fn(),
+  resolveConversation: vi.fn(),
+}));
+
+let server: ReturnType<express.Express['listen']> | null = null;
+let baseUrl = '';
+
+beforeAll(async () => {
+  process.env.BRICKS_PLATFORM_API_KEY = 'test-platform-key';
+  process.env.BRICKS_PLATFORM_API_SCOPES = 'events:read,events:ack,messages:write,conversations:read';
+  process.env.JWT_SECRET = 'test-jwt-secret';
+
+  const app = express();
+  app.use(express.json());
+  const { default: platformRoutes } = await import('./platform.js');
+  app.use('/api/v1/platform', platformRoutes);
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const address = server?.address();
+      if (address && typeof address === 'object') {
+        baseUrl = `http://127.0.0.1:${address.port}`;
+      }
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    if (!server) {
+      resolve();
+      return;
+    }
+    server.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+});
+
+describe('platform route auth and ack constraints', () => {
+  it('returns 400 when plugin header is missing', async () => {
+    const response = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-platform-key',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ackedEventIds: ['evt_1'], cursor: 'cur_1' }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('MISSING_PLUGIN_ID');
+  });
+
+  it('rejects pluginId in ack body with 400', async () => {
+    const response = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-platform-key',
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({ pluginId: 'forbidden', ackedEventIds: ['evt_1'], cursor: 'cur_1' }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('INVALID_PAYLOAD');
+  });
+
+  it('accepts valid ack payload idempotently', async () => {
+    const first = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-platform-key',
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({ ackedEventIds: ['evt_1'], cursor: 'cur_1' }),
+    });
+
+    const second = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-platform-key',
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({ ackedEventIds: ['evt_1'], cursor: 'cur_1' }),
+    });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+
+    const body = (await second.json()) as { ok?: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  it('accepts user-scoped JWT platform token', async () => {
+    const jwtToken = issuePlatformAccessToken({
+      userId: 'user-123',
+      pluginId: 'plugin_local_main',
+      scopes: ['events:ack'],
+      expiresIn: '1h',
+    });
+    const response = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwtToken}`,
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({ ackedEventIds: ['evt_2'], cursor: 'cur_2' }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok?: boolean };
+    expect(body.ok).toBe(true);
+  });
+});

--- a/apps/node_backend/src/routes/platform.test.ts
+++ b/apps/node_backend/src/routes/platform.test.ts
@@ -2,11 +2,15 @@ import express from 'express';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { vi } from 'vitest';
 import { issuePlatformAccessToken } from '../middleware/platformAuth.js';
+import {
+  listPlatformEvents,
+  createPlatformMessage,
+} from '../services/platformIntegrationService.js';
 
 vi.mock('../services/platformIntegrationService.js', () => ({
   listPlatformEvents: vi.fn(async () => ({ nextCursor: 'cur_0', events: [] })),
   ackPlatformEvents: vi.fn(async () => ({ ok: true })),
-  createPlatformMessage: vi.fn(),
+  createPlatformMessage: vi.fn(async () => ({ messageId: 'msg_test', conversationId: 'conv_1', revision: 1 })),
   patchPlatformMessage: vi.fn(),
   resolveConversation: vi.fn(),
 }));
@@ -131,5 +135,86 @@ describe('platform route auth and ack constraints', () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as { ok?: boolean };
     expect(body.ok).toBe(true);
+  });
+
+  it('JWT events listing passes userId to service', async () => {
+    const jwtToken = issuePlatformAccessToken({
+      userId: 'user-456',
+      pluginId: 'plugin_local_main',
+      scopes: ['events:read'],
+      expiresIn: '1h',
+    });
+
+    vi.mocked(listPlatformEvents).mockClear();
+
+    const response = await fetch(`${baseUrl}/api/v1/platform/events?cursor=cur_0`, {
+      headers: {
+        Authorization: `Bearer ${jwtToken}`,
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(listPlatformEvents)).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-456' }),
+    );
+  });
+
+  it('JWT token prevents userId override in POST /messages', async () => {
+    const jwtToken = issuePlatformAccessToken({
+      userId: 'user-123',
+      pluginId: 'plugin_local_main',
+      scopes: ['messages:write'],
+      expiresIn: '1h',
+    });
+
+    const response = await fetch(`${baseUrl}/api/v1/platform/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwtToken}`,
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({
+        userId: 'different-user',
+        conversationId: 'conv-1',
+        channelId: 'ch-1',
+        text: 'hello',
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('FORBIDDEN');
+  });
+
+  it('JWT token uses token userId when body userId is absent in POST /messages', async () => {
+    const jwtToken = issuePlatformAccessToken({
+      userId: 'user-123',
+      pluginId: 'plugin_local_main',
+      scopes: ['messages:write'],
+      expiresIn: '1h',
+    });
+
+    vi.mocked(createPlatformMessage).mockClear();
+
+    const response = await fetch(`${baseUrl}/api/v1/platform/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwtToken}`,
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({
+        conversationId: 'conv-1',
+        channelId: 'ch-1',
+        text: 'hello',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(createPlatformMessage)).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-123' }),
+    );
   });
 });

--- a/apps/node_backend/src/routes/platform.ts
+++ b/apps/node_backend/src/routes/platform.ts
@@ -38,8 +38,28 @@ function readTrimmedString(input: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+/**
+ * Resolves the effective userId for a platform request.
+ * When a JWT token is present, its userId is canonical and body userId must match or be absent.
+ * In static API key mode, body userId is used directly.
+ * Returns the resolved userId or null if unavailable, and an error descriptor if mismatch is detected.
+ */
+function resolveRequestUserId(
+  platformUserId: string | undefined,
+  bodyUserId: string | null,
+): { userId: string | null; mismatch: boolean } {
+  if (platformUserId) {
+    if (bodyUserId && bodyUserId !== platformUserId) {
+      return { userId: null, mismatch: true };
+    }
+    return { userId: platformUserId, mismatch: false };
+  }
+  return { userId: bodyUserId, mismatch: false };
+}
+
 router.get('/events', requirePlatformScope('events:read'), async (req: Request, res: Response) => {
   try {
+    const platformReq = req as PlatformAuthRequest;
     const cursor = readTrimmedString(req.query.cursor);
     const limitRaw = req.query.limit;
     const limit =
@@ -52,7 +72,11 @@ router.get('/events', requirePlatformScope('events:read'), async (req: Request, 
       return;
     }
 
-    const response = await listPlatformEvents({ cursor: cursor ?? undefined, limit });
+    const response = await listPlatformEvents({
+      cursor: cursor ?? undefined,
+      limit,
+      userId: platformReq.platformUserId,
+    });
     res.status(200).json(response);
   } catch (error) {
     if (error instanceof Error && error.message === 'INVALID_CURSOR') {
@@ -91,6 +115,10 @@ router.post(
       });
       res.status(200).json({ ok: true });
     } catch (error) {
+      if (error instanceof Error && error.message === 'INVALID_CURSOR') {
+        sendError(res, 400, 'INVALID_CURSOR', 'cursor is malformed');
+        return;
+      }
       console.error('platform ack error:', error);
       sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
     }
@@ -102,18 +130,28 @@ router.post(
   requirePlatformScope('messages:write'),
   async (req: PlatformAuthRequest, res: Response) => {
   try {
-    const userId = readTrimmedString(req.body?.userId) ?? req.platformUserId ?? null;
+    const { userId, mismatch } = resolveRequestUserId(
+      req.platformUserId,
+      readTrimmedString(req.body?.userId),
+    );
+    if (mismatch) {
+      sendError(res, 403, 'FORBIDDEN', 'userId in body does not match token');
+      return;
+    }
+
     const conversationId = readTrimmedString(req.body?.conversationId);
     const channelId = readTrimmedString(req.body?.channelId);
-    const text = readTrimmedString(req.body?.text);
-    const role = readTrimmedString(req.body?.role) ?? 'assistant';
+    // Support both `text` and `content` field names per OpenClaw contract
+    const text = readTrimmedString(req.body?.text) ?? readTrimmedString(req.body?.content);
+    // Support both `role` and `author` field names per OpenClaw contract
+    const role = readTrimmedString(req.body?.role) ?? readTrimmedString(req.body?.author) ?? 'assistant';
 
     if (!userId || !conversationId || !channelId || !text) {
       sendError(
         res,
         400,
         'INVALID_PAYLOAD',
-        'userId, conversationId, channelId, text are required',
+        'userId, conversationId, channelId, and text or content are required',
       );
       return;
     }
@@ -146,9 +184,17 @@ router.patch(
   async (req: PlatformAuthRequest, res: Response) => {
     try {
       const messageId = readTrimmedString(req.params.messageId);
-      const userId = readTrimmedString(req.body?.userId) ?? req.platformUserId ?? null;
+      const { userId, mismatch } = resolveRequestUserId(
+        req.platformUserId,
+        readTrimmedString(req.body?.userId),
+      );
+      if (mismatch) {
+        sendError(res, 403, 'FORBIDDEN', 'userId in body does not match token');
+        return;
+      }
+
       if (!messageId || !userId) {
-        sendError(res, 400, 'INVALID_PAYLOAD', 'messageId param and userId body are required');
+        sendError(res, 400, 'INVALID_PAYLOAD', 'messageId param and userId are required');
         return;
       }
 
@@ -182,6 +228,7 @@ router.get(
   requirePlatformScope('conversations:read'),
   async (req: Request, res: Response) => {
     try {
+      const platformReq = req as PlatformAuthRequest;
       const conversationId = readTrimmedString(req.query.conversationId);
       const rawId = readTrimmedString(req.query.rawId);
       if (!conversationId && !rawId) {
@@ -189,7 +236,11 @@ router.get(
         return;
       }
 
-      const resolved = await resolveConversation({ conversationId: conversationId ?? undefined, rawId: rawId ?? undefined });
+      const resolved = await resolveConversation({
+        conversationId: conversationId ?? undefined,
+        rawId: rawId ?? undefined,
+        userId: platformReq.platformUserId,
+      });
       if (!resolved) {
         sendError(res, 404, 'CONVERSATION_NOT_FOUND', 'conversation not found');
         return;

--- a/apps/node_backend/src/routes/platform.ts
+++ b/apps/node_backend/src/routes/platform.ts
@@ -1,0 +1,206 @@
+import express, { type Request, type Response } from 'express';
+import {
+  authenticatePlatformApiKey,
+  requirePlatformScope,
+  type PlatformAuthRequest,
+} from '../middleware/platformAuth.js';
+import {
+  ackPlatformEvents,
+  createPlatformMessage,
+  listPlatformEvents,
+  patchPlatformMessage,
+  resolveConversation,
+} from '../services/platformIntegrationService.js';
+
+const router = express.Router();
+router.use(authenticatePlatformApiKey);
+
+function requestId(): string {
+  return `req_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function sendError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  retryable = false,
+): void {
+  res.status(status).json({
+    error: { code, message, retryable },
+    requestId: requestId(),
+  });
+}
+
+function readTrimmedString(input: unknown): string | null {
+  if (typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+router.get('/events', requirePlatformScope('events:read'), async (req: Request, res: Response) => {
+  try {
+    const cursor = readTrimmedString(req.query.cursor);
+    const limitRaw = req.query.limit;
+    const limit =
+      typeof limitRaw === 'string' && limitRaw.trim().length > 0
+        ? Number.parseInt(limitRaw, 10)
+        : undefined;
+
+    if (limit !== undefined && (!Number.isFinite(limit) || limit <= 0)) {
+      sendError(res, 400, 'INVALID_LIMIT', 'limit must be a positive integer');
+      return;
+    }
+
+    const response = await listPlatformEvents({ cursor: cursor ?? undefined, limit });
+    res.status(200).json(response);
+  } catch (error) {
+    if (error instanceof Error && error.message === 'INVALID_CURSOR') {
+      sendError(res, 400, 'INVALID_CURSOR', 'cursor is malformed');
+      return;
+    }
+    console.error('platform events error:', error);
+    sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
+  }
+});
+
+router.post(
+  '/events/ack',
+  requirePlatformScope('events:ack'),
+  async (req: PlatformAuthRequest, res: Response) => {
+    try {
+      if (req.body && typeof req.body === 'object' && 'pluginId' in req.body) {
+        sendError(res, 400, 'INVALID_PAYLOAD', 'pluginId body field is forbidden');
+        return;
+      }
+
+      const ackedEventIds = Array.isArray(req.body?.ackedEventIds)
+        ? req.body.ackedEventIds.filter((v: unknown) => typeof v === 'string' && v.trim().length > 0)
+        : null;
+      const cursor = readTrimmedString(req.body?.cursor);
+
+      if (!ackedEventIds || !cursor) {
+        sendError(res, 400, 'INVALID_PAYLOAD', 'ackedEventIds and cursor are required');
+        return;
+      }
+
+      await ackPlatformEvents({
+        pluginId: req.platformPluginId ?? 'unknown',
+        ackedEventIds,
+        cursor,
+      });
+      res.status(200).json({ ok: true });
+    } catch (error) {
+      console.error('platform ack error:', error);
+      sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
+    }
+  },
+);
+
+router.post(
+  '/messages',
+  requirePlatformScope('messages:write'),
+  async (req: PlatformAuthRequest, res: Response) => {
+  try {
+    const userId = readTrimmedString(req.body?.userId) ?? req.platformUserId ?? null;
+    const conversationId = readTrimmedString(req.body?.conversationId);
+    const channelId = readTrimmedString(req.body?.channelId);
+    const text = readTrimmedString(req.body?.text);
+    const role = readTrimmedString(req.body?.role) ?? 'assistant';
+
+    if (!userId || !conversationId || !channelId || !text) {
+      sendError(
+        res,
+        400,
+        'INVALID_PAYLOAD',
+        'userId, conversationId, channelId, text are required',
+      );
+      return;
+    }
+
+    const result = await createPlatformMessage({
+      userId,
+      conversationId,
+      channelId,
+      threadId: readTrimmedString(req.body?.threadId),
+      text,
+      role,
+      clientToken: readTrimmedString(req.body?.clientToken) ?? undefined,
+      metadata:
+        req.body?.metadata && typeof req.body.metadata === 'object' && !Array.isArray(req.body.metadata)
+          ? (req.body.metadata as Record<string, unknown>)
+          : undefined,
+    });
+
+    res.status(200).json(result);
+    } catch (error) {
+      console.error('platform create message error:', error);
+      sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
+    }
+  },
+);
+
+router.patch(
+  '/messages/:messageId',
+  requirePlatformScope('messages:write'),
+  async (req: PlatformAuthRequest, res: Response) => {
+    try {
+      const messageId = readTrimmedString(req.params.messageId);
+      const userId = readTrimmedString(req.body?.userId) ?? req.platformUserId ?? null;
+      if (!messageId || !userId) {
+        sendError(res, 400, 'INVALID_PAYLOAD', 'messageId param and userId body are required');
+        return;
+      }
+
+      const text = readTrimmedString(req.body?.text);
+      const metadata =
+        req.body?.metadata && typeof req.body.metadata === 'object' && !Array.isArray(req.body.metadata)
+          ? (req.body.metadata as Record<string, unknown>)
+          : undefined;
+
+      if (!text && !metadata) {
+        sendError(res, 400, 'INVALID_PAYLOAD', 'at least one of text or metadata is required');
+        return;
+      }
+
+      const result = await patchPlatformMessage({ userId, messageId, text: text ?? undefined, metadata });
+      if (!result) {
+        sendError(res, 404, 'MESSAGE_NOT_FOUND', 'message not found');
+        return;
+      }
+
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('platform patch message error:', error);
+      sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
+    }
+  },
+);
+
+router.get(
+  '/conversations/resolve',
+  requirePlatformScope('conversations:read'),
+  async (req: Request, res: Response) => {
+    try {
+      const conversationId = readTrimmedString(req.query.conversationId);
+      const rawId = readTrimmedString(req.query.rawId);
+      if (!conversationId && !rawId) {
+        sendError(res, 400, 'INVALID_QUERY', 'conversationId or rawId is required');
+        return;
+      }
+
+      const resolved = await resolveConversation({ conversationId: conversationId ?? undefined, rawId: rawId ?? undefined });
+      if (!resolved) {
+        sendError(res, 404, 'CONVERSATION_NOT_FOUND', 'conversation not found');
+        return;
+      }
+
+      res.status(200).json(resolved);
+    } catch (error) {
+      console.error('platform resolve conversation error:', error);
+      sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
+    }
+  },
+);
+
+export default router;

--- a/apps/node_backend/src/services/platformIntegrationService.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.ts
@@ -1,0 +1,303 @@
+import pool from '../db/index.js';
+import { upsertMessages } from './chatAsyncTransportService.js';
+
+type ChatMessageEventRow = {
+  write_seq: number;
+  message_id: string;
+  user_id: string;
+  channel_id: string;
+  session_id: string;
+  thread_id: string | null;
+  role: string;
+  content: string;
+  created_at: string;
+};
+
+type ExistingMessageRow = {
+  message_id: string;
+  user_id: string;
+  channel_id: string;
+  session_id: string;
+  thread_id: string | null;
+  role: string;
+  content: string;
+  metadata: unknown;
+  created_at: string;
+  updated_at: string;
+};
+
+export interface PlatformEvent {
+  eventId: string;
+  eventType: 'message.created';
+  workspaceId: string;
+  conversationId: string;
+  rawId: string;
+  occurredAt: string;
+  payload: {
+    messageId: string;
+    sender: {
+      userId: string;
+      displayName: string;
+    };
+    text: string;
+    attachments: unknown[];
+  };
+}
+
+function cursorToSeq(cursor?: string): number {
+  if (!cursor) return 0;
+  const m = /^cur_(\d+)$/.exec(cursor.trim());
+  if (!m) {
+    throw new Error('INVALID_CURSOR');
+  }
+  return Number.parseInt(m[1], 10);
+}
+
+function seqToCursor(seq: number): string {
+  return `cur_${Math.max(0, seq)}`;
+}
+
+function toRawId(channelId: string, threadId: string | null): string {
+  if (threadId && threadId.trim().length > 0) {
+    return `channel:${channelId}/thread:${threadId}`;
+  }
+  return `channel:${channelId}`;
+}
+
+function displayNameFromRole(role: string): string {
+  switch (role) {
+    case 'assistant':
+      return 'assistant';
+    case 'system':
+      return 'system';
+    default:
+      return 'user';
+  }
+}
+
+export async function listPlatformEvents(params: {
+  cursor?: string;
+  limit?: number;
+  workspaceId?: string;
+}): Promise<{ nextCursor: string; events: PlatformEvent[] }> {
+  const limit = Math.min(200, Math.max(1, params.limit ?? 50));
+  const afterSeq = cursorToSeq(params.cursor);
+  const workspaceId = params.workspaceId ?? process.env.BRICKS_PLATFORM_WORKSPACE_ID ?? 'ws_local';
+
+  const result = await pool.query<ChatMessageEventRow>(
+    `SELECT write_seq, message_id, user_id, channel_id, session_id, thread_id, role, content, created_at
+       FROM chat_messages
+      WHERE write_seq > $1
+      ORDER BY write_seq ASC
+      LIMIT $2`,
+    [afterSeq, limit],
+  );
+
+  const events = result.rows.map((row) => ({
+    eventId: `evt_msg_${row.message_id}_${row.write_seq}`,
+    eventType: 'message.created' as const,
+    workspaceId,
+    conversationId: row.session_id,
+    rawId: toRawId(row.channel_id, row.thread_id),
+    occurredAt: row.created_at,
+    payload: {
+      messageId: row.message_id,
+      sender: {
+        userId: row.user_id,
+        displayName: displayNameFromRole(row.role),
+      },
+      text: row.content,
+      attachments: [],
+    },
+  }));
+
+  const nextSeq = result.rows.length > 0 ? result.rows[result.rows.length - 1].write_seq : afterSeq;
+  return {
+    nextCursor: seqToCursor(nextSeq),
+    events,
+  };
+}
+
+export async function ackPlatformEvents(_params: {
+  pluginId: string;
+  cursor: string;
+  ackedEventIds: string[];
+}): Promise<{ ok: true }> {
+  // ACK is idempotent by contract. Current MVP does not persist ack state yet.
+  return { ok: true };
+}
+
+function generateMessageId(clientToken?: string): string {
+  if (clientToken && clientToken.trim().length > 0) {
+    return clientToken.trim().slice(0, 255);
+  }
+  return `msg_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export async function createPlatformMessage(input: {
+  userId: string;
+  conversationId: string;
+  channelId: string;
+  threadId?: string | null;
+  role: string;
+  text: string;
+  clientToken?: string;
+  metadata?: Record<string, unknown>;
+}): Promise<{ messageId: string; conversationId: string }> {
+  const messageId = generateMessageId(input.clientToken);
+
+  await upsertMessages(input.userId, [
+    {
+      messageId,
+      taskId: null,
+      channelId: input.channelId,
+      sessionId: input.conversationId,
+      threadId: input.threadId ?? null,
+      role: input.role,
+      content: input.text,
+      taskState: null,
+      checkpointCursor: null,
+      metadata: input.metadata ?? { source: 'platform.messages.create' },
+      createdAt: null,
+    },
+  ]);
+
+  return {
+    messageId,
+    conversationId: input.conversationId,
+  };
+}
+
+function parseMetadata(raw: unknown): Record<string, unknown> | null {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return null;
+    }
+  }
+  if (typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  return null;
+}
+
+export async function patchPlatformMessage(input: {
+  userId: string;
+  messageId: string;
+  text?: string;
+  metadata?: Record<string, unknown>;
+}): Promise<{ messageId: string; updated: true } | null> {
+  const existing = await pool.query<ExistingMessageRow>(
+    `SELECT message_id, user_id, channel_id, session_id, thread_id, role, content, metadata, created_at, updated_at
+       FROM chat_messages
+      WHERE user_id = $1 AND message_id = $2
+      LIMIT 1`,
+    [input.userId, input.messageId],
+  );
+  const row = existing.rows[0];
+  if (!row) return null;
+
+  const mergedMetadata = {
+    ...(parseMetadata(row.metadata) ?? {}),
+    ...(input.metadata ?? {}),
+    source: 'platform.messages.patch',
+  };
+
+  await upsertMessages(input.userId, [
+    {
+      messageId: row.message_id,
+      taskId: null,
+      channelId: row.channel_id,
+      sessionId: row.session_id,
+      threadId: row.thread_id,
+      role: row.role,
+      content: input.text ?? row.content,
+      taskState: null,
+      checkpointCursor: null,
+      metadata: mergedMetadata,
+      createdAt: row.created_at,
+    },
+  ]);
+
+  return {
+    messageId: row.message_id,
+    updated: true,
+  };
+}
+
+export async function resolveConversation(params: {
+  conversationId?: string;
+  rawId?: string;
+}): Promise<
+  | {
+      conversationId: string;
+      rawId: string;
+      channelId: string;
+      threadId: string | null;
+    }
+  | null
+> {
+  if (params.conversationId && params.conversationId.trim().length > 0) {
+    const byConversation = await pool.query<{
+      session_id: string;
+      channel_id: string;
+      thread_id: string | null;
+    }>(
+      `SELECT session_id, channel_id, thread_id
+         FROM chat_messages
+        WHERE session_id = $1
+        ORDER BY write_seq DESC
+        LIMIT 1`,
+      [params.conversationId.trim()],
+    );
+
+    const row = byConversation.rows[0];
+    if (!row) return null;
+    return {
+      conversationId: row.session_id,
+      channelId: row.channel_id,
+      threadId: row.thread_id,
+      rawId: toRawId(row.channel_id, row.thread_id),
+    };
+  }
+
+  if (!params.rawId || params.rawId.trim().length === 0) {
+    return null;
+  }
+
+  const raw = params.rawId.trim();
+  const parsed = /^channel:([^/]+)(?:\/thread:(.+))?$/.exec(raw);
+  if (!parsed) return null;
+
+  const channelId = parsed[1];
+  const threadId = parsed[2] ?? null;
+
+  const byRawId = await pool.query<{
+    session_id: string;
+    channel_id: string;
+    thread_id: string | null;
+  }>(
+    `SELECT session_id, channel_id, thread_id
+       FROM chat_messages
+      WHERE channel_id = $1
+        AND (($2 IS NULL AND thread_id IS NULL) OR thread_id = $2)
+      ORDER BY write_seq DESC
+      LIMIT 1`,
+    [channelId, threadId],
+  );
+
+  const row = byRawId.rows[0];
+  if (!row) return null;
+
+  return {
+    conversationId: row.session_id,
+    channelId: row.channel_id,
+    threadId: row.thread_id,
+    rawId: toRawId(row.channel_id, row.thread_id),
+  };
+}

--- a/apps/node_backend/src/services/platformIntegrationService.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.ts
@@ -79,18 +79,22 @@ export async function listPlatformEvents(params: {
   cursor?: string;
   limit?: number;
   workspaceId?: string;
+  userId?: string;
 }): Promise<{ nextCursor: string; events: PlatformEvent[] }> {
   const limit = Math.min(200, Math.max(1, params.limit ?? 50));
   const afterSeq = cursorToSeq(params.cursor);
   const workspaceId = params.workspaceId ?? process.env.BRICKS_PLATFORM_WORKSPACE_ID ?? 'ws_local';
 
+  const baseSelect = `SELECT write_seq, message_id, user_id, channel_id, session_id, thread_id, role, content, created_at
+       FROM chat_messages`;
+  const queryParams: unknown[] = [afterSeq, limit];
+  const userFilter = params.userId ? ` AND user_id = $${queryParams.push(params.userId)}` : '';
   const result = await pool.query<ChatMessageEventRow>(
-    `SELECT write_seq, message_id, user_id, channel_id, session_id, thread_id, role, content, created_at
-       FROM chat_messages
-      WHERE write_seq > $1
+    `${baseSelect}
+      WHERE write_seq > $1${userFilter}
       ORDER BY write_seq ASC
       LIMIT $2`,
-    [afterSeq, limit],
+    queryParams,
   );
 
   const events = result.rows.map((row) => ({
@@ -118,12 +122,22 @@ export async function listPlatformEvents(params: {
   };
 }
 
-export async function ackPlatformEvents(_params: {
+export async function ackPlatformEvents(params: {
   pluginId: string;
   cursor: string;
   ackedEventIds: string[];
 }): Promise<{ ok: true }> {
-  // ACK is idempotent by contract. Current MVP does not persist ack state yet.
+  // Validate inputs even though ACK persistence is intentionally deferred in the MVP.
+  // This keeps the endpoint idempotent while surfacing client-side protocol bugs.
+  cursorToSeq(params.cursor);
+  if (!Array.isArray(params.ackedEventIds)) {
+    throw new Error('INVALID_ACKED_EVENT_IDS');
+  }
+  for (const eventId of params.ackedEventIds) {
+    if (typeof eventId !== 'string' || eventId.trim().length === 0) {
+      throw new Error('INVALID_ACKED_EVENT_IDS');
+    }
+  }
   return { ok: true };
 }
 
@@ -143,7 +157,7 @@ export async function createPlatformMessage(input: {
   text: string;
   clientToken?: string;
   metadata?: Record<string, unknown>;
-}): Promise<{ messageId: string; conversationId: string }> {
+}): Promise<{ messageId: string; conversationId: string; revision: number }> {
   const messageId = generateMessageId(input.clientToken);
 
   await upsertMessages(input.userId, [
@@ -165,6 +179,7 @@ export async function createPlatformMessage(input: {
   return {
     messageId,
     conversationId: input.conversationId,
+    revision: 1,
   };
 }
 
@@ -230,9 +245,16 @@ export async function patchPlatformMessage(input: {
   };
 }
 
+/** Returns a SQL filter clause and appends the userId to queryParams when provided. */
+function appendUserIdFilter(userId: string | undefined, queryParams: unknown[]): string {
+  if (!userId) return '';
+  return ` AND user_id = $${queryParams.push(userId)}`;
+}
+
 export async function resolveConversation(params: {
   conversationId?: string;
   rawId?: string;
+  userId?: string;
 }): Promise<
   | {
       conversationId: string;
@@ -243,6 +265,9 @@ export async function resolveConversation(params: {
   | null
 > {
   if (params.conversationId && params.conversationId.trim().length > 0) {
+    const queryParams: unknown[] = [params.conversationId.trim()];
+    const userFilter = appendUserIdFilter(params.userId, queryParams);
+
     const byConversation = await pool.query<{
       session_id: string;
       channel_id: string;
@@ -250,10 +275,10 @@ export async function resolveConversation(params: {
     }>(
       `SELECT session_id, channel_id, thread_id
          FROM chat_messages
-        WHERE session_id = $1
+        WHERE session_id = $1${userFilter}
         ORDER BY write_seq DESC
         LIMIT 1`,
-      [params.conversationId.trim()],
+      queryParams,
     );
 
     const row = byConversation.rows[0];
@@ -277,6 +302,9 @@ export async function resolveConversation(params: {
   const channelId = parsed[1];
   const threadId = parsed[2] ?? null;
 
+  const rawQueryParams: unknown[] = [channelId, threadId];
+  const rawUserFilter = appendUserIdFilter(params.userId, rawQueryParams);
+
   const byRawId = await pool.query<{
     session_id: string;
     channel_id: string;
@@ -285,10 +313,10 @@ export async function resolveConversation(params: {
     `SELECT session_id, channel_id, thread_id
        FROM chat_messages
       WHERE channel_id = $1
-        AND (($2 IS NULL AND thread_id IS NULL) OR thread_id = $2)
+        AND (($2 IS NULL AND thread_id IS NULL) OR thread_id = $2)${rawUserFilter}
       ORDER BY write_seq DESC
       LIMIT 1`,
-    [channelId, threadId],
+    rawQueryParams,
   );
 
   const row = byRawId.rows[0];

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: feature_map
 owner: bricks
-last_updated: 2026-04-14
+last_updated: 2026-04-16
 purpose: >
   为人类测试员和 AI 测试员提供产品功能清单与进入路径，作为回归测试与变更影响评估的入口索引。
 
@@ -46,7 +46,7 @@ products:
 
       - feature_id: model_settings
         name: 模型与提供商配置
-        user_value: 用户可选择可用模型并保存默认配置，并可快速复制 API URL 与 API Key。
+        user_value: 用户可选择可用模型并保存默认配置，并可快速复制 API URL、API Key 与小龙虾/OpenClaw 对接 Token。
         entry_paths:
           - screen: ModelSettingsScreen
             route_hint: apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
@@ -57,6 +57,7 @@ products:
           - 重新进入页面后配置保持一致。
           - 点击 Base URL 右侧复制按钮后可复制 API URL。
           - 点击 API Key 右侧复制按钮时，非空 key 可被复制，空值会提示不可复制。
+          - 点击 “Get Xiaolongxia Token” 后可展示 plugin/baseUrl/scopes，并复制 Token。
 
       - feature_id: workspace_resources
         name: Workspace / Projects / Skills / Resources 管理
@@ -99,14 +100,20 @@ products:
 
       - feature_id: backend_chat_llm
         name: Chat 与 LLM 调用
-        user_value: 服务端可处理聊天请求并路由到模型提供商。
+        user_value: 服务端可处理聊天请求并路由到模型提供商，并向远端小龙虾/OpenClaw 提供 pull-only 平台接口。
         entry_paths:
           - route: /api/chat
             route_hint: apps/node_backend/src/routes/chat.ts
           - route: /api/llm
             route_hint: apps/node_backend/src/routes/llm.ts
+          - route: /api/v1/platform/*
+            route_hint: apps/node_backend/src/routes/platform.ts
+          - route: /api/config/platform-token
+            route_hint: apps/node_backend/src/routes/config.ts
           - service: LlmService
             route_hint: apps/node_backend/src/llm/llm_service.ts
         smoke_checks:
           - 调用 chat 接口时返回结构化响应。
           - provider 配置缺失时给出明确错误。
+          - 使用 API Key + X-Bricks-Plugin-Id 可访问 `/api/v1/platform/events` 并获取 `nextCursor`。
+          - `/api/v1/platform/events/ack` 禁止 body 中传 `pluginId`，合法 ACK 可重复调用并返回成功。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: logic_map
 owner: bricks
-last_updated: 2026-04-14
+last_updated: 2026-04-16
 purpose: >
   为人类测试员、AI 测试员与 AI 工程师提供“功能 -> 代码/文档/关键词”映射，
   用于影响面分析、回归测试设计与遗留逻辑清理。
@@ -94,9 +94,12 @@ index:
       - copy
       - api key
       - api url
+      - xiaolongxia token
+      - openclaw token
     change_risks:
       - 字段格式变化导致保存后读取失败。
       - 后端默认模型与前端选择策略不一致。
+      - token 颁发与平台鉴权策略不一致会导致远端插件无法连接。
 
   - feature_id: workspace_resources
     capability: Workspace / Projects / Skills / Resources 导航
@@ -148,13 +151,18 @@ index:
     code_index:
       - apps/node_backend/src/routes/chat.ts
       - apps/node_backend/src/routes/llm.ts
+      - apps/node_backend/src/routes/platform.ts
+      - apps/node_backend/src/routes/config.ts
+      - apps/node_backend/src/middleware/platformAuth.ts
+      - apps/node_backend/src/services/platformIntegrationService.ts
       - apps/node_backend/src/llm/llm_service.ts
       - apps/node_backend/src/llm/providers/anthropic_adapter.ts
       - apps/node_backend/src/llm/providers/google_ai_studio_adapter.ts
     doc_index:
       - docs/architecture.md
       - docs/openclaw_pull_only_integration_dev_doc.md
-    test_index: []
+    test_index:
+      - apps/node_backend/src/routes/platform.test.ts
     keywords:
       - chat
       - llm
@@ -162,9 +170,15 @@ index:
       - stream
       - anthropic
       - google
+      - platform events
+      - openclaw
+      - x-bricks-plugin-id
+      - events ack
     change_risks:
       - provider 适配器接口变动导致 LLM 调用失败。
       - 流式响应格式变化导致前端解析出错。
+      - 平台 API key 或 scope 变更导致远端插件鉴权失败。
+      - cursor 语义变化导致插件重复消费或漏消费消息事件。
 
 maintenance_rules:
   update_required_when:

--- a/docs/plans/2026-04-16-05-00-UTC-openclaw-gap-audit-and-token-chain.md
+++ b/docs/plans/2026-04-16-05-00-UTC-openclaw-gap-audit-and-token-chain.md
@@ -1,0 +1,29 @@
+# OpenClaw Gap Audit and Token Chain Validation (Consolidated)
+
+## Background
+The previous iteration produced multiple short plan files and partial implementation updates. This consolidated document merges the current review context and implementation goals into a single artifact.
+
+## Goals
+1. Compare target requirements from post-main docs with current implementation status.
+2. Close critical integration gaps for remote OpenClaw/小龙虾 token flow.
+3. Ensure the user journey is end-to-end: generate token in Settings -> configure external server -> external server connects back and sends messages.
+
+## Implementation Plan (phased)
+### Phase 1: Gap audit
+- Verify target vs implementation for pull-only APIs and auth model.
+- Confirm whether Settings currently exposes OpenClaw token issuance.
+
+### Phase 2: Gap closure
+- Add backend token-issuance endpoint for authenticated users.
+- Support JWT platform tokens in platform auth middleware.
+- Wire Settings UI to request, show, and copy the OpenClaw token bundle.
+
+### Phase 3: Validation
+- Add/extend automated tests for token retrieval and copy behavior.
+- Verify backend type-check and platform route tests.
+
+## Acceptance Criteria
+- Settings page can fetch and copy a dedicated OpenClaw token.
+- External service can use that token with `X-Bricks-Plugin-Id` against `/api/v1/platform/*`.
+- Platform middleware accepts scoped JWT tokens and enforces plugin identity constraints.
+- Consolidated planning is captured in one markdown file for this iteration.


### PR DESCRIPTION
### Motivation
- Provide a pull-only platform integration (OpenClaw / 小龙虾) so remote adapters can poll events and push messages. 
- Offer a scoped platform token issuance endpoint so authenticated users can generate tokens from the Settings UI and copy them into external services. 
- Secure platform APIs with a middleware that supports both a static API key and user-scoped JWT tokens with scope enforcement.

### Description
- Add backend platform auth middleware `platformAuth.ts` with `authenticatePlatformApiKey`, `issuePlatformAccessToken`, and `requirePlatformScope` to validate static keys and signed JWTs and expose plugin/scopes on requests. 
- Implement platform routes in `routes/platform.ts` and wire them under `/api/v1/platform` in `app.ts`, exposing endpoints for listing events (`GET /events`), ACKing events (`POST /events/ack`), creating/patching messages (`POST /messages`, `PATCH /messages/:messageId`), and resolving conversations (`GET /conversations/resolve`). 
- Add `services/platformIntegrationService.ts` that implements event listing, ack handling (idempotent), message creation/patching, and conversation lookup backed by the DB layer. 
- Add a platform token issuance endpoint `GET /api/config/platform-token` in `routes/config.ts` that returns a token bundle (`token`, `pluginId`, `scopes`, `baseUrl`, `expiresIn`). 
- Frontend: add `LlmConfigService.fetchPlatformToken` and `PlatformTokenBundle`, extend `ModelSettingsScreen` to request, display and let users copy the token and metadata, and improve `copyToClipboard` snackbar handling. 
- Update and add automated tests and documentation: update `model_settings_screen_test.dart` to exercise the UI token flow, add `platform.test.ts` for platform route auth/ACK semantics, and update `feature_map.yaml`, `logic_map.yaml`, and add a plan `docs/plans/2026-04-16-05-00-UTC-openclaw-gap-audit-and-token-chain.md`.

### Testing
- Ran the Flutter widget tests in `apps/mobile_chat_app/test/model_settings_screen_test.dart`, which exercise delete/copy flows and the new Xiaolongxia token UI, and they passed. 
- Ran backend vitest `apps/node_backend/src/routes/platform.test.ts` to validate platform auth header behavior, ACK constraints, and JWT token acceptance, and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e01fdfb9fc832dbcd672ae81eade0e)