### PR TITLE
Add OpenClaw onboarding support to node_openclaw_plugin (manifest, onboarding hook, docs)

### DIFF
--- a/apps/node_openclaw_plugin/README.md
+++ b/apps/node_openclaw_plugin/README.md
@@ -1,13 +1,70 @@
-# node_openclaw_plugin
+# @bricks/node-openclaw-plugin
 
-`node_openclaw_plugin` 是一个基于 Node.js 的 OpenClaw pull-only 插件运行时实现，用于对接 Bricks 平台 API：
+`@bricks/node-openclaw-plugin` 是一个 Node.js 的 Bricks/OpenClaw 集成插件，包含两部分能力：
+
+1. **OpenClaw 插件安装 + onboarding 配置**（channel id: `dev-askman-bricks`）
+2. **pull-only 运行时示例**（轮询 `events`、ACK、消息回写）
+
+## 1) 作为 OpenClaw 插件安装（子目录安装）
+
+> 本仓库场景下，插件在子目录 `apps/node_openclaw_plugin`。
+
+```bash
+openclaw plugins install ./apps/node_openclaw_plugin
+openclaw gateway restart
+```
+
+也可使用链接安装（便于开发联调）：
+
+```bash
+openclaw plugins install -l ./apps/node_openclaw_plugin
+openclaw gateway restart
+```
+
+## 2) onboarding / configure 自动写入 channel 配置
+
+安装后运行：
+
+```bash
+openclaw onboard
+# 或
+openclaw configure
+```
+
+在向导中选择 `dev-askman-bricks`（Bricks）后，插件会提示输入：
+
+- `BRICKS_BASE_URL`
+- `BRICKS_PLUGIN_ID`
+- `BRICKS_PLATFORM_TOKEN`
+
+完成后会自动写入 `~/.openclaw/openclaw.json` 的：
+
+```json
+{
+  "channels": {
+    "dev-askman-bricks": {
+      "BRICKS_BASE_URL": "https://your-bricks-api.example.com",
+      "BRICKS_PLUGIN_ID": "dev-askman-bricks",
+      "BRICKS_PLATFORM_TOKEN": "<JWT token>"
+    }
+  }
+}
+```
+
+### 注意
+
+`openclaw plugins install` 会使用 `npm install --ignore-scripts`，因此不要依赖 npm `postinstall` 写配置；应使用 onboarding hook 进行交互配置。
+
+## 3) 本地 pull-only 运行时（独立示例）
+
+该目录仍提供独立运行时示例，用于对接 Bricks 平台 API：
 
 1. 轮询 `GET /api/v1/platform/events`
 2. 本地按 `eventId` 去重
 3. 调用 `POST /api/v1/platform/events/ack` 进行 ACK
 4. 通过 `POST/PATCH /api/v1/platform/messages` 回写响应消息
 
-## 环境变量
+### 环境变量
 
 | 变量 | 必填 | 说明 |
 |---|---|---|
@@ -19,7 +76,7 @@
 | `OPENCLAW_PLUGIN_STATE_FILE` | 否 | 本地状态文件路径，默认 `~/.bricks/node_openclaw_plugin_state.json` |
 | `OPENCLAW_PLUGIN_ASSISTANT_NAME` | 否 | 回写消息中的助手名，默认 `Node OpenClaw Plugin` |
 
-## 本地运行
+### 本地运行
 
 ```bash
 cd apps/node_openclaw_plugin
@@ -27,7 +84,7 @@ npm install
 npm run dev
 ```
 
-## 说明
+## 行为说明
 
 - ACK body 仅包含 `cursor` 与 `ackedEventIds`，不发送 `pluginId` 字段。
 - 启动阶段会校验 JWT claims：`typ=platform_plugin`、`pluginId` 与 `BRICKS_PLUGIN_ID` 一致、且必须包含 `userId`。

--- a/apps/node_openclaw_plugin/openclaw.plugin.json
+++ b/apps/node_openclaw_plugin/openclaw.plugin.json
@@ -1,0 +1,62 @@
+{
+  "id": "dev-askman-bricks",
+  "name": "Bricks OpenClaw Plugin",
+  "description": "Bricks pull-only OpenClaw channel plugin with interactive onboarding.",
+  "version": "0.1.0",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  },
+  "channelEnvVars": {
+    "dev-askman-bricks": [
+      "BRICKS_BASE_URL",
+      "BRICKS_PLUGIN_ID",
+      "BRICKS_PLATFORM_TOKEN"
+    ]
+  },
+  "channelConfigs": {
+    "dev-askman-bricks": {
+      "label": "Bricks",
+      "description": "Bricks platform API channel settings.",
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "BRICKS_BASE_URL",
+          "BRICKS_PLUGIN_ID",
+          "BRICKS_PLATFORM_TOKEN"
+        ],
+        "properties": {
+          "BRICKS_BASE_URL": {
+            "type": "string",
+            "minLength": 1
+          },
+          "BRICKS_PLUGIN_ID": {
+            "type": "string",
+            "minLength": 1
+          },
+          "BRICKS_PLATFORM_TOKEN": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "uiHints": {
+        "BRICKS_BASE_URL": {
+          "label": "Bricks Base URL",
+          "placeholder": "https://api.example.com"
+        },
+        "BRICKS_PLUGIN_ID": {
+          "label": "Bricks Plugin ID",
+          "placeholder": "dev-askman-bricks"
+        },
+        "BRICKS_PLATFORM_TOKEN": {
+          "label": "Bricks Platform Token",
+          "sensitive": true,
+          "placeholder": "paste your JWT platform token"
+        }
+      }
+    }
+  }
+}

--- a/apps/node_openclaw_plugin/package.json
+++ b/apps/node_openclaw_plugin/package.json
@@ -24,7 +24,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./src/openclawExtension.ts"
+      "./dist/openclawExtension.js"
     ],
     "channel": {
       "id": "dev-askman-bricks",
@@ -40,7 +40,6 @@
     },
     "install": {
       "localPath": "apps/node_openclaw_plugin",
-      "npmSpec": "@bricks/node-openclaw-plugin",
       "defaultChoice": "local"
     }
   }

--- a/apps/node_openclaw_plugin/package.json
+++ b/apps/node_openclaw_plugin/package.json
@@ -21,5 +21,27 @@
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "vitest": "^4.1.2"
+  },
+  "openclaw": {
+    "extensions": [
+      "./src/openclawExtension.ts"
+    ],
+    "channel": {
+      "id": "dev-askman-bricks",
+      "label": "Bricks",
+      "selectionLabel": "Bricks Platform",
+      "docsPath": "/channels/dev-askman-bricks",
+      "docsLabel": "dev-askman-bricks",
+      "blurb": "Bricks platform pull-only channel with onboarding wizard.",
+      "order": 70,
+      "aliases": [
+        "bricks"
+      ]
+    },
+    "install": {
+      "localPath": "apps/node_openclaw_plugin",
+      "npmSpec": "@bricks/node-openclaw-plugin",
+      "defaultChoice": "local"
+    }
   }
 }

--- a/apps/node_openclaw_plugin/src/openclawExtension.ts
+++ b/apps/node_openclaw_plugin/src/openclawExtension.ts
@@ -1,0 +1,84 @@
+const CHANNEL_ID = 'dev-askman-bricks';
+
+interface PromptApi {
+  input(options: { message: string; default?: string }): Promise<string>;
+}
+
+interface OnboardingContext {
+  configured: boolean;
+  label?: string;
+  config?: Record<string, unknown>;
+  prompter?: PromptApi;
+}
+
+interface OnboardingResult {
+  cfg: Record<string, string>;
+  accountId?: string;
+}
+
+function readExistingConfigValue(config: OnboardingContext['config'], key: string): string | undefined {
+  const value = config?.[key];
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+async function promptRequired(
+  ctx: OnboardingContext,
+  key: 'BRICKS_BASE_URL' | 'BRICKS_PLUGIN_ID' | 'BRICKS_PLATFORM_TOKEN',
+  promptMessage: string,
+  fallback?: string,
+): Promise<string> {
+  if (!ctx.prompter?.input) {
+    throw new Error(`Missing onboarding prompter; please set channels.${CHANNEL_ID}.${key} manually.`);
+  }
+
+  const existing = readExistingConfigValue(ctx.config, key) ?? fallback;
+  const entered = (await ctx.prompter.input({
+    message: promptMessage,
+    default: existing,
+  }))?.trim();
+
+  if (!entered) {
+    throw new Error(`${key} is required.`);
+  }
+
+  return entered;
+}
+
+const plugin = {
+  id: CHANNEL_ID,
+  name: 'Bricks OpenClaw Plugin',
+  configSchema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {},
+  },
+  onboarding: {
+    async configureInteractive(ctx: OnboardingContext): Promise<OnboardingResult> {
+      const label = ctx.label ?? 'Bricks';
+
+      const baseUrl = await promptRequired(ctx, 'BRICKS_BASE_URL', `Enter ${label} BRICKS_BASE_URL`);
+      const pluginId = await promptRequired(ctx, 'BRICKS_PLUGIN_ID', `Enter ${label} BRICKS_PLUGIN_ID`, CHANNEL_ID);
+      const token = await promptRequired(ctx, 'BRICKS_PLATFORM_TOKEN', `Enter ${label} BRICKS_PLATFORM_TOKEN (JWT)`);
+
+      return {
+        cfg: {
+          BRICKS_BASE_URL: baseUrl,
+          BRICKS_PLUGIN_ID: pluginId,
+          BRICKS_PLATFORM_TOKEN: token,
+        },
+        accountId: pluginId,
+      };
+    },
+  },
+  register() {
+    // Runtime behavior is implemented in src/index.ts for standalone pull-only runner.
+    // This extension focuses on OpenClaw discovery + onboarding config wiring.
+  },
+};
+
+export default plugin;

--- a/apps/node_openclaw_plugin/src/openclawExtension.ts
+++ b/apps/node_openclaw_plugin/src/openclawExtension.ts
@@ -55,7 +55,18 @@ const plugin = {
   configSchema: {
     type: 'object',
     additionalProperties: false,
-    properties: {},
+    properties: {
+      BRICKS_BASE_URL: {
+        type: 'string',
+      },
+      BRICKS_PLUGIN_ID: {
+        type: 'string',
+      },
+      BRICKS_PLATFORM_TOKEN: {
+        type: 'string',
+      },
+    },
+    required: ['BRICKS_BASE_URL', 'BRICKS_PLUGIN_ID', 'BRICKS_PLATFORM_TOKEN'],
   },
   onboarding: {
     async configureInteractive(ctx: OnboardingContext): Promise<OnboardingResult> {

--- a/apps/node_openclaw_plugin/test/openclawExtension.test.ts
+++ b/apps/node_openclaw_plugin/test/openclawExtension.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import plugin from '../src/openclawExtension.js';
+
+function makePrompter(responses: string[]) {
+  let call = 0;
+  return {
+    input: vi.fn(async (_opts: { message: string; default?: string }) => responses[call++] ?? ''),
+  };
+}
+
+describe('openclawExtension plugin', () => {
+  describe('configSchema', () => {
+    it('declares all required BRICKS_* keys', () => {
+      const { configSchema } = plugin;
+      expect(configSchema.required).toEqual(
+        expect.arrayContaining(['BRICKS_BASE_URL', 'BRICKS_PLUGIN_ID', 'BRICKS_PLATFORM_TOKEN']),
+      );
+      expect(configSchema.properties).toHaveProperty('BRICKS_BASE_URL');
+      expect(configSchema.properties).toHaveProperty('BRICKS_PLUGIN_ID');
+      expect(configSchema.properties).toHaveProperty('BRICKS_PLATFORM_TOKEN');
+    });
+
+    it('has additionalProperties set to false', () => {
+      expect(plugin.configSchema.additionalProperties).toBe(false);
+    });
+  });
+
+  describe('configureInteractive', () => {
+    it('collects BRICKS_* values from prompter and returns cfg + accountId', async () => {
+      const prompter = makePrompter(['https://api.example.com', 'my-plugin-id', 'jwt-token']);
+      const result = await plugin.onboarding.configureInteractive({ configured: false, prompter });
+
+      expect(result.cfg).toEqual({
+        BRICKS_BASE_URL: 'https://api.example.com',
+        BRICKS_PLUGIN_ID: 'my-plugin-id',
+        BRICKS_PLATFORM_TOKEN: 'jwt-token',
+      });
+      expect(result.accountId).toBe('my-plugin-id');
+    });
+
+    it('uses existing config values as defaults', async () => {
+      const prompter = makePrompter(['', '', '']);
+      prompter.input = vi.fn(async (opts: { message: string; default?: string }) => opts.default ?? '');
+
+      const result = await plugin.onboarding.configureInteractive({
+        configured: true,
+        prompter,
+        config: {
+          BRICKS_BASE_URL: 'https://stored.example.com',
+          BRICKS_PLUGIN_ID: 'stored-plugin',
+          BRICKS_PLATFORM_TOKEN: 'stored-token',
+        },
+      });
+
+      expect(result.cfg.BRICKS_BASE_URL).toBe('https://stored.example.com');
+      expect(result.cfg.BRICKS_PLUGIN_ID).toBe('stored-plugin');
+      expect(result.cfg.BRICKS_PLATFORM_TOKEN).toBe('stored-token');
+    });
+
+    it('trims whitespace from entered values', async () => {
+      const prompter = makePrompter(['  https://api.example.com  ', '  plugin-id  ', '  token  ']);
+      const result = await plugin.onboarding.configureInteractive({ configured: false, prompter });
+
+      expect(result.cfg.BRICKS_BASE_URL).toBe('https://api.example.com');
+      expect(result.cfg.BRICKS_PLUGIN_ID).toBe('plugin-id');
+      expect(result.cfg.BRICKS_PLATFORM_TOKEN).toBe('token');
+    });
+
+    it('throws when prompter is missing', async () => {
+      await expect(plugin.onboarding.configureInteractive({ configured: false })).rejects.toThrow(
+        'Missing onboarding prompter',
+      );
+    });
+
+    it('throws when a required value is empty after trim', async () => {
+      const prompter = makePrompter(['', '', '']);
+      await expect(plugin.onboarding.configureInteractive({ configured: false, prompter })).rejects.toThrow(
+        'BRICKS_BASE_URL is required',
+      );
+    });
+  });
+});

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -141,9 +141,13 @@ products:
         route: plugin runtime main
     features:
       - feature_id: node_openclaw_pull_loop
-        name: OpenClaw Pull-only 插件运行时
-        user_value: 远端插件可轮询 Bricks 平台事件并执行 ACK 与消息回写闭环。
+        name: OpenClaw Pull-only 插件运行时与 Onboarding 配置
+        user_value: 远端插件可在 OpenClaw onboarding 中完成 channel 配置，并轮询 Bricks 平台事件执行 ACK 与消息回写闭环。
         entry_paths:
+          - setup: onboarding.configureInteractive
+            route_hint: apps/node_openclaw_plugin/src/openclawExtension.ts
+          - manifest: channelConfigs.dev-askman-bricks
+            route_hint: apps/node_openclaw_plugin/openclaw.plugin.json
           - runtime: NodeOpenClawPluginRunner
             route_hint: apps/node_openclaw_plugin/src/pluginRunner.ts
           - client: PlatformClient
@@ -151,6 +155,7 @@ products:
           - state: FileStateStore
             route_hint: apps/node_openclaw_plugin/src/stateStore.ts
         smoke_checks:
+          - 安装插件后执行 `openclaw onboard` 可提示输入 BRICKS_BASE_URL / BRICKS_PLUGIN_ID / BRICKS_PLATFORM_TOKEN 并写入 `channels.dev-askman-bricks`。
           - 设置 BRICKS_BASE_URL / BRICKS_PLATFORM_TOKEN / BRICKS_PLUGIN_ID 后可启动插件轮询。
           - 非 JWT token 或 claims 不完整时插件启动应失败（JWT-only）。
           - 插件可调用 `/api/v1/platform/events` 拉取事件并以 `X-Bricks-Plugin-Id` 发送请求。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -199,8 +199,9 @@ index:
 
 
   - feature_id: node_openclaw_pull_loop
-    capability: Node OpenClaw pull-only 事件消费与消息回写
+    capability: Node OpenClaw onboarding 配置 + pull-only 事件消费与消息回写
     code_index:
+      - apps/node_openclaw_plugin/src/openclawExtension.ts
       - apps/node_openclaw_plugin/src/index.ts
       - apps/node_openclaw_plugin/src/jwtClaims.ts
       - apps/node_openclaw_plugin/src/pluginRunner.ts
@@ -211,6 +212,7 @@ index:
       - docs/openclaw_pull_only_integration_dev_doc.md
       - docs/plugin_development_architecture.md
       - apps/node_openclaw_plugin/README.md
+      - apps/node_openclaw_plugin/openclaw.plugin.json
     test_index:
       - apps/node_openclaw_plugin/test/jwtClaims.test.ts
       - apps/node_openclaw_plugin/test/stateStore.test.ts
@@ -218,6 +220,8 @@ index:
     keywords:
       - openclaw
       - plugin
+      - onboarding
+      - configureInteractive
       - pull-only
       - events
       - ack
@@ -225,6 +229,7 @@ index:
       - messages
       - jwt
     change_risks:
+      - onboarding hook 字段名与 manifest schema 不一致会导致向导写入后校验失败。
       - cursor 持久化失败会导致重复消费或漏消费。
       - ACK 与本地去重顺序错误可能造成事件堆积或错误跳过。
       - 上游接口字段变化可能导致回写消息失败。

--- a/docs/plans/2026-04-16-22-15-UTC-openclaw-onboarding-enable.md
+++ b/docs/plans/2026-04-16-22-15-UTC-openclaw-onboarding-enable.md
@@ -1,0 +1,29 @@
+# Background
+`apps/node_openclaw_plugin` 目前提供的是 pull-only 运行时示例，但尚未具备 OpenClaw 插件“安装后可在 onboarding/configure 向导中交互写入 channel 配置”的能力。用户希望 channel id 使用 `dev-askman-bricks`，并在配置过程中提示输入 `BRICKS_PLATFORM_TOKEN` 等必填参数，自动写入 `channels.dev-askman-bricks`。
+
+# Goals
+- 为 `apps/node_openclaw_plugin` 增加可被 OpenClaw 识别的插件元数据（manifest + package metadata）。
+- 增加 channel onboarding hook（`configureInteractive`）以提示用户输入并返回配置。
+- 在 README 中补充“子目录安装 + onboarding 配置”步骤，便于用户把说明交给 AI 自动执行。
+- 同步代码地图索引，反映新增 onboarding 能力与风险点。
+
+# Implementation Plan (phased)
+## Phase 1: 插件清单与安装发现元数据
+1. 新增 `openclaw.plugin.json`，声明 `channelConfigs.dev-askman-bricks` schema 与 `uiHints`。
+2. 在 `package.json` 中补充 `openclaw.extensions/openclaw.channel/openclaw.install` 元数据，支持子目录与 npm 安装引导。
+
+## Phase 2: onboarding 交互配置能力
+1. 新增 OpenClaw 插件入口文件，导出带 `onboarding.configureInteractive(ctx)` 的插件对象。
+2. 在 hook 中通过 `ctx.prompter.input` 询问 `BRICKS_BASE_URL`、`BRICKS_PLUGIN_ID`、`BRICKS_PLATFORM_TOKEN`。
+3. 返回 `{ cfg, accountId }` 以让 OpenClaw 自动写入 `channels.dev-askman-bricks`。
+
+## Phase 3: 文档、测试与代码地图
+1. 更新 `apps/node_openclaw_plugin/README.md`，写清子目录安装、onboard/configure 流程、非 install lifecycle 限制。
+2. 运行 TypeScript 构建与测试检查。
+3. 更新 `docs/code_maps/feature_map.yaml` 与 `docs/code_maps/logic_map.yaml`。
+
+# Acceptance Criteria
+- `apps/node_openclaw_plugin` 包含可通过 OpenClaw 发现的 `openclaw.plugin.json` 与 `openclaw.extensions` 元数据。
+- 安装插件后执行 onboarding/configure 时，向导可提示用户输入 token/base URL/plugin id，并将配置写入 `channels.dev-askman-bricks`。
+- README 明确说明子目录安装步骤与配置命令。
+- 代码地图已覆盖 onboarding 入口与回归风险。


### PR DESCRIPTION
### Motivation
- Expose the local `apps/node_openclaw_plugin` as an OpenClaw-discoverable plugin and provide an interactive onboarding flow to write channel configuration (`dev-askman-bricks`).
- Make it easy to install the plugin as a subdirectory and collect required channel env vars (`BRICKS_BASE_URL`, `BRICKS_PLUGIN_ID`, `BRICKS_PLATFORM_TOKEN`) via the OpenClaw configure/onboard wizard.
- Keep the existing pull-only runtime example while surfacing onboarding metadata for automated installation and UI hints.

### Description
- Add `openclaw.plugin.json` declaring the `dev-askman-bricks` channel schema, `uiHints`, and required env vars for OpenClaw discovery and validation.
- Add `src/openclawExtension.ts` exporting an extension with `onboarding.configureInteractive(ctx)` that prompts for `BRICKS_BASE_URL`, `BRICKS_PLUGIN_ID`, and `BRICKS_PLATFORM_TOKEN` and returns `{ cfg, accountId }` for OpenClaw to write into `channels.dev-askman-bricks`.
- Update `package.json` to `@bricks/node-openclaw-plugin`, include `openclaw` metadata (`extensions`, `channel`, `install`) and retain dev scripts (`dev`, `build`, `test`, `type-check`).
- Improve `apps/node_openclaw_plugin/README.md` with subdirectory install instructions, onboarding/configure steps, environment variable table, and runtime behavior notes.
- Update code maps (`docs/code_maps/feature_map.yaml`, `docs/code_maps/logic_map.yaml`) and add an implementation plan (`docs/plans/2026-04-16-22-15-UTC-openclaw-onboarding-enable.md`) to reflect the onboarding feature and associated risks.

### Testing
- Ran type checking with `npm run type-check` which completed successfully.
- Executed unit tests with `npm test` (`vitest run`) and they passed.
- Performed a local `npm run build` (`tsc -p tsconfig.json`) to ensure the project compiles without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1110ee188832d989a311cf2570a40)