### PR TITLE
fix(chat): add sync polling backoff

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -81,6 +81,9 @@ class _ChatScreenState extends State<ChatScreen> {
   Timer? _persistDebounce;
   Timer? _syncTimer;
   bool _syncInFlight = false;
+  static const Duration _syncPollInterval = Duration(seconds: 2);
+  static const Duration _syncMaxBackoff = Duration(seconds: 10);
+  Duration _nextSyncDelay = _syncPollInterval;
   final Map<String, ChatRouter> _channelRouters = {};
   final Map<String, ChatRouter> _threadRouters = {};
   int _respondGeneration = 0;
@@ -94,7 +97,7 @@ class _ChatScreenState extends State<ChatScreen> {
   @override
   void dispose() {
     _persistDebounce?.cancel();
-    _syncTimer?.cancel();
+    _cancelSyncPolling(resetDelay: false);
     _doPersistActiveScopeMessages();
     Timer(const Duration(seconds: 5), _chatHistoryApiService.dispose);
     _currentSubscription?.cancel();
@@ -598,8 +601,7 @@ class _ChatScreenState extends State<ChatScreen> {
         (remembered != null && sections.any((s) => s.id == remembered))
         ? remembered
         : 'main';
-    _syncTimer?.cancel();
-    _syncTimer = null;
+    _cancelSyncPolling();
     setState(() {
       _activeChannelId = resolvedChannelId;
       _activeSubSection = restoredSubSection;
@@ -660,8 +662,7 @@ class _ChatScreenState extends State<ChatScreen> {
     final capturedChannelId = _activeChannelId;
     final capturedSubSection = _activeSubSection;
     final capturedSessionId = _sessionIdForScope;
-    _syncTimer?.cancel();
-    _syncTimer = null;
+    _cancelSyncPolling();
 
     bool _isScopeStale() => _sessionIdForScope != capturedSessionId;
 
@@ -937,21 +938,43 @@ class _ChatScreenState extends State<ChatScreen> {
     return _hasPendingAssistantTasks();
   }
 
-  void _configureActiveScopeSync({bool triggerNow = true}) {
-    if (!_shouldSyncActiveScope()) {
-      _syncTimer?.cancel();
-      _syncTimer = null;
+  void _cancelSyncPolling({bool resetDelay = true}) {
+    _syncTimer?.cancel();
+    _syncTimer = null;
+    if (resetDelay) {
+      _nextSyncDelay = _syncPollInterval;
+    }
+  }
+
+  void _scheduleSync(Duration delay) {
+    if (_syncTimer != null || _syncInFlight || !_shouldSyncActiveScope()) {
       return;
     }
-    final shouldTriggerImmediately =
-        triggerNow && _syncTimer == null && !_syncInFlight;
-    _syncTimer ??= Timer.periodic(const Duration(seconds: 2), (_) {
-      if (_syncInFlight) return;
+
+    _syncTimer = Timer(delay, () {
+      _syncTimer = null;
+      if (_syncInFlight || !_shouldSyncActiveScope()) {
+        return;
+      }
       unawaited(_syncActiveScope());
     });
-    if (shouldTriggerImmediately) {
-      unawaited(_syncActiveScope());
+  }
+
+  void _increaseSyncBackoff() {
+    final doubledMilliseconds = _nextSyncDelay.inMilliseconds * 2;
+    final cappedMilliseconds = doubledMilliseconds.clamp(
+      _syncPollInterval.inMilliseconds,
+      _syncMaxBackoff.inMilliseconds,
+    );
+    _nextSyncDelay = Duration(milliseconds: cappedMilliseconds);
+  }
+
+  void _configureActiveScopeSync({bool triggerNow = true}) {
+    if (!_shouldSyncActiveScope()) {
+      _cancelSyncPolling();
+      return;
     }
+    _scheduleSync(triggerNow ? Duration.zero : _nextSyncDelay);
   }
 
   ChatTaskState? _normalizedServerTaskState(
@@ -1045,6 +1068,7 @@ class _ChatScreenState extends State<ChatScreen> {
     final capturedChannelId = _activeChannelId;
     final capturedSubSection = _activeSubSection;
     _syncInFlight = true;
+    var syncFailed = false;
     try {
       final snapshot = await _chatHistoryApiService.sync(
         token: token,
@@ -1069,9 +1093,15 @@ class _ChatScreenState extends State<ChatScreen> {
         subSection: capturedSubSection,
       );
     } catch (error) {
+      syncFailed = true;
       debugPrint('chat scope sync failed: $error');
     } finally {
       _syncInFlight = false;
+      if (syncFailed) {
+        _increaseSyncBackoff();
+      } else {
+        _nextSyncDelay = _syncPollInterval;
+      }
       if (mounted) {
         _configureActiveScopeSync(triggerNow: false);
       }
@@ -1625,8 +1655,7 @@ class _ChatScreenState extends State<ChatScreen> {
                   _createSubSection();
                   unawaited(_loadMessagesForActiveScope());
                 } else {
-                  _syncTimer?.cancel();
-                  _syncTimer = null;
+                  _cancelSyncPolling();
                   setState(() {
                     _activeSubSection = value;
                     _messages.clear();

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -1097,12 +1097,12 @@ class _ChatScreenState extends State<ChatScreen> {
       debugPrint('chat scope sync failed: $error');
     } finally {
       _syncInFlight = false;
-      if (syncFailed) {
-        _increaseSyncBackoff();
-      } else {
-        _nextSyncDelay = _syncPollInterval;
-      }
-      if (mounted) {
+      if (mounted && _sessionIdForScope == capturedSessionId) {
+        if (syncFailed) {
+          _increaseSyncBackoff();
+        } else {
+          _nextSyncDelay = _syncPollInterval;
+        }
         _configureActiveScopeSync(triggerNow: false);
       }
     }

--- a/docs/plans/2026-04-17-10-29-UTC-request-performance-improvements.md
+++ b/docs/plans/2026-04-17-10-29-UTC-request-performance-improvements.md
@@ -1,0 +1,244 @@
+# Request performance improvements
+
+## Problem
+
+The current Bricks request model favors simple polling over request efficiency.
+That works for correctness, but it can create too many empty requests and raise
+the chance of `429` responses when either:
+
+- the web client repeatedly polls `/api/chat/sync/:sessionId`
+- the OpenClaw plugin repeatedly polls `/api/v1/platform/events`
+
+We do **not** want to implement the full fix in this task. This document is a
+future-work guide for improving request efficiency safely.
+
+## Current state
+
+### Web chat sync
+
+- `apps/mobile_chat_app/lib/features/chat/chat_screen.dart`
+- The chat UI polls `/api/chat/sync/:sessionId` every 2 seconds when the active
+  scope is routed to OpenClaw or when there are pending assistant tasks.
+- The current loop is timer-driven, not completion-driven.
+- Recent work already reduced one source of 429s by moving `/api/chat/sync/*`
+  off the coarse global `/api/*` limiter.
+
+### OpenClaw plugin polling
+
+- `apps/node_openclaw_plugin/src/pluginRunner.ts`
+- The plugin loop is already **end-to-start**:
+  1. run a full tick
+  2. pull events
+  3. ack them
+  4. write message updates
+  5. then sleep
+- Default poll interval is 2000 ms.
+
+### Backend rate limiting
+
+- `apps/node_backend/src/app.ts`
+- A coarse limiter still applies to most `/api/*` traffic:
+  - 100 requests / 15 minutes / IP
+- That is too small for any route that intentionally polls.
+- `/api/chat/sync/*` has already been carved out, but `/api/v1/platform/*`
+  still deserves its own dedicated policy.
+
+### Platform routes
+
+- `apps/node_backend/src/routes/platform.ts`
+- Platform routes already have authentication and scope checks, but they do not
+  yet have a platform-specific limiter or a long-poll contract.
+
+## Goals
+
+1. Reduce empty requests.
+2. Reduce `429` responses during normal chat/plugin operation.
+3. Keep perceived latency low when new messages arrive.
+4. Stay compatible with Vercel/serverless constraints.
+5. Avoid broad protocol changes until the smaller fixes are validated.
+
+## Recommended staged plan
+
+### Stage 1: Improve polling behavior without changing the HTTP contract
+
+#### Web `/api/chat/sync`
+
+Move the web client to **completion-based polling**:
+
+- schedule the next sync **after** the previous request finishes
+- do not use fixed periodic ticks as the source of truth
+
+Add client backoff on failed syncs:
+
+- success: `2s`
+- first failure: `4s`
+- second failure: `8s`
+- later failures: cap at `10s`
+
+Reset the delay back to `2s` after any successful response.
+
+Also:
+
+- honor `Retry-After` if the backend sends it
+- add a small jitter window (for example ±10%) so many clients do not poll in
+  lockstep
+- make sure only one sync loop is active per visible scope/tab
+
+#### OpenClaw plugin `/api/v1/platform/events`
+
+The plugin already polls end-to-start, so it is in a better shape than the web
+client. The next improvement should be **retry behavior**, not loop shape:
+
+- treat `429` and retryable `5xx` responses as backoff signals
+- use the same capped retry ladder:
+  - `2s` -> `4s` -> `8s` -> `10s`
+- prefer backend-provided `Retry-After` when present
+
+### Stage 2: Add route-specific backend rate limiting
+
+#### `/api/chat/sync/*`
+
+Keep the current approach:
+
+- do **not** let this route share the generic `/api/*` IP limiter
+- keep a route-specific budget keyed by authenticated chat context
+
+#### `/api/v1/platform/*`
+
+Add a dedicated limiter for platform traffic instead of sharing the generic IP
+bucket.
+
+Recommended keying:
+
+- JWT platform token mode: `pluginId:userId`
+- static platform key mode: `pluginId:remoteAddress` (or another stable plugin
+  identity if one is introduced later)
+
+Recommended behavior:
+
+- separate read-heavy polling routes from write routes if needed
+- return structured `429` errors with retry hints
+- avoid adding many new environment variables unless real operations require it
+
+### Stage 3: Reduce empty responses with long polling
+
+If Stage 1 and Stage 2 are still not enough, add **short long-poll** behavior.
+
+#### `/api/chat/sync/:sessionId`
+
+Allow the server to hold an empty request for up to **10 seconds** before
+returning a no-change response.
+
+Behavior:
+
+- if new messages already exist, return immediately
+- if no new messages exist, wait up to 10 seconds
+- return early as soon as new data becomes available
+- return an empty/no-change payload only when the wait window expires
+
+#### `/api/v1/platform/events`
+
+Apply the same idea to platform event pulls:
+
+- return immediately when unread events exist
+- otherwise hold the request briefly instead of replying empty right away
+
+Important note:
+
+- this is a bigger change than client backoff
+- validate carefully on Vercel/serverless before rolling it out broadly
+
+### Stage 4: Consider event-driven transport only if needed
+
+If polling and long-polling are still not sufficient, then evaluate:
+
+- Server-Sent Events for chat updates
+- Server-Sent Events for platform events
+- WebSockets only if truly bidirectional low-latency behavior is needed
+
+This should come later because it increases operational and protocol
+complexity.
+
+## Detailed implementation notes
+
+### Web sync scheduler
+
+Recommended behavior for the next implementation:
+
+1. start one sync request
+2. wait for completion
+3. decide the next delay from the outcome
+4. schedule exactly one future sync
+
+Outcome table:
+
+| Outcome | Next delay |
+| --- | --- |
+| Success | 2s |
+| Retryable failure / 429 | 4s, then 8s, then 10s max |
+| `Retry-After` present | use `Retry-After`, capped at a sane upper bound if desired |
+
+Additional safeguards:
+
+- ignore stale responses when the user changed channel/thread while the request
+  was in flight
+- cancel timers immediately on scope switch
+- consider pausing or widening intervals when the tab is hidden
+
+### Platform polling
+
+The plugin loop should remain:
+
+```text
+tick -> sleep
+```
+
+That is already the right shape.
+
+Future work should focus on:
+
+- backend rate-limit symmetry
+- retry/backoff
+- optional long-poll for empty event pulls
+
+## Validation plan
+
+### Functional tests
+
+- web sync scheduler never runs more than one request at a time
+- failure backoff caps at `10s`
+- success resets delay to `2s`
+- stale scope changes do not reschedule old loops
+- platform limiter does not block normal polling traffic
+
+### Load / soak checks
+
+- one OpenClaw-routed web tab open for 15+ minutes
+- multiple tabs for the same user
+- multiple plugin runners against the same backend
+- empty queue behavior vs active queue behavior
+
+### Metrics to watch
+
+- requests/minute per active session
+- requests/minute per active plugin
+- `429` count by route
+- empty response ratio
+- median and p95 latency
+- Vercel execution time and timeout behavior for long-poll candidates
+
+## Recommended implementation order
+
+1. Web completion-based polling with `2s -> 4s -> 8s -> 10s` capped backoff
+2. Platform route-specific limiter and plugin retry/backoff
+3. Short long-poll prototype for `/api/chat/sync`
+4. Long-poll evaluation for `/api/v1/platform/events`
+5. Event-driven transport only if polling remains insufficient
+
+## Decision log
+
+- This document intentionally records future work only.
+- We are **not** implementing the long-poll / advanced performance changes in
+  this task.
+- Prefer fixed code-level defaults first; only introduce more env config if
+  production operations actually need it.


### PR DESCRIPTION
## Summary
- change web chat sync polling to schedule the next request after the previous request finishes
- add client-side sync backoff capped at 10 seconds and reset to 2 seconds on success
- add a follow-up doc describing larger request-performance improvements for later work

## Validation
- flutter analyze lib/features/chat/chat_screen.dart
- flutter test test/chat_history_api_service_test.dart test/chat_topology_and_task_protocol_test.dart