### PR TITLE
OpenClaw: use `accepted` async state, remove assistant placeholder, add platform ack handling and docs

### DIFF
--- a/apps/mobile_chat_app/test/chat_history_api_service_test.dart
+++ b/apps/mobile_chat_app/test/chat_history_api_service_test.dart
@@ -174,6 +174,83 @@ void main() {
     expect(result.taskState, ChatTaskState.completed);
   });
 
+  test(
+    'respond maps openclaw async accepted state to sent-but-unread contract',
+    () async {
+      final client = MockClient((request) async {
+        expect(request.url.path.endsWith('/chat/respond'), isTrue);
+        expect(request.method, equals('POST'));
+        final decoded = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(decoded['channelId'], equals('default'));
+        expect(decoded['threadId'], equals('main'));
+        expect(decoded['taskId'], equals('task-openclaw-accepted'));
+        return http.Response(
+          jsonEncode({
+            'text': '',
+            'lastSeqId': 18,
+            'mode': 'async',
+            'state': 'accepted',
+          }),
+          200,
+        );
+      });
+
+      final service = ChatHistoryApiService(httpClient: client);
+      final result = await service.respond(
+        token: 'token-1',
+        taskId: 'task-openclaw-accepted',
+        idempotencyKey: 'idem-openclaw-accepted',
+        scope: const ChatSessionScope(channelId: 'default', threadId: 'main'),
+        userMessageId: 'u-openclaw-1',
+        assistantMessageId: 'a-openclaw-1',
+        userMessage: 'ping openclaw',
+      );
+
+      expect(result.isAsync, isTrue);
+      expect(result.taskState, ChatTaskState.accepted);
+      expect(result.text, isEmpty);
+      expect(result.lastSeqId, equals(18));
+    },
+  );
+
+  test(
+    'respond maps openclaw completed state to read-with-reply contract',
+    () async {
+      final client = MockClient((request) async {
+        expect(request.url.path.endsWith('/chat/respond'), isTrue);
+        expect(request.method, equals('POST'));
+        final decoded = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(decoded['taskId'], equals('task-openclaw-completed'));
+        expect(decoded['userMessage'], equals('hello plugin'));
+        return http.Response(
+          jsonEncode({
+            'text': 'plugin reply',
+            'lastSeqId': 21,
+            'mode': 'sync',
+            'state': 'completed',
+          }),
+          200,
+        );
+      });
+
+      final service = ChatHistoryApiService(httpClient: client);
+      final result = await service.respond(
+        token: 'token-1',
+        taskId: 'task-openclaw-completed',
+        idempotencyKey: 'idem-openclaw-completed',
+        scope: const ChatSessionScope(channelId: 'default', threadId: 'main'),
+        userMessageId: 'u-openclaw-2',
+        assistantMessageId: 'a-openclaw-2',
+        userMessage: 'hello plugin',
+      );
+
+      expect(result.isAsync, isFalse);
+      expect(result.taskState, ChatTaskState.completed);
+      expect(result.text, equals('plugin reply'));
+      expect(result.lastSeqId, equals(21));
+    },
+  );
+
   test('loads persisted scopes for channel/sidebar hydration', () async {
     final client = MockClient((request) async {
       expect(request.url.path.endsWith('/chat/scopes'), isTrue);

--- a/apps/node_backend/src/routes/chat.test.ts
+++ b/apps/node_backend/src/routes/chat.test.ts
@@ -144,28 +144,23 @@ describe('chat routes', () => {
       lastSeqId?: number;
     };
     expect(body.mode).toBe('async');
-    expect(body.state).toBe('dispatched');
-    expect(body.text).toBe('Waiting for OpenClaw...');
+    expect(body.state).toBe('accepted');
+    expect(body.text).toBe('');
     expect(body.lastSeqId).toBe(7);
     expect(generateWithUserConfigMock).not.toHaveBeenCalled();
     expect(upsertMessagesMock).toHaveBeenCalledWith(
       'user-123',
-      expect.arrayContaining([
+      [
         expect.objectContaining({
           messageId: 'msg-user-1',
           role: 'user',
-          taskState: 'dispatched',
+          taskState: 'accepted',
           metadata: expect.objectContaining({
             source: 'backend.respond.openclaw',
             pendingAssistantMessageId: 'msg-assistant-1',
           }),
         }),
-        expect.objectContaining({
-          messageId: 'msg-assistant-1',
-          role: 'assistant',
-          taskState: 'dispatched',
-        }),
-      ]),
+      ],
     );
   });
 

--- a/apps/node_backend/src/routes/chat.ts
+++ b/apps/node_backend/src/routes/chat.ts
@@ -26,7 +26,6 @@ import type { LlmProvider } from '../llm/types.js';
 const router = express.Router();
 router.use(authenticate);
 
-const OPENCLAW_PENDING_TEXT = 'Waiting for OpenClaw...';
 const CHAT_SYNC_WINDOW_MS = 60 * 1000;
 const CHAT_SYNC_MAX_REQUESTS_PER_WINDOW = 120;
 
@@ -137,27 +136,9 @@ router.post('/respond', async (req: AuthRequest, res: Response) => {
           threadId: input.threadId,
           role: 'user',
           content: userMessage,
-          taskState: 'dispatched',
+          taskState: 'accepted',
           checkpointCursor: null,
           metadata: userMessageMetadata,
-          createdAt: typeof body.createdAt === 'string' ? body.createdAt : null,
-        },
-        {
-          messageId: assistantMessageId,
-          taskId: acceptedTaskId,
-          channelId,
-          sessionId: acceptedSessionId,
-          threadId: input.threadId,
-          role: 'assistant',
-          content: OPENCLAW_PENDING_TEXT,
-          taskState: 'dispatched',
-          checkpointCursor: null,
-          metadata: {
-            resolvedBotId: input.resolvedBotId,
-            resolvedSkillId: input.resolvedSkillId,
-            source: 'backend.respond.openclaw.placeholder',
-            pendingFromMessageId: userMessageId,
-          },
           createdAt: typeof body.createdAt === 'string' ? body.createdAt : null,
         },
       ]);
@@ -166,9 +147,9 @@ router.post('/respond', async (req: AuthRequest, res: Response) => {
         taskId: acceptedTaskId,
         sessionId: acceptedSessionId,
         assistantMessageId,
-        text: OPENCLAW_PENDING_TEXT,
+        text: '',
         lastSeqId: persisted.lastSeqId,
-        state: 'dispatched',
+        state: 'accepted',
         mode: 'async',
         router: resolvedRouter,
       });

--- a/apps/node_backend/src/routes/platform.ts
+++ b/apps/node_backend/src/routes/platform.ts
@@ -110,6 +110,7 @@ router.post(
 
       await ackPlatformEvents({
         pluginId: req.platformPluginId ?? 'unknown',
+        userId: req.platformUserId,
         ackedEventIds,
         cursor,
       });

--- a/apps/node_backend/src/services/platformIntegrationService.test.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.test.ts
@@ -16,6 +16,7 @@ vi.mock('./chatAsyncTransportService.js', () => ({
 }));
 
 import {
+  ackPlatformEvents,
   createPlatformMessage,
   listPlatformEvents,
   patchPlatformMessage,
@@ -115,5 +116,23 @@ describe('platformIntegrationService', () => {
         }),
       ]),
     );
+  });
+
+  it('ack marks user message as completed and records plugin read marker', async () => {
+    queryMock.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const result = await ackPlatformEvents({
+      pluginId: 'plugin_local_main',
+      userId: 'u-1',
+      cursor: 'cur_5',
+      ackedEventIds: ['evt_msg_msg-user-1_5'],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("SET task_state = 'completed'");
+    expect(sql).toContain("AND task_state IN ('accepted', 'dispatched')");
+    expect(params).toEqual(['msg-user-1', 5, 'plugin_local_main', 'u-1']);
   });
 });

--- a/apps/node_backend/src/services/platformIntegrationService.test.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.test.ts
@@ -133,6 +133,7 @@ describe('platformIntegrationService', () => {
     const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]];
     expect(sql).toContain("SET task_state = 'completed'");
     expect(sql).toContain("AND task_state IN ('accepted', 'dispatched')");
-    expect(params).toEqual(['msg-user-1', 5, 'plugin_local_main', 'u-1']);
+    expect(sql).toContain('UNNEST($1::text[], $2::int[])');
+    expect(params).toEqual([['msg-user-1'], [5], 'plugin_local_main', 'u-1']);
   });
 });

--- a/apps/node_backend/src/services/platformIntegrationService.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.ts
@@ -157,11 +157,12 @@ export async function ackPlatformEvents(params: {
     throw new Error('INVALID_ACKED_EVENT_IDS');
   }
 
+  // Deduplicate to prevent redundant DB updates for duplicate event IDs in the payload.
   const ackedMessages = Array.from(
     new Map(
-      (parsedAckedMessages as { messageId: string; writeSeq: number }[]).map(
-        (item) => [`${item.messageId}:${item.writeSeq}`, item] as const,
-      ),
+      parsedAckedMessages
+        .filter((item): item is { messageId: string; writeSeq: number } => item !== null)
+        .map((item) => [`${item.messageId}:${item.writeSeq}`, item] as const),
     ).values(),
   );
 

--- a/apps/node_backend/src/services/platformIntegrationService.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.ts
@@ -100,7 +100,7 @@ export async function listPlatformEvents(params: {
          msg.metadata
        FROM chat_messages msg`;
   const queryParams: unknown[] = [afterSeq, limit];
-  const userFilter = params.userId ? ` AND msg.user_id = $${queryParams.push(params.userId)}` : '';
+  const userFilter = appendUserIdFilter(params.userId, queryParams);
   const result = await pool.query<ChatMessageEventRow>(
     `${baseSelect}
       WHERE msg.write_seq > $1${userFilter}
@@ -147,43 +147,51 @@ export async function ackPlatformEvents(params: {
   cursor: string;
   ackedEventIds: string[];
 }): Promise<{ ok: true }> {
-  // Validate inputs even though ACK persistence is intentionally deferred in the MVP.
-  // This keeps the endpoint idempotent while surfacing client-side protocol bugs.
   cursorToSeq(params.cursor);
   if (!Array.isArray(params.ackedEventIds)) {
     throw new Error('INVALID_ACKED_EVENT_IDS');
   }
-  for (const eventId of params.ackedEventIds) {
-    if (typeof eventId !== 'string' || eventId.trim().length === 0) {
-      throw new Error('INVALID_ACKED_EVENT_IDS');
-    }
+
+  const parsedAckedMessages = params.ackedEventIds.map(parseAckedMessageEventId);
+  if (parsedAckedMessages.some((item) => item === null)) {
+    throw new Error('INVALID_ACKED_EVENT_IDS');
   }
 
-  const ackedMessages = params.ackedEventIds
-    .map(parseAckedMessageEventId)
-    .filter((item): item is { messageId: string; writeSeq: number } => item !== null);
+  const ackedMessages = Array.from(
+    new Map(
+      (parsedAckedMessages as { messageId: string; writeSeq: number }[]).map(
+        (item) => [`${item.messageId}:${item.writeSeq}`, item] as const,
+      ),
+    ).values(),
+  );
 
-  for (const item of ackedMessages) {
-    const queryParams: unknown[] = [item.messageId, item.writeSeq, params.pluginId];
-    const userFilter = params.userId ? ` AND user_id = $${queryParams.push(params.userId)}` : '';
-    await pool.query(
-      `UPDATE chat_messages
-          SET task_state = 'completed',
-              metadata = jsonb_set(
-                COALESCE(metadata, '{}'::jsonb),
-                '{pluginReadBy}',
-                COALESCE(COALESCE(metadata, '{}'::jsonb)->'pluginReadBy', '{}'::jsonb)
-                  || jsonb_build_object($3, to_jsonb(CURRENT_TIMESTAMP)),
-                true
-              ),
-              updated_at = CURRENT_TIMESTAMP
-        WHERE message_id = $1
-          AND write_seq = $2
-          AND role = 'user'
-          AND task_state IN ('accepted', 'dispatched')${userFilter}`,
-      queryParams,
-    );
+  if (ackedMessages.length === 0) {
+    return { ok: true };
   }
+
+  const messageIds = ackedMessages.map((item) => item.messageId);
+  const writeSeqs = ackedMessages.map((item) => item.writeSeq);
+  const queryParams: unknown[] = [messageIds, writeSeqs, params.pluginId];
+  const userFilter = appendUserIdFilter(params.userId, queryParams);
+
+  await pool.query(
+    `UPDATE chat_messages
+        SET task_state = 'completed',
+            metadata = jsonb_set(
+              COALESCE(metadata, '{}'::jsonb),
+              '{pluginReadBy}',
+              COALESCE(COALESCE(metadata, '{}'::jsonb)->'pluginReadBy', '{}'::jsonb)
+                || jsonb_build_object($3, to_jsonb(CURRENT_TIMESTAMP)),
+              true
+            ),
+            updated_at = CURRENT_TIMESTAMP
+      WHERE (message_id, write_seq) IN (
+        SELECT * FROM UNNEST($1::text[], $2::int[])
+      )
+        AND role = 'user'
+        AND task_state IN ('accepted', 'dispatched')${userFilter}`,
+    queryParams,
+  );
   return { ok: true };
 }
 

--- a/apps/node_backend/src/services/platformIntegrationService.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.ts
@@ -105,7 +105,7 @@ export async function listPlatformEvents(params: {
     `${baseSelect}
       WHERE msg.write_seq > $1${userFilter}
         AND msg.role = 'user'
-        AND msg.task_state = 'dispatched'
+        AND msg.task_state IN ('accepted', 'dispatched')
         AND CAST(msg.metadata AS TEXT) LIKE '%pendingAssistantMessageId%'
       ORDER BY msg.write_seq ASC
       LIMIT $2`,
@@ -143,6 +143,7 @@ export async function listPlatformEvents(params: {
 
 export async function ackPlatformEvents(params: {
   pluginId: string;
+  userId?: string;
   cursor: string;
   ackedEventIds: string[];
 }): Promise<{ ok: true }> {
@@ -157,7 +158,42 @@ export async function ackPlatformEvents(params: {
       throw new Error('INVALID_ACKED_EVENT_IDS');
     }
   }
+
+  const ackedMessages = params.ackedEventIds
+    .map(parseAckedMessageEventId)
+    .filter((item): item is { messageId: string; writeSeq: number } => item !== null);
+
+  for (const item of ackedMessages) {
+    const queryParams: unknown[] = [item.messageId, item.writeSeq, params.pluginId];
+    const userFilter = params.userId ? ` AND user_id = $${queryParams.push(params.userId)}` : '';
+    await pool.query(
+      `UPDATE chat_messages
+          SET task_state = 'completed',
+              metadata = jsonb_set(
+                COALESCE(metadata, '{}'::jsonb),
+                '{pluginReadBy}',
+                COALESCE(COALESCE(metadata, '{}'::jsonb)->'pluginReadBy', '{}'::jsonb)
+                  || jsonb_build_object($3, to_jsonb(CURRENT_TIMESTAMP)),
+                true
+              ),
+              updated_at = CURRENT_TIMESTAMP
+        WHERE message_id = $1
+          AND write_seq = $2
+          AND role = 'user'
+          AND task_state IN ('accepted', 'dispatched')${userFilter}`,
+      queryParams,
+    );
+  }
   return { ok: true };
+}
+
+function parseAckedMessageEventId(eventId: string): { messageId: string; writeSeq: number } | null {
+  const match = /^evt_msg_(.+)_(\d+)$/.exec(eventId.trim());
+  if (!match) return null;
+  const messageId = match[1].trim();
+  const writeSeq = Number.parseInt(match[2], 10);
+  if (!messageId || !Number.isFinite(writeSeq) || writeSeq <= 0) return null;
+  return { messageId, writeSeq };
 }
 
 function generateMessageId(clientToken?: string): string {

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: feature_map
 owner: bricks
-last_updated: 2026-04-17
+last_updated: 2026-04-18
 purpose: >
   为人类测试员和 AI 测试员提供产品功能清单与进入路径，作为回归测试与变更影响评估的入口索引。
 

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: feature_map
 owner: bricks
-last_updated: 2026-04-16
+last_updated: 2026-04-17
 purpose: >
   为人类测试员和 AI 测试员提供产品功能清单与进入路径，作为回归测试与变更影响评估的入口索引。
 
@@ -37,6 +37,9 @@ products:
             route_hint: apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
         smoke_checks:
           - 发送一条消息后可以看到消息列表更新。
+          - 将路由切到 openclaw 后发送消息，在插件离线时应呈现“已发送但未完成（未读）”。
+          - 启动并配置 openclaw 插件后再次发送，消息应完成并出现 assistant 回复。
+          - Openclaw 异步模式下不应额外持久化 assistant 站位消息行；“已读”应由用户消息状态属性反映。
           - 发送消息后，最新 user 消息会定位在可见区域首条，assistant 回复显示在其后。
           - 打开或切换到已有历史的会话后，列表按“最新 user 消息优先”定位而非强制到底部。
           - 刷新页面后，已发送过消息的频道仍会在侧边栏中显示并可继续会话。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: logic_map
 owner: bricks
-last_updated: 2026-04-16
+last_updated: 2026-04-17
 purpose: >
   为人类测试员、AI 测试员与 AI 工程师提供“功能 -> 代码/文档/关键词”映射，
   用于影响面分析、回归测试设计与遗留逻辑清理。
@@ -47,12 +47,14 @@ index:
     doc_index:
       - docs/architecture.md
       - openspec/changes/multi-agent-participation/design.md
+      - docs/plans/2026-04-18-00-20-UTC-openclaw-message-routing-current-state.md
     test_index:
       - apps/mobile_chat_app/test/chat_arbitration_engine_test.dart
       - apps/mobile_chat_app/test/chat_topology_and_task_protocol_test.dart
       - apps/mobile_chat_app/test/chat_history_api_service_test.dart
       - apps/mobile_chat_app/test/message_list_test.dart
       - apps/mobile_chat_app/test/composer_bar_test.dart
+      - tests/usecases/mobile_chat_openclaw_web_routing.yaml
       - apps/node_backend/src/services/chatAsyncTransportService.test.ts
     keywords:
       - chat
@@ -179,8 +181,11 @@ index:
     doc_index:
       - docs/architecture.md
       - docs/openclaw_pull_only_integration_dev_doc.md
+      - docs/plans/2026-04-18-00-20-UTC-openclaw-message-routing-current-state.md
     test_index:
+      - apps/node_backend/src/routes/chat.test.ts
       - apps/node_backend/src/routes/platform.test.ts
+      - apps/node_backend/src/services/platformIntegrationService.test.ts
       - apps/node_openclaw_plugin/test/pluginRunner.test.ts
     keywords:
       - chat

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: logic_map
 owner: bricks
-last_updated: 2026-04-17
+last_updated: 2026-04-18
 purpose: >
   为人类测试员、AI 测试员与 AI 工程师提供“功能 -> 代码/文档/关键词”映射，
   用于影响面分析、回归测试设计与遗留逻辑清理。

--- a/docs/plans/2026-04-18-00-20-UTC-openclaw-message-routing-current-state.md
+++ b/docs/plans/2026-04-18-00-20-UTC-openclaw-message-routing-current-state.md
@@ -2,11 +2,9 @@
 
 ## Background
 
-为避免历史方案并存造成误解，本文件合并并替代以下旧文档中的阶段性结论：
-- `2026-04-17-09-30-UTC-openclaw-web-read-state-test.md`
-- `2026-04-17-10-25-UTC-openclaw-read-state-and-placeholder-removal.md`
-- `2026-04-17-11-15-UTC-openclaw-platform-events-filter-investigation.md`
-- `2026-04-17-11-50-UTC-openclaw-full-flow-test-coverage-review.md`
+为避免历史方案并存造成误解，本文件统一承接 2026-04-17 这一组 OpenClaw 消息路由调整的阶段性结论。
+此前对应的阶段性计划文档已从 `docs/plans/` 中移除，因此此处不再保留旧文件名列表，避免形成失效引用。
+本文件即为该主题当前唯一保留且持续维护的有效基线。
 
 ## Goals
 

--- a/docs/plans/2026-04-18-00-20-UTC-openclaw-message-routing-current-state.md
+++ b/docs/plans/2026-04-18-00-20-UTC-openclaw-message-routing-current-state.md
@@ -1,0 +1,57 @@
+# OpenClaw 消息路由与读状态（当前有效基线）
+
+## Background
+
+为避免历史方案并存造成误解，本文件合并并替代以下旧文档中的阶段性结论：
+- `2026-04-17-09-30-UTC-openclaw-web-read-state-test.md`
+- `2026-04-17-10-25-UTC-openclaw-read-state-and-placeholder-removal.md`
+- `2026-04-17-11-15-UTC-openclaw-platform-events-filter-investigation.md`
+- `2026-04-17-11-50-UTC-openclaw-full-flow-test-coverage-review.md`
+
+## Goals
+
+1. 定义 OpenClaw 路由下“已发送未读 / 已读并回复”的**当前**语义与数据形态。
+2. 明确平台事件过滤条件与空事件排查入口。
+3. 给出当前测试覆盖边界与后续补强重点。
+
+## Implementation Plan (phased)
+
+### Phase 1 — 当前行为基线（已生效）
+- OpenClaw 异步发送不再持久化 assistant 站位消息行。
+- `respond` 在 OpenClaw 路由下返回 `mode=async`, `state=accepted`, `text=''`。
+- 用户消息通过属性表达状态演进：
+  - `accepted/dispatched`：已发送待插件消费。
+  - 插件 ACK 后更新为 `completed`，并记录 `metadata.pluginReadBy.<pluginId>`。
+
+### Phase 2 — 平台事件供给条件（已生效）
+`/api/v1/platform/events` 返回事件时，需满足：
+- `write_seq > cursor`
+- `role = 'user'`
+- `task_state IN ('accepted','dispatched')`
+- `metadata` 含 `pendingAssistantMessageId`
+- 若 JWT 带 `userId`，还需匹配 `msg.user_id = token.userId`
+
+### Phase 3 — 空事件排查（当前推荐顺序）
+1. 核对 cursor 是否已追平。
+2. 核对 JWT `userId` 与消息归属用户是否一致。
+3. 核对消息是否满足 role / task_state / metadata 过滤条件。
+4. 核对插件请求头 `X-Bricks-Plugin-Id` 与 token claim/plugin scope 是否一致。
+
+### Phase 4 — 测试覆盖现状与补强方向
+- 当前覆盖是“分段覆盖”：
+  - 前端 `respond` 状态映射
+  - 后端 OpenClaw `respond` 行为
+  - 平台鉴权与 userId 透传
+  - 平台 events/ack 服务逻辑
+- 尚缺“单用例闭环集成测试”串联：
+  - `respond -> events -> messages(create/patch) -> ack -> sync`
+
+## Acceptance Criteria
+
+1. 仓库仅保留本文件作为 2026-04-17 这一组 OpenClaw 消息路由调整的有效基线。
+2. 旧阶段性文档删除并由本文件统一承接。
+3. 代码地图索引仅指向本文件，不再指向旧文档。
+
+### Validation commands
+
+- `git diff -- docs/plans docs/code_maps/logic_map.yaml`

--- a/tests/usecases/mobile_chat_openclaw_web_routing.yaml
+++ b/tests/usecases/mobile_chat_openclaw_web_routing.yaml
@@ -1,0 +1,33 @@
+module: mobile_chat_openclaw_web_routing
+
+openclaw_router_delivery_states:
+  description: Validate deterministic web-visible delivery state transitions when channel router is set to openclaw.
+  given:
+    - description: The web chat channel router is configured to openclaw and backend respond API is reachable in local test mode.
+      when:
+        - description: A user sends a message while the OpenClaw plugin is offline and backend responds with async accepted state.
+          then:
+            - The web client shows the message as sent with a non-completed task state.
+            - The web client keeps the assistant reply pending or empty until completion arrives.
+        - description: A user sends a message after OpenClaw plugin is started and configured, and backend responds with completed state and reply text.
+          then:
+            - The web client marks the task as completed.
+            - The web client renders the assistant reply text in the conversation.
+
+openclaw_router_full_flow_contract:
+  description: Validate the full contract from user send to plugin consumption, read acknowledgment, and visible reply.
+  given:
+    - description: The user has set router to openclaw and backend stores user messages with pendingAssistantMessageId metadata.
+      when:
+        - description: The plugin pulls events with a cursor lower than the new user message write_seq.
+          then:
+            - The events API returns the user message event with message text and pendingAssistantMessageId metadata.
+            - The event is filtered by token user scope when JWT userId is present.
+        - description: The plugin posts assistant create and patch messages for the consumed event.
+          then:
+            - The assistant message reuses the pendingAssistantMessageId as client token to keep message identity stable.
+            - The conversation shows the assistant reply as the completion of that event handling.
+        - description: The plugin sends ACK with the consumed event id and cursor.
+          then:
+            - The backend marks the related user message as completed.
+            - The backend records plugin-specific read metadata for audit and debugging.


### PR DESCRIPTION
### Motivation
- Unify OpenClaw async semantics so a sent-but-unread state is represented by the user message `task_state` rather than a persisted assistant placeholder and make plugin ACKs mark messages as read/completed.
- Ensure platform events surface messages for both `accepted` and legacy `dispatched` states so plugins can pull pending work.
- Record plugin-specific read markers for auditing and debugging and update client/server contracts and tests accordingly.

### Description
- Update `POST /api/chat/respond` (`apps/node_backend/src/routes/chat.ts`) to stop persisting an assistant placeholder, write the user message `task_state` as `accepted`, and return `mode: 'async'`, `state: 'accepted'`, and `text: ''` for OpenClaw routing instead of the previous placeholder text and `dispatched` state.
- Extend event selection in `listPlatformEvents` (`apps/node_backend/src/services/platformIntegrationService.ts`) to include `task_state IN ('accepted','dispatched')` so OpenClaw-ready events are returned for both states.
- Add `ackPlatformEvents` implementation to `platformIntegrationService.ts` to parse acked event ids, mark corresponding user messages as `completed`, and record `metadata.pluginReadBy.<pluginId>` timestamps with an optional `userId` filter; add `parseAckedMessageEventId` helper.
- Wire `userId` through the platform ack route (`apps/node_backend/src/routes/platform.ts`) so the ack operation can scope updates to a specific user.
- Remove the `OPENCLAW_PENDING_TEXT` constant and related persisted assistant placeholder message creation.
- Update and add tests: adjust expectations in `apps/node_backend/src/routes/chat.test.ts`, add ack test in `apps/node_backend/src/services/platformIntegrationService.test.ts`, and add mapping tests in `apps/mobile_chat_app/test/chat_history_api_service_test.dart` for OpenClaw `accepted` and `completed` mappings.
- Add documentation and test matrices: new plan `docs/plans/2026-04-18-00-20-UTC-openclaw-message-routing-current-state.md`, update `docs/code_maps/*`, and add `tests/usecases/mobile_chat_openclaw_web_routing.yaml` describing expected client-visible flows.

### Testing
- Ran backend route tests: `apps/node_backend/src/routes/chat.test.ts` updated expectations for OpenClaw and passed.
- Ran backend service tests: `apps/node_backend/src/services/platformIntegrationService.test.ts` including the new `ackPlatformEvents` case and they passed.
- Ran frontend unit tests: `apps/mobile_chat_app/test/chat_history_api_service_test.dart` with new OpenClaw mapping tests and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20d7deb04832d96e8b3da3fa4a9eb)