### PR TITLE
style(chat): remove assistant bubble and reduce horizontal inset

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -197,22 +197,27 @@ class _MessageListState extends State<MessageList> {
                     'bubble-${msg.messageId ?? '${msg.timestamp}-$index'}',
                   ),
                   margin: const EdgeInsets.only(bottom: BricksSpacing.xs),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: BricksSpacing.md,
-                    vertical: BricksSpacing.sm,
-                  ),
+                  padding: isUser
+                      ? const EdgeInsets.symmetric(
+                          horizontal: BricksSpacing.md,
+                          vertical: BricksSpacing.sm,
+                        )
+                      : const EdgeInsets.symmetric(
+                          horizontal: BricksSpacing.xs,
+                          vertical: BricksSpacing.xs,
+                        ),
                   width: isUser ? null : double.infinity,
                   constraints: isUser
                       ? BoxConstraints(
                           maxWidth: MediaQuery.of(context).size.width * 0.75,
                         )
                       : null,
-                  decoration: BoxDecoration(
-                    color: isUser
-                        ? Theme.of(context).colorScheme.primary
-                        : Theme.of(context).colorScheme.surfaceContainerHighest,
-                    borderRadius: BorderRadius.circular(BricksRadius.md),
-                  ),
+                  decoration: isUser
+                      ? BoxDecoration(
+                          color: Theme.of(context).colorScheme.primary,
+                          borderRadius: BorderRadius.circular(BricksRadius.md),
+                        )
+                      : null,
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
@@ -227,12 +232,12 @@ class _MessageListState extends State<MessageList> {
                       else
                         Text(
                           msg.content,
-                          style:
-                              Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .onSurface,
-                                  ),
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodyMedium
+                              ?.copyWith(
+                                color: Theme.of(context).colorScheme.onSurface,
+                              ),
                         ),
                       if (msg.isStreaming)
                         Padding(

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -194,7 +194,7 @@ class _MessageListState extends State<MessageList> {
                   ),
                 Container(
                   key: ValueKey<String>(
-                    'bubble-${msg.messageId ?? '${msg.timestamp}-$index'}',
+                    'message-${msg.messageId ?? '${msg.timestamp}-$index'}',
                   ),
                   margin: const EdgeInsets.only(bottom: BricksSpacing.xs),
                   padding: isUser

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -168,6 +168,24 @@ void main() {
     });
   });
 
+  testWidgets('does not render a bubble decoration for assistant messages',
+      (tester) async {
+    final assistant = ChatMessage(
+      messageId: 'assistant-plain',
+      role: 'assistant',
+      content: 'plain assistant content',
+      timestamp: DateTime.utc(2026, 1, 1),
+    );
+
+    await tester.pumpWidget(_build([assistant]));
+    await tester.pumpAndSettle();
+
+    final assistantContainer = tester.widget<Container>(
+      find.byKey(const ValueKey<String>('bubble-assistant-plain')),
+    );
+    expect(assistantContainer.decoration, isNull);
+  });
+
   group('MessageList bubble width', () {
     testWidgets(
         'assistant bubble uses full list width while user stays compact',
@@ -196,7 +214,7 @@ void main() {
       );
 
       expect(assistantBox.size.width, greaterThan(userBox.size.width));
-      expect(assistantBox.size.width, greaterThanOrEqualTo(320));
+      expect(assistantBox.size.width, greaterThanOrEqualTo(330));
     });
   });
 }

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -168,7 +168,7 @@ void main() {
     });
   });
 
-  testWidgets('does not render a bubble decoration for assistant messages',
+  testWidgets('does not render a decoration for assistant messages',
       (tester) async {
     final assistant = ChatMessage(
       messageId: 'assistant-plain',
@@ -181,14 +181,14 @@ void main() {
     await tester.pumpAndSettle();
 
     final assistantContainer = tester.widget<Container>(
-      find.byKey(const ValueKey<String>('bubble-assistant-plain')),
+      find.byKey(const ValueKey<String>('message-assistant-plain')),
     );
     expect(assistantContainer.decoration, isNull);
   });
 
-  group('MessageList bubble width', () {
+  group('MessageList message width', () {
     testWidgets(
-        'assistant bubble uses full list width while user stays compact',
+        'assistant message uses full list width while user stays compact',
         (tester) async {
       final user = ChatMessage(
         messageId: 'u',
@@ -207,10 +207,10 @@ void main() {
       await tester.pumpAndSettle();
 
       final userBox = tester.renderObject<RenderBox>(
-        find.byKey(const ValueKey<String>('bubble-u')),
+        find.byKey(const ValueKey<String>('message-u')),
       );
       final assistantBox = tester.renderObject<RenderBox>(
-        find.byKey(const ValueKey<String>('bubble-a')),
+        find.byKey(const ValueKey<String>('message-a')),
       );
 
       expect(assistantBox.size.width, greaterThan(userBox.size.width));

--- a/docs/plans/2026-04-18-03-19-UTC-ai-message-no-bubble.md
+++ b/docs/plans/2026-04-18-03-19-UTC-ai-message-no-bubble.md
@@ -1,0 +1,18 @@
+# Background
+The mobile chat message list currently renders both user and assistant messages inside rounded bubble containers. For assistant replies, this consumes horizontal space due to bubble padding and creates a denser layout than desired.
+
+# Goals
+- Remove the bubble visual treatment for assistant messages in the conversation list.
+- Reduce horizontal spacing for assistant output so more text fits per line.
+- Keep user message bubble style and behavior unchanged.
+
+# Implementation Plan (phased)
+1. Update `MessageList` assistant row rendering to use plain text content without background bubble decoration.
+2. Keep user branch on the existing bubble styling path so outgoing message visuals are unchanged.
+3. Adjust/add widget tests to verify assistant layout width increases while user bubble constraints remain.
+
+# Acceptance Criteria
+- Assistant messages no longer show a rounded/background bubble container in the message list.
+- Assistant messages have less horizontal inset than before and display a wider content area.
+- User messages still render with existing bubble style and compact width constraints.
+- Validation command passes: `cd apps/mobile_chat_app && flutter test test/message_list_test.dart`.


### PR DESCRIPTION
### Motivation
- Assistant (AI) messages should use a plain text presentation so they occupy less horizontal padding and show more content per line while user messages keep their existing bubble styling. 
- This change improves message density for assistant output in the conversation list without altering chat behavior or routing. 

### Description
- Update `MessageList` to conditionally apply `padding` and `decoration` on the message container so `assistant` rows no longer set a `decoration` and use smaller horizontal insets while `user` rows retain the original bubble `BoxDecoration` and width constraint. 
- Adjusted assistant text style formatting in `apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart` to match the new layout. 
- Added a widget test `does not render a bubble decoration for assistant messages` in `apps/mobile_chat_app/test/message_list_test.dart` and bumped the assistant width assertion threshold to reflect the wider layout. 
- Added a plan file `docs/plans/2026-04-18-03-19-UTC-ai-message-no-bubble.md`; no code map update was made because the change is strictly presentational and does not modify feature entry points or business-logic paths. 

### Testing
- Ran the widget test suite with `cd apps/mobile_chat_app && flutter test test/message_list_test.dart` and all tests passed (`All tests passed!`, 9 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f835ab14832d8c3b94d75ff261fb)