### PR TITLE
Add node_openclaw_plugin: Node.js OpenClaw pull-only plugin runtime (JWT-only)

### DIFF
--- a/apps/node_openclaw_plugin/.gitignore
+++ b/apps/node_openclaw_plugin/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/apps/node_openclaw_plugin/README.md
+++ b/apps/node_openclaw_plugin/README.md
@@ -31,5 +31,5 @@ npm run dev
 
 - ACK body 仅包含 `cursor` 与 `ackedEventIds`，不发送 `pluginId` 字段。
 - 启动阶段会校验 JWT claims：`typ=platform_plugin`、`pluginId` 与 `BRICKS_PLUGIN_ID` 一致、且必须包含 `userId`。
-- 收到 `message.created` 时会写入一条 streaming 消息并 patch 为 completed。
+- 收到 `message.created` 时会先写入一条 streaming 消息，随后通过 PATCH 更新消息的 `text`/`metadata`；当前不会将 `status` patch 为 `completed`。
 - 收到 `conversation.binding_changed` 时当前仅记录日志（MVP noop）。

--- a/apps/node_openclaw_plugin/README.md
+++ b/apps/node_openclaw_plugin/README.md
@@ -1,0 +1,35 @@
+# node_openclaw_plugin
+
+`node_openclaw_plugin` 是一个基于 Node.js 的 OpenClaw pull-only 插件运行时实现，用于对接 Bricks 平台 API：
+
+1. 轮询 `GET /api/v1/platform/events`
+2. 本地按 `eventId` 去重
+3. 调用 `POST /api/v1/platform/events/ack` 进行 ACK
+4. 通过 `POST/PATCH /api/v1/platform/messages` 回写响应消息
+
+## 环境变量
+
+| 变量 | 必填 | 说明 |
+|---|---|---|
+| `BRICKS_BASE_URL` | 是 | Bricks API 基地址（例如 `http://localhost:8787`） |
+| `BRICKS_PLATFORM_TOKEN` | 是 | 从 `/api/config/platform-token` 获取的 **JWT platform token**（仅支持 JWT） |
+| `BRICKS_PLUGIN_ID` | 是 | 与请求头 `X-Bricks-Plugin-Id` 一致的插件标识 |
+| `OPENCLAW_PLUGIN_POLL_INTERVAL_MS` | 否 | 轮询间隔，默认 `2000` |
+| `OPENCLAW_PLUGIN_DEFAULT_CURSOR` | 否 | 初始游标，默认 `cur_0` |
+| `OPENCLAW_PLUGIN_STATE_FILE` | 否 | 本地状态文件路径，默认 `~/.bricks/node_openclaw_plugin_state.json` |
+| `OPENCLAW_PLUGIN_ASSISTANT_NAME` | 否 | 回写消息中的助手名，默认 `Node OpenClaw Plugin` |
+
+## 本地运行
+
+```bash
+cd apps/node_openclaw_plugin
+npm install
+npm run dev
+```
+
+## 说明
+
+- ACK body 仅包含 `cursor` 与 `ackedEventIds`，不发送 `pluginId` 字段。
+- 启动阶段会校验 JWT claims：`typ=platform_plugin`、`pluginId` 与 `BRICKS_PLUGIN_ID` 一致、且必须包含 `userId`。
+- 收到 `message.created` 时会写入一条 streaming 消息并 patch 为 completed。
+- 收到 `conversation.binding_changed` 时当前仅记录日志（MVP noop）。

--- a/apps/node_openclaw_plugin/package-lock.json
+++ b/apps/node_openclaw_plugin/package-lock.json
@@ -1,0 +1,1825 @@
+{
+  "name": "@bricks/node-openclaw-plugin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@bricks/node-openclaw-plugin",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.10.6",
+        "tsx": "^4.20.6",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/apps/node_openclaw_plugin/package.json
+++ b/apps/node_openclaw_plugin/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bricks/node-openclaw-plugin",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Reference pull-only OpenClaw plugin runtime for Bricks platform APIs",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "type-check": "tsc --noEmit -p tsconfig.json"
+  },
+  "engines": {
+    "node": ">=20.19.0"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.10.6",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.2"
+  }
+}

--- a/apps/node_openclaw_plugin/src/index.ts
+++ b/apps/node_openclaw_plugin/src/index.ts
@@ -42,4 +42,7 @@ async function main(): Promise<void> {
   await runner.runForever();
 }
 
-void main();
+main().catch((error) => {
+  console.error('Failed to start node_openclaw_plugin:', error);
+  process.exitCode = 1;
+});

--- a/apps/node_openclaw_plugin/src/index.ts
+++ b/apps/node_openclaw_plugin/src/index.ts
@@ -1,0 +1,45 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { parseAndValidatePlatformTokenClaims } from './jwtClaims.js';
+import { NodeOpenClawPluginRunner } from './pluginRunner.js';
+import type { PluginRuntimeConfig } from './types.js';
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required env: ${name}`);
+  }
+  return value;
+}
+
+function loadConfig(): PluginRuntimeConfig {
+  const pollIntervalMs = Number(process.env.OPENCLAW_PLUGIN_POLL_INTERVAL_MS ?? '2000');
+  if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+    throw new Error('OPENCLAW_PLUGIN_POLL_INTERVAL_MS must be a positive number');
+  }
+
+  const token = requiredEnv('BRICKS_PLATFORM_TOKEN');
+  const pluginId = requiredEnv('BRICKS_PLUGIN_ID');
+  const tokenClaims = parseAndValidatePlatformTokenClaims(token, pluginId);
+
+  return {
+    baseUrl: requiredEnv('BRICKS_BASE_URL'),
+    token,
+    pluginId,
+    tokenUserId: tokenClaims.userId,
+    pollIntervalMs,
+    defaultCursor: process.env.OPENCLAW_PLUGIN_DEFAULT_CURSOR?.trim() || 'cur_0',
+    stateFilePath:
+      process.env.OPENCLAW_PLUGIN_STATE_FILE?.trim() ||
+      join(homedir(), '.bricks', 'node_openclaw_plugin_state.json'),
+    assistantName: process.env.OPENCLAW_PLUGIN_ASSISTANT_NAME?.trim() || 'Node OpenClaw Plugin',
+  };
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const runner = new NodeOpenClawPluginRunner(config);
+  await runner.runForever();
+}
+
+void main();

--- a/apps/node_openclaw_plugin/src/jwtClaims.ts
+++ b/apps/node_openclaw_plugin/src/jwtClaims.ts
@@ -1,0 +1,52 @@
+export interface PlatformTokenClaims {
+  typ: string;
+  pluginId: string;
+  userId: string;
+  exp?: number;
+}
+
+function decodeBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4);
+  return Buffer.from(padded, 'base64').toString('utf8');
+}
+
+function readClaims(token: string): Record<string, unknown> {
+  const segments = token.split('.');
+  if (segments.length !== 3) {
+    throw new Error('BRICKS_PLATFORM_TOKEN must be a JWT with 3 segments');
+  }
+
+  try {
+    return JSON.parse(decodeBase64Url(segments[1])) as Record<string, unknown>;
+  } catch {
+    throw new Error('BRICKS_PLATFORM_TOKEN payload is not valid JSON');
+  }
+}
+
+export function parseAndValidatePlatformTokenClaims(token: string, pluginId: string): PlatformTokenClaims {
+  const claims = readClaims(token);
+  const typ = typeof claims.typ === 'string' ? claims.typ : '';
+  const claimPluginId = typeof claims.pluginId === 'string' ? claims.pluginId : '';
+  const userId = typeof claims.userId === 'string' ? claims.userId : '';
+  const exp = typeof claims.exp === 'number' ? claims.exp : undefined;
+
+  if (typ !== 'platform_plugin') {
+    throw new Error('BRICKS_PLATFORM_TOKEN typ must equal platform_plugin');
+  }
+  if (!claimPluginId) {
+    throw new Error('BRICKS_PLATFORM_TOKEN must include pluginId claim');
+  }
+  if (claimPluginId !== pluginId) {
+    throw new Error('BRICKS_PLATFORM_TOKEN pluginId claim does not match BRICKS_PLUGIN_ID');
+  }
+  if (!userId) {
+    throw new Error('BRICKS_PLATFORM_TOKEN must include userId claim');
+  }
+
+  if (exp && exp <= Math.floor(Date.now() / 1000)) {
+    throw new Error('BRICKS_PLATFORM_TOKEN has expired');
+  }
+
+  return { typ, pluginId: claimPluginId, userId, exp };
+}

--- a/apps/node_openclaw_plugin/src/jwtClaims.ts
+++ b/apps/node_openclaw_plugin/src/jwtClaims.ts
@@ -44,7 +44,7 @@ export function parseAndValidatePlatformTokenClaims(token: string, pluginId: str
     throw new Error('BRICKS_PLATFORM_TOKEN must include userId claim');
   }
 
-  if (exp && exp <= Math.floor(Date.now() / 1000)) {
+  if (exp !== undefined && exp <= Math.floor(Date.now() / 1000)) {
     throw new Error('BRICKS_PLATFORM_TOKEN has expired');
   }
 

--- a/apps/node_openclaw_plugin/src/platformClient.ts
+++ b/apps/node_openclaw_plugin/src/platformClient.ts
@@ -1,0 +1,103 @@
+import type {
+  CreateMessageRequest,
+  CreateMessageResponse,
+  GetEventsResponse,
+  PatchMessageRequest,
+  ResolveConversationResponse,
+} from './types.js';
+
+export class PlatformHttpError extends Error {
+  readonly status: number;
+  readonly code?: string;
+  readonly retryable?: boolean;
+
+  constructor(status: number, message: string, code?: string, retryable?: boolean) {
+    super(message);
+    this.name = 'PlatformHttpError';
+    this.status = status;
+    this.code = code;
+    this.retryable = retryable;
+  }
+}
+
+export class PlatformClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly token: string,
+    private readonly pluginId: string,
+  ) {}
+
+  async getEvents(cursor: string, limit = 50): Promise<GetEventsResponse> {
+    const params = new URLSearchParams({ cursor, limit: String(limit) });
+    return this.request<GetEventsResponse>(`/api/v1/platform/events?${params.toString()}`);
+  }
+
+  async ackEvents(cursor: string, ackedEventIds: string[]): Promise<{ ok: boolean }> {
+    return this.request<{ ok: boolean }>('/api/v1/platform/events/ack', {
+      method: 'POST',
+      body: JSON.stringify({ cursor, ackedEventIds }),
+    });
+  }
+
+  async resolveConversation(args: {
+    conversationId?: string;
+    rawId?: string;
+  }): Promise<ResolveConversationResponse> {
+    const params = new URLSearchParams();
+    if (args.conversationId) params.set('conversationId', args.conversationId);
+    if (args.rawId) params.set('rawId', args.rawId);
+    return this.request<ResolveConversationResponse>(`/api/v1/platform/conversations/resolve?${params.toString()}`);
+  }
+
+  async createMessage(payload: CreateMessageRequest): Promise<CreateMessageResponse> {
+    return this.request<CreateMessageResponse>('/api/v1/platform/messages', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async patchMessage(messageId: string, payload: PatchMessageRequest): Promise<{ ok: boolean }> {
+    return this.request<{ ok: boolean }>(`/api/v1/platform/messages/${encodeURIComponent(messageId)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    });
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(new URL(path, this.baseUrl), {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'X-Bricks-Plugin-Id': this.pluginId,
+        'Content-Type': 'application/json',
+        ...init?.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const message = `Platform request failed: ${response.status} ${response.statusText}`;
+      try {
+        const body = (await response.json()) as {
+          error?: { code?: string; message?: string; retryable?: boolean };
+        };
+        throw new PlatformHttpError(
+          response.status,
+          body.error?.message ?? message,
+          body.error?.code,
+          body.error?.retryable,
+        );
+      } catch (error) {
+        if (error instanceof PlatformHttpError) {
+          throw error;
+        }
+        throw new PlatformHttpError(response.status, message);
+      }
+    }
+
+    if (response.status === 204) {
+      return {} as T;
+    }
+
+    return (await response.json()) as T;
+  }
+}

--- a/apps/node_openclaw_plugin/src/pluginRunner.ts
+++ b/apps/node_openclaw_plugin/src/pluginRunner.ts
@@ -1,0 +1,191 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+import { PlatformClient, PlatformHttpError } from './platformClient.js';
+import { FileStateStore } from './stateStore.js';
+import type {
+  CreateMessageRequest,
+  PlatformEvent,
+  PluginPersistentState,
+  PluginRuntimeConfig,
+} from './types.js';
+
+export class NodeOpenClawPluginRunner {
+  private readonly client: PlatformClient;
+  private readonly stateStore: FileStateStore;
+  private state: PluginPersistentState;
+
+  constructor(private readonly config: PluginRuntimeConfig) {
+    this.client = new PlatformClient(config.baseUrl, config.token, config.pluginId);
+    this.stateStore = new FileStateStore(config.stateFilePath, config.defaultCursor);
+    this.state = {
+      cursor: config.defaultCursor,
+      processedEventIds: [],
+      clientTokenMessageMap: {},
+      pendingAck: null,
+    };
+  }
+
+  async runForever(): Promise<void> {
+    this.state = await this.stateStore.load();
+    console.log('[node_openclaw_plugin] started with cursor:', this.state.cursor);
+
+    for (;;) {
+      try {
+        await this.tick();
+      } catch (error) {
+        console.error('[node_openclaw_plugin] tick failed:', error);
+      }
+      await sleep(this.config.pollIntervalMs);
+    }
+  }
+
+  async tick(): Promise<void> {
+    await this.flushPendingAck();
+
+    const response = await this.client.getEvents(this.state.cursor, 50);
+    const receivedEventIds = response.events
+      .map((event) => event.eventId)
+      .filter((eventId) => eventId.trim().length > 0);
+
+    for (const event of response.events) {
+      if (this.state.processedEventIds.includes(event.eventId)) {
+        continue;
+      }
+
+      await this.handleEvent(event);
+      this.state.processedEventIds.push(event.eventId);
+    }
+
+    if (receivedEventIds.length > 0) {
+      this.state.pendingAck = {
+        cursor: response.nextCursor,
+        eventIds: receivedEventIds,
+      };
+      await this.stateStore.save(this.state);
+      await this.flushPendingAck();
+      return;
+    }
+
+    this.state.cursor = response.nextCursor;
+    await this.stateStore.save(this.state);
+  }
+
+  private async flushPendingAck(): Promise<void> {
+    if (!this.state.pendingAck) {
+      return;
+    }
+
+    await this.client.ackEvents(this.state.pendingAck.cursor, this.state.pendingAck.eventIds);
+    this.state.cursor = this.state.pendingAck.cursor;
+    this.state.pendingAck = null;
+    await this.stateStore.save(this.state);
+  }
+
+  private async handleEvent(event: PlatformEvent): Promise<void> {
+    switch (event.eventType) {
+      case 'message.created':
+        await this.handleMessageCreated(event);
+        return;
+      case 'conversation.binding_changed':
+        console.log('[node_openclaw_plugin] binding_changed received', {
+          eventId: event.eventId,
+          conversationId: event.conversationId,
+        });
+        return;
+      default:
+        console.log('[node_openclaw_plugin] ignored event type', {
+          eventId: event.eventId,
+          eventType: event.eventType,
+        });
+    }
+  }
+
+  private async handleMessageCreated(event: PlatformEvent): Promise<void> {
+    if (!event.conversationId && !event.rawId) {
+      console.warn('[node_openclaw_plugin] skip event without conversation identity', event.eventId);
+      return;
+    }
+    if (!shouldProcessEvent(event, this.config.tokenUserId)) {
+      return;
+    }
+
+    const topology = await this.client.resolveConversation({
+      conversationId: event.conversationId,
+      rawId: event.rawId,
+    });
+
+    const inputText = extractIncomingText(event.payload);
+    const responseText = `收到消息：${inputText}`;
+    const clientToken = `evt:${event.eventId}`;
+
+    const createPayload: CreateMessageRequest = {
+      workspaceId: event.workspaceId,
+      conversationId: topology.conversationId,
+      channelId: topology.channelId,
+      threadId: topology.threadId,
+      role: 'assistant',
+      status: 'streaming',
+      text: `${this.config.assistantName} 正在处理...`,
+      clientToken,
+      metadata: {
+        sourceEventId: event.eventId,
+        plugin: 'node_openclaw_plugin',
+      },
+    };
+
+    let messageId = this.state.clientTokenMessageMap[clientToken];
+
+    if (!messageId) {
+      const created = await this.client.createMessage(createPayload);
+      messageId = created.messageId;
+      this.state.clientTokenMessageMap[clientToken] = messageId;
+    }
+
+    try {
+      await this.client.patchMessage(messageId, {
+        text: responseText,
+        metadata: {
+          sourceEventId: event.eventId,
+          handledBy: this.config.assistantName,
+        },
+      });
+    } catch (error) {
+      if (error instanceof PlatformHttpError && error.status === 409) {
+        console.warn('[node_openclaw_plugin] revision conflict; skipped patch', { messageId, eventId: event.eventId });
+        return;
+      }
+      throw error;
+    }
+  }
+}
+
+export function extractIncomingText(payload?: PlatformEvent['payload']): string {
+  const text = payload?.text;
+  if (typeof text === 'string' && text.trim().length > 0) {
+    return text.trim();
+  }
+
+  const nestedText = payload?.content;
+  if (typeof nestedText === 'string' && nestedText.trim().length > 0) {
+    return nestedText.trim();
+  }
+
+  return '[empty message]';
+}
+
+export function shouldProcessEvent(event: PlatformEvent, tokenUserId: string): boolean {
+  if (event.eventType !== 'message.created') {
+    return true;
+  }
+
+  const sender = event.payload?.sender;
+  if (!sender) return true;
+
+  if (sender.userId && sender.userId === tokenUserId) {
+    return false;
+  }
+  if (sender.displayName && ['assistant', 'system'].includes(sender.displayName.toLowerCase())) {
+    return false;
+  }
+
+  return true;
+}

--- a/apps/node_openclaw_plugin/src/pluginRunner.ts
+++ b/apps/node_openclaw_plugin/src/pluginRunner.ts
@@ -1,6 +1,6 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 import { PlatformClient, PlatformHttpError } from './platformClient.js';
-import { FileStateStore } from './stateStore.js';
+import { DEFAULT_MAX_PROCESSED_EVENTS, FileStateStore } from './stateStore.js';
 import type {
   CreateMessageRequest,
   PlatformEvent,
@@ -54,6 +54,9 @@ export class NodeOpenClawPluginRunner {
       await this.handleEvent(event);
       this.state.processedEventIds.push(event.eventId);
     }
+
+    // Keep in-memory array bounded to prevent unbounded growth during long runs
+    this.state.processedEventIds = this.state.processedEventIds.slice(-DEFAULT_MAX_PROCESSED_EVENTS);
 
     if (receivedEventIds.length > 0) {
       this.state.pendingAck = {

--- a/apps/node_openclaw_plugin/src/stateStore.ts
+++ b/apps/node_openclaw_plugin/src/stateStore.ts
@@ -1,0 +1,57 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import type { PluginPersistentState } from './types.js';
+
+export const DEFAULT_MAX_PROCESSED_EVENTS = 5000;
+
+export function createDefaultState(defaultCursor: string): PluginPersistentState {
+  return {
+    cursor: defaultCursor,
+    processedEventIds: [],
+    clientTokenMessageMap: {},
+    pendingAck: null,
+  };
+}
+
+export class FileStateStore {
+  constructor(
+    private readonly filePath: string,
+    private readonly defaultCursor: string,
+    private readonly maxProcessedEvents = DEFAULT_MAX_PROCESSED_EVENTS,
+  ) {}
+
+  async load(): Promise<PluginPersistentState> {
+    try {
+      const raw = await readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(raw) as PluginPersistentState;
+      return {
+        cursor: parsed.cursor || this.defaultCursor,
+        processedEventIds: Array.isArray(parsed.processedEventIds) ? parsed.processedEventIds : [],
+        clientTokenMessageMap: parsed.clientTokenMessageMap ?? {},
+        pendingAck:
+          parsed.pendingAck &&
+          typeof parsed.pendingAck === 'object' &&
+          typeof parsed.pendingAck.cursor === 'string' &&
+          Array.isArray(parsed.pendingAck.eventIds)
+            ? {
+                cursor: parsed.pendingAck.cursor,
+                eventIds: parsed.pendingAck.eventIds.filter(
+                  (value): value is string => typeof value === 'string' && value.trim().length > 0,
+                ),
+              }
+            : null,
+      };
+    } catch {
+      return createDefaultState(this.defaultCursor);
+    }
+  }
+
+  async save(state: PluginPersistentState): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const normalized: PluginPersistentState = {
+      ...state,
+      processedEventIds: state.processedEventIds.slice(-this.maxProcessedEvents),
+    };
+    await writeFile(this.filePath, JSON.stringify(normalized, null, 2), 'utf8');
+  }
+}

--- a/apps/node_openclaw_plugin/src/types.ts
+++ b/apps/node_openclaw_plugin/src/types.ts
@@ -1,0 +1,80 @@
+export type PlatformEventType = 'message.created' | 'interaction.submitted' | 'conversation.binding_changed' | string;
+
+export interface PlatformEvent {
+  eventId: string;
+  eventType: PlatformEventType;
+  workspaceId?: string;
+  conversationId?: string;
+  rawId?: string;
+  occurredAt?: string;
+  payload?: {
+    text?: string;
+    content?: string;
+    sender?: {
+      userId?: string;
+      displayName?: string;
+    };
+    [key: string]: unknown;
+  };
+}
+
+export interface GetEventsResponse {
+  nextCursor: string;
+  events: PlatformEvent[];
+}
+
+export interface ResolveConversationResponse {
+  conversationId: string;
+  channelId?: string;
+  threadId?: string;
+  sessionId?: string;
+  rawId?: string;
+}
+
+export interface CreateMessageRequest {
+  workspaceId?: string;
+  conversationId: string;
+  channelId?: string;
+  threadId?: string;
+  text?: string;
+  content?: string;
+  role?: string;
+  author?: string;
+  status?: 'streaming' | 'completed' | string;
+  clientToken?: string;
+  userId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateMessageResponse {
+  messageId: string;
+  revision?: number;
+}
+
+export interface PatchMessageRequest {
+  text?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PendingAckState {
+  cursor: string;
+  eventIds: string[];
+}
+
+export interface PluginPersistentState {
+  cursor: string;
+  processedEventIds: string[];
+  clientTokenMessageMap: Record<string, string>;
+  pendingAck: PendingAckState | null;
+}
+
+export interface PluginRuntimeConfig {
+  baseUrl: string;
+  token: string;
+  pluginId: string;
+  tokenUserId: string;
+  pollIntervalMs: number;
+  defaultCursor: string;
+  stateFilePath: string;
+  assistantName: string;
+}

--- a/apps/node_openclaw_plugin/src/types.ts
+++ b/apps/node_openclaw_plugin/src/types.ts
@@ -25,9 +25,8 @@ export interface GetEventsResponse {
 
 export interface ResolveConversationResponse {
   conversationId: string;
-  channelId?: string;
+  channelId: string;
   threadId?: string;
-  sessionId?: string;
   rawId?: string;
 }
 

--- a/apps/node_openclaw_plugin/test/jwtClaims.test.ts
+++ b/apps/node_openclaw_plugin/test/jwtClaims.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { parseAndValidatePlatformTokenClaims } from '../src/jwtClaims.js';
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.signature`;
+}
+
+describe('parseAndValidatePlatformTokenClaims', () => {
+  it('parses required claims', () => {
+    const token = makeJwt({
+      typ: 'platform_plugin',
+      pluginId: 'plugin_local_main',
+      userId: 'user_1',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    const claims = parseAndValidatePlatformTokenClaims(token, 'plugin_local_main');
+    expect(claims.userId).toBe('user_1');
+  });
+
+  it('rejects plugin mismatch and missing required claims', () => {
+    const mismatchPlugin = makeJwt({ typ: 'platform_plugin', pluginId: 'another_plugin', userId: 'user_1' });
+    expect(() => parseAndValidatePlatformTokenClaims(mismatchPlugin, 'plugin_local_main')).toThrow(
+      'pluginId claim does not match BRICKS_PLUGIN_ID',
+    );
+
+    const missingUser = makeJwt({ typ: 'platform_plugin', pluginId: 'plugin_local_main' });
+    expect(() => parseAndValidatePlatformTokenClaims(missingUser, 'plugin_local_main')).toThrow(
+      'must include userId claim',
+    );
+  });
+});

--- a/apps/node_openclaw_plugin/test/pluginRunner.test.ts
+++ b/apps/node_openclaw_plugin/test/pluginRunner.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { extractIncomingText, shouldProcessEvent } from '../src/pluginRunner.js';
+
+describe('extractIncomingText', () => {
+  it('returns top-level text first', () => {
+    expect(extractIncomingText({ text: ' hello ' })).toBe('hello');
+  });
+
+  it('falls back to content when text is missing', () => {
+    expect(extractIncomingText({ content: ' world ' })).toBe('world');
+  });
+
+  it('returns placeholder for empty payload', () => {
+    expect(extractIncomingText()).toBe('[empty message]');
+  });
+});
+
+describe('shouldProcessEvent', () => {
+  it('skips assistant/system events and same-user events', () => {
+    expect(
+      shouldProcessEvent(
+        {
+          eventId: 'evt_1',
+          eventType: 'message.created',
+          payload: { sender: { userId: 'u_1', displayName: 'user' } },
+        },
+        'u_1',
+      ),
+    ).toBe(false);
+
+    expect(
+      shouldProcessEvent(
+        {
+          eventId: 'evt_2',
+          eventType: 'message.created',
+          payload: { sender: { userId: 'u_2', displayName: 'assistant' } },
+        },
+        'u_1',
+      ),
+    ).toBe(false);
+  });
+
+  it('keeps user-created events from other users', () => {
+    expect(
+      shouldProcessEvent(
+        {
+          eventId: 'evt_3',
+          eventType: 'message.created',
+          payload: { sender: { userId: 'u_2', displayName: 'user' } },
+        },
+        'u_1',
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/node_openclaw_plugin/test/stateStore.test.ts
+++ b/apps/node_openclaw_plugin/test/stateStore.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDefaultState, FileStateStore } from '../src/stateStore.js';
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop();
+    if (path) {
+      await rm(path, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('FileStateStore', () => {
+  it('returns default state when file does not exist', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'node-openclaw-test-'));
+    cleanupPaths.push(root);
+
+    const store = new FileStateStore(join(root, 'state.json'), 'cur_0');
+    const loaded = await store.load();
+    expect(loaded).toEqual(createDefaultState('cur_0'));
+  });
+
+  it('persists cursor and processed event list', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'node-openclaw-test-'));
+    cleanupPaths.push(root);
+
+    const store = new FileStateStore(join(root, 'state.json'), 'cur_0', 3);
+    await store.save({
+      cursor: 'cur_12',
+      processedEventIds: ['evt_1', 'evt_2', 'evt_3', 'evt_4'],
+      clientTokenMessageMap: {
+        'evt:evt_4': 'msg_4',
+      },
+      pendingAck: {
+        cursor: 'cur_12',
+        eventIds: ['evt_3', 'evt_4'],
+      },
+    });
+
+    const loaded = await store.load();
+    expect(loaded.cursor).toBe('cur_12');
+    expect(loaded.processedEventIds).toEqual(['evt_2', 'evt_3', 'evt_4']);
+    expect(loaded.clientTokenMessageMap['evt:evt_4']).toBe('msg_4');
+    expect(loaded.pendingAck).toEqual({ cursor: 'cur_12', eventIds: ['evt_3', 'evt_4'] });
+  });
+});

--- a/apps/node_openclaw_plugin/tsconfig.json
+++ b/apps/node_openclaw_plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -131,3 +131,28 @@ products:
           - provider 配置缺失时给出明确错误。
           - 使用 API Key + X-Bricks-Plugin-Id 可访问 `/api/v1/platform/events` 并获取 `nextCursor`。
           - `/api/v1/platform/events/ack` 禁止 body 中传 `pluginId`，合法 ACK 可重复调用并返回成功。
+
+  - product_id: node_openclaw_plugin
+    name: Node OpenClaw Plugin
+    platform:
+      - nodejs
+    entry_points:
+      - path: apps/node_openclaw_plugin/src/index.ts
+        route: plugin runtime main
+    features:
+      - feature_id: node_openclaw_pull_loop
+        name: OpenClaw Pull-only 插件运行时
+        user_value: 远端插件可轮询 Bricks 平台事件并执行 ACK 与消息回写闭环。
+        entry_paths:
+          - runtime: NodeOpenClawPluginRunner
+            route_hint: apps/node_openclaw_plugin/src/pluginRunner.ts
+          - client: PlatformClient
+            route_hint: apps/node_openclaw_plugin/src/platformClient.ts
+          - state: FileStateStore
+            route_hint: apps/node_openclaw_plugin/src/stateStore.ts
+        smoke_checks:
+          - 设置 BRICKS_BASE_URL / BRICKS_PLATFORM_TOKEN / BRICKS_PLUGIN_ID 后可启动插件轮询。
+          - 非 JWT token 或 claims 不完整时插件启动应失败（JWT-only）。
+          - 插件可调用 `/api/v1/platform/events` 拉取事件并以 `X-Bricks-Plugin-Id` 发送请求。
+          - 插件 ACK body 仅包含 `cursor` 与 `ackedEventIds` 且可推进本地 cursor。
+          - 收到 `message.created` 事件后可执行 create + patch 消息回写。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -197,6 +197,38 @@ index:
       - 平台 API key 或 scope 变更导致远端插件鉴权失败。
       - cursor 语义变化导致插件重复消费或漏消费消息事件。
 
+
+  - feature_id: node_openclaw_pull_loop
+    capability: Node OpenClaw pull-only 事件消费与消息回写
+    code_index:
+      - apps/node_openclaw_plugin/src/index.ts
+      - apps/node_openclaw_plugin/src/jwtClaims.ts
+      - apps/node_openclaw_plugin/src/pluginRunner.ts
+      - apps/node_openclaw_plugin/src/platformClient.ts
+      - apps/node_openclaw_plugin/src/stateStore.ts
+      - apps/node_openclaw_plugin/src/types.ts
+    doc_index:
+      - docs/openclaw_pull_only_integration_dev_doc.md
+      - docs/plugin_development_architecture.md
+      - apps/node_openclaw_plugin/README.md
+    test_index:
+      - apps/node_openclaw_plugin/test/jwtClaims.test.ts
+      - apps/node_openclaw_plugin/test/stateStore.test.ts
+      - apps/node_openclaw_plugin/test/pluginRunner.test.ts
+    keywords:
+      - openclaw
+      - plugin
+      - pull-only
+      - events
+      - ack
+      - cursor
+      - messages
+      - jwt
+    change_risks:
+      - cursor 持久化失败会导致重复消费或漏消费。
+      - ACK 与本地去重顺序错误可能造成事件堆积或错误跳过。
+      - 上游接口字段变化可能导致回写消息失败。
+
 maintenance_rules:
   update_required_when:
     - 新增、删除或重命名用户可见功能入口。

--- a/docs/plans/2026-04-16-10-51-UTC-node-openclaw-plugin-implementation.md
+++ b/docs/plans/2026-04-16-10-51-UTC-node-openclaw-plugin-implementation.md
@@ -1,0 +1,33 @@
+# Background
+用户希望“根据文档实现 node_openclaw_plugin”。仓库当前已具备 Bricks 平台侧 pull-only API（`/api/v1/platform/*`）与 token 签发能力，但尚无独立的 Node.js 插件示例/运行时来执行文档中的事件拉取、ACK、消息写回闭环。
+
+# Goals
+- 新增 `apps/node_openclaw_plugin`，提供最小可运行的 Node.js/TypeScript 插件实现。
+- 按文档实现 pull-only 主循环：拉取事件、去重处理、ACK、消息回写。
+- 提供环境变量与运行说明，便于本地联调。
+- 增加基础单测，覆盖关键状态持久化与处理逻辑。
+- 同步更新代码地图索引，确保新功能可被测试与 AI 检索。
+
+# Implementation Plan (phased)
+## Phase 1: 项目骨架与客户端
+1. 创建 `apps/node_openclaw_plugin` 包（`package.json`、`tsconfig.json`、`src/`）。
+2. 实现平台 API 客户端：`events` 拉取、`events/ack`、`messages` 创建/更新、`conversations/resolve`。
+3. 定义插件内部类型与错误处理（标准化 HTTP 异常）。
+
+## Phase 2: 事件处理与状态持久化
+1. 实现文件状态仓库（`cursor`、`processedEventIds`、`clientToken->messageId` 映射）。
+2. 实现插件运行器：轮询、按 `eventId` 去重、按批 ACK、失败重试边界。
+3. 为 `message.created` 事件实现示例回写逻辑（create + patch）。
+4. 为 `conversation.binding_changed` 增加日志处理分支（MVP noop）。
+
+## Phase 3: 文档、测试与代码地图
+1. 添加插件目录 README（环境变量、运行命令、行为说明）。
+2. 编写并运行单测（状态仓库/处理流程）。
+3. 更新 `docs/code_maps/feature_map.yaml` 与 `docs/code_maps/logic_map.yaml`，纳入新插件功能索引。
+
+# Acceptance Criteria
+- 在 `apps/node_openclaw_plugin` 下可执行 `npm run build`、`npm run test` 并通过。
+- 插件主循环可根据环境变量连接 Bricks API，执行“pull -> process -> ack -> writeback”流程。
+- ACK 请求体不包含 `pluginId`，并使用请求头 `X-Bricks-Plugin-Id`。
+- 本地状态可持久化并在重启后继续使用 cursor 与去重集合。
+- 代码地图已更新，包含 `node_openclaw_plugin` 的入口、代码索引与回归风险。

--- a/docs/plans/2026-04-16-16-00-UTC-node-openclaw-plugin-jwt-hardening.md
+++ b/docs/plans/2026-04-16-16-00-UTC-node-openclaw-plugin-jwt-hardening.md
@@ -1,0 +1,30 @@
+# Background
+用户反馈上一版 `node_openclaw_plugin` 与目标不一致：需要明确该实现是用于 OpenClaw 对接的插件运行时（而非文档描述中的宽泛 adapter 表述），并且需要在代码层面真正收敛到 JWT token 路径，避免“文档改了但逻辑仍保留静态 key 兼容”的遗留错误资产。
+
+# Goals
+- 将 `node_openclaw_plugin` 的运行前校验与调用语义收敛为 JWT-only。
+- 修复当前插件与后端平台接口字段不一致导致的消息 patch 失效问题。
+- 修复 ACK 与本地状态持久化顺序问题，避免 ACK 成功但本地状态未落盘。
+- 同步更新 README 与架构文档，消除“adapter/bridge”歧义与静态 key 残留描述。
+
+# Implementation Plan (phased)
+## Phase 1: JWT-only 运行时约束
+1. 新增 JWT claims 解析与基础校验逻辑（typ/pluginId/userId/exp）。
+2. 在启动配置加载阶段强制校验 token，失败直接退出。
+3. 在运行时使用 token userId 执行消息过滤（避免自触发回环）。
+
+## Phase 2: 协议对齐与可靠性修复
+1. 将消息 patch 字段调整为后端当前可识别的 `text`/`metadata`。
+2. 重构 ACK 流程：先持久化 pending ACK，再发送 ACK，成功后提交 cursor。
+3. 为 pending ACK 增加重试入口，确保崩溃恢复后可继续推进 cursor。
+
+## Phase 3: 文档与测试收口
+1. 更新 `apps/node_openclaw_plugin/README.md`：明确 OpenClaw 插件运行时 + JWT-only。
+2. 更新 `docs/plugin_development_architecture.md` 代码结构，纳入新插件目录。
+3. 增加测试覆盖 JWT claims 校验与状态仓库新字段兼容。
+
+# Acceptance Criteria
+- 插件启动时若 token 非合法 JWT claims（缺 typ/pluginId/userId 或过期）会直接失败。
+- 插件向 `PATCH /api/v1/platform/messages/:id` 发送后端可识别字段并能更新文本。
+- ACK 流程具备 pending 持久化，崩溃恢复后可继续 ACK 并推进 cursor。
+- README 不再声明静态 key 支持，且语义明确为 OpenClaw 插件运行时。

--- a/docs/plugin_development_architecture.md
+++ b/docs/plugin_development_architecture.md
@@ -31,6 +31,15 @@ apps/node_backend/src/
   services/
     platformIntegrationService.ts             # 平台协议与 chat_messages 的读写映射
 
+apps/node_openclaw_plugin/
+  src/
+    index.ts                                 # 插件运行时入口（JWT claims 校验 + loop 启动）
+    jwtClaims.ts                             # JWT-only claims 解析/校验
+    platformClient.ts                        # 平台 API 客户端
+    pluginRunner.ts                          # pull-only 主循环（pull/dedup/ack/writeback）
+    stateStore.ts                            # 本地状态持久化（cursor/processed/pendingAck）
+  README.md                                  # 本地运行与 JWT-only 约束说明
+
 apps/mobile_chat_app/lib/features/settings/
   llm_config_service.dart                     # 拉取 platform token
   model_settings_screen.dart                  # UI：生成/展示/复制 token
@@ -75,6 +84,8 @@ Scope 控制：
 - `events:ack`
 - `messages:write`
 - `conversations:read`
+
+> 对 `apps/node_openclaw_plugin` 参考实现：当前已收敛为 **JWT-only** 启动策略，不保留静态 key 运行路径。
 
 ### 3.3 协议路由层（`platform.ts`）
 
@@ -251,4 +262,3 @@ GET /api/v1/platform/conversations/resolve?conversationId=conv_001
 - **400 MISSING_PLUGIN_ID**：缺少 `X-Bricks-Plugin-Id` 请求头  
 - **403 FORBIDDEN**：scope 不足或 token 的 pluginId 与请求头不一致  
 - **INVALID_CURSOR**：游标格式不符合 `cur_<number>`
-


### PR DESCRIPTION
### Motivation

- Provide a minimal, runnable Node.js/TypeScript reference runtime to integrate remote OpenClaw (pull-only) plugins with the Bricks platform. 
- Enforce JWT-only startup semantics and avoid token/identity ambiguity by validating required JWT claims before running. 
- Ensure reliable event consumption with local state persistence, ack batching, deduplication, and a simple create+patch message writeback flow. 

### Description

- Added a new package at `apps/node_openclaw_plugin` including `package.json`, `tsconfig.json`, `README.md`, and `package-lock.json` to describe install/run steps and environment variables. 
- Implemented platform integration code: `PlatformClient` (`src/platformClient.ts`) for platform HTTP calls and `PlatformHttpError` for normalized errors. 
- Implemented runtime core: `NodeOpenClawPluginRunner` (`src/pluginRunner.ts`) which implements the pull loop, local de-duplication, pending-ACK persistence, create+patch message writeback, and basic event handling. 
- Added local state persistence in `FileStateStore` (`src/stateStore.ts`) for cursor, processed event ids, clientToken->messageId mapping, and pending ACKs with trimming of processed event list. 
- Added JWT parsing and validation (`src/jwtClaims.ts`) to require `typ=platform_plugin`, matching `pluginId`, present `userId`, and optional expiry check. 
- Defined shared types (`src/types.ts`) and entrypoint (`src/index.ts`) which loads config, validates token claims, and starts the runner. 
- Added unit tests covering JWT claim parsing, state store persistence, and small runner helpers (`test/*.test.ts`). 
- Updated documentation and code maps to index the new plugin and plans (`README`, `docs/code_maps/*`, `docs/plans/*`, and `docs/plugin_development_architecture.md`). 

### Testing

- Added unit tests `test/jwtClaims.test.ts`, `test/stateStore.test.ts`, and `test/pluginRunner.test.ts` that run under `vitest`. 
- Ran the plugin package tests with `npm run test` in `apps/node_openclaw_plugin`, and the test suite passed. 
- Performed a TypeScript check with `npm run type-check` in the plugin package and it completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0beeb10e4832db3a36351bb898aa7)