### PR TITLE
Relocate chat router switch into ComposerBar and add dynamic router icon

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -174,12 +174,10 @@ class _ChatScreenState extends State<ChatScreen> {
         _activeAgent ??= definitions.isNotEmpty ? definitions.first : null;
         _loadingAgents = false;
         _llmConfigs = llmConfigs;
-        _sessionConfigSlotId ??= llmConfigs.isNotEmpty
-            ? defaultConfig.slotId
-            : null;
-        _sessionModelOverride ??= llmConfigs.isNotEmpty
-            ? defaultConfig.defaultModel
-            : null;
+        _sessionConfigSlotId ??=
+            llmConfigs.isNotEmpty ? defaultConfig.slotId : null;
+        _sessionModelOverride ??=
+            llmConfigs.isNotEmpty ? defaultConfig.defaultModel : null;
         _loadingLlmConfigs = false;
         _authToken = authToken;
         _channels
@@ -265,8 +263,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
   AgentSettings _settingsForAgent(AgentDefinition? agent) {
     final selectedConfig = _activeLlmConfig;
-    final selectedModel =
-        _sessionModelOverride ??
+    final selectedModel = _sessionModelOverride ??
         selectedConfig?.defaultModel ??
         _resolveModelId(agent?.model);
     return AgentSettings(
@@ -314,8 +311,7 @@ class _ChatScreenState extends State<ChatScreen> {
       return;
     }
 
-    var selectedSlot =
-        _sessionConfigSlotId ??
+    var selectedSlot = _sessionConfigSlotId ??
         _llmConfigs
             .firstWhere((c) => c.isDefault, orElse: () => _llmConfigs.first)
             .slotId;
@@ -521,8 +517,7 @@ class _ChatScreenState extends State<ChatScreen> {
       final current = byChannel[scope.channelId];
       final currentAt = current?.lastActivityAt;
       final nextAt = scope.lastActivityAt;
-      final shouldReplace =
-          current == null ||
+      final shouldReplace = current == null ||
           (nextAt != null && (currentAt == null || nextAt.isAfter(currentAt)));
       if (shouldReplace) byChannel[scope.channelId] = scope;
     }
@@ -734,8 +729,8 @@ class _ChatScreenState extends State<ChatScreen> {
     final sections = _channelSubSections[resolvedChannelId] ?? const [];
     final restoredSubSection =
         (remembered != null && sections.any((s) => s.id == remembered))
-        ? remembered
-        : 'main';
+            ? remembered
+            : 'main';
     _cancelSyncPolling();
     setState(() {
       _activeChannelId = resolvedChannelId;
@@ -771,9 +766,9 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   ChatSessionScope get _activeScope => ChatSessionScope(
-    channelId: _activeChannelId,
-    threadId: _activeSubSection,
-  );
+        channelId: _activeChannelId,
+        threadId: _activeSubSection,
+      );
 
   String get _sessionIdForScope => _activeScope.sessionId;
 
@@ -1011,10 +1006,9 @@ class _ChatScreenState extends State<ChatScreen> {
     if (latest == null) return;
     setState(() {
       _subSectionLastMessageAt[_subSectionKey(
-            resolvedChannelId,
-            resolvedSubSection,
-          )] =
-          latest;
+        resolvedChannelId,
+        resolvedSubSection,
+      )] = latest;
     });
   }
 
@@ -1047,13 +1041,12 @@ class _ChatScreenState extends State<ChatScreen> {
       _chatHistoryApiService
           .upsertMessages(token: token, messages: _messages)
           .then((lastSeq) {
-            if (!mounted || lastSeq <= 0) return;
-            // Only advance the cursor, never move it backwards.
-            setState(() {
-              if (lastSeq > _lastSyncedSeq) _lastSyncedSeq = lastSeq;
-            });
-          })
-          .catchError((_) {}),
+        if (!mounted || lastSeq <= 0) return;
+        // Only advance the cursor, never move it backwards.
+        setState(() {
+          if (lastSeq > _lastSyncedSeq) _lastSyncedSeq = lastSeq;
+        });
+      }).catchError((_) {}),
     );
   }
 
@@ -1296,18 +1289,16 @@ class _ChatScreenState extends State<ChatScreen> {
       messageId: message.messageId ?? _newId('msg'),
       channelId: message.channelId ?? _activeScope.channelId,
       sessionId: message.sessionId ?? _activeScope.sessionId,
-      threadId:
-          message.threadId ??
+      threadId: message.threadId ??
           (_activeScope.threadId == 'main' ? null : _activeScope.threadId),
     );
     final messageTime = normalized.createdAt ?? normalized.timestamp;
     setState(() {
       _messages.add(normalized);
       _subSectionLastMessageAt[_subSectionKey(
-            _activeScope.channelId,
-            _activeScope.threadId,
-          )] =
-          messageTime;
+        _activeScope.channelId,
+        _activeScope.threadId,
+      )] = messageTime;
     });
     final shouldPersistImmediately =
         normalized.role == 'user' || (!normalized.isStreaming);
@@ -1320,9 +1311,8 @@ class _ChatScreenState extends State<ChatScreen> {
 
     final agent = _activeAgent;
     final activeParticipants = _participantManager.participants.active;
-    final positiveCandidates = activeParticipants
-        .where((item) => item.probability > 1e-9)
-        .toList();
+    final positiveCandidates =
+        activeParticipants.where((item) => item.probability > 1e-9).toList();
     final arbitrationMode = positiveCandidates.length > 1;
     final arbitration = _arbitrationEngine.resolve(
       candidates: positiveCandidates
@@ -1433,72 +1423,68 @@ class _ChatScreenState extends State<ChatScreen> {
     final generation = ++_respondGeneration;
     _chatHistoryApiService
         .respond(
-          token: token,
-          taskId: taskId,
-          idempotencyKey: idempotencyKey,
-          scope: _activeScope,
-          userMessageId: _messages[agentMessageIndex - 1].messageId!,
-          assistantMessageId: _messages[agentMessageIndex].messageId!,
-          userMessage: text,
-          resolvedBotId: resolvedBotId,
-          resolvedSkillId: resolvedSkillId,
-          provider: runtimeSettings.provider,
-          model: runtimeSettings.model,
-          configId: runtimeSettings.configId,
-          createdAt: envelope.createdAt,
-        )
+      token: token,
+      taskId: taskId,
+      idempotencyKey: idempotencyKey,
+      scope: _activeScope,
+      userMessageId: _messages[agentMessageIndex - 1].messageId!,
+      assistantMessageId: _messages[agentMessageIndex].messageId!,
+      userMessage: text,
+      resolvedBotId: resolvedBotId,
+      resolvedSkillId: resolvedSkillId,
+      provider: runtimeSettings.provider,
+      model: runtimeSettings.model,
+      configId: runtimeSettings.configId,
+      createdAt: envelope.createdAt,
+    )
         .then((result) async {
-          if (!mounted || agentMessageIndex >= _messages.length) return;
-          // Ignore stale completions if stop was pressed after this request started.
-          if (generation != _respondGeneration) return;
-          setState(() {
-            _messages[agentMessageIndex] = _messages[agentMessageIndex]
-                .copyWith(
-                  content: result.text,
-                  isStreaming: false,
-                  taskState:
-                      result.taskState ??
-                      (result.isAsync
-                          ? ChatTaskState.dispatched
-                          : ChatTaskState.completed),
-                );
-            if (result.lastSeqId > _lastSyncedSeq) {
-              _lastSyncedSeq = result.lastSeqId;
-            }
-            if (result.isAsync) {
-              _isSending = false;
-              _isStreaming = false;
-            }
-          });
-          if (result.isAsync) {
-            _configureActiveScopeSync();
-            return;
-          }
-          // Backend already persisted both messages; skip redundant client-side
-          // upsert to avoid overwriting backend-only metadata (provider/model/source).
-          if (mounted) {
-            await _handleProactiveResponses(text);
-            setState(() {
-              _isSending = false;
-              _isStreaming = false;
-            });
-          }
-        })
-        .catchError((error) {
-          if (!mounted || agentMessageIndex >= _messages.length) return;
-          if (generation != _respondGeneration) return;
-          setState(() {
-            _messages[agentMessageIndex] = _messages[agentMessageIndex]
-                .copyWith(
-                  content: 'Error: $error',
-                  isStreaming: false,
-                  taskState: ChatTaskState.failed,
-                );
-            _isSending = false;
-            _isStreaming = false;
-          });
-          _persistActiveScopeMessages(immediate: true);
+      if (!mounted || agentMessageIndex >= _messages.length) return;
+      // Ignore stale completions if stop was pressed after this request started.
+      if (generation != _respondGeneration) return;
+      setState(() {
+        _messages[agentMessageIndex] = _messages[agentMessageIndex].copyWith(
+          content: result.text,
+          isStreaming: false,
+          taskState: result.taskState ??
+              (result.isAsync
+                  ? ChatTaskState.dispatched
+                  : ChatTaskState.completed),
+        );
+        if (result.lastSeqId > _lastSyncedSeq) {
+          _lastSyncedSeq = result.lastSeqId;
+        }
+        if (result.isAsync) {
+          _isSending = false;
+          _isStreaming = false;
+        }
+      });
+      if (result.isAsync) {
+        _configureActiveScopeSync();
+        return;
+      }
+      // Backend already persisted both messages; skip redundant client-side
+      // upsert to avoid overwriting backend-only metadata (provider/model/source).
+      if (mounted) {
+        await _handleProactiveResponses(text);
+        setState(() {
+          _isSending = false;
+          _isStreaming = false;
         });
+      }
+    }).catchError((error) {
+      if (!mounted || agentMessageIndex >= _messages.length) return;
+      if (generation != _respondGeneration) return;
+      setState(() {
+        _messages[agentMessageIndex] = _messages[agentMessageIndex].copyWith(
+          content: 'Error: $error',
+          isStreaming: false,
+          taskState: ChatTaskState.failed,
+        );
+        _isSending = false;
+        _isStreaming = false;
+      });
+      _persistActiveScopeMessages(immediate: true);
+    });
   }
 
   void _stopStreaming() {
@@ -1752,47 +1738,6 @@ class _ChatScreenState extends State<ChatScreen> {
           actions: [
             PopupMenuButton<String>(
               popUpAnimationStyle: BricksTheme.menuPopupAnimationStyle,
-              tooltip: 'Router settings',
-              onSelected: _handleRouterMenuSelection,
-              itemBuilder: (context) => [
-                PopupMenuItem<String>(
-                  enabled: false,
-                  child: Text(
-                    'Channel router · ${_routerLabel(_channelRouters[_activeChannelId] ?? ChatRouter.defaultRoute)}',
-                  ),
-                ),
-                const PopupMenuItem<String>(
-                  value: 'channel:default',
-                  child: Text('Bricks Default'),
-                ),
-                const PopupMenuItem<String>(
-                  value: 'channel:openclaw',
-                  child: Text('OpenClaw'),
-                ),
-                const PopupMenuDivider(),
-                PopupMenuItem<String>(
-                  enabled: false,
-                  child: Text(
-                    'Thread router · ${_threadRouterMenuLabel(_explicitThreadRouter())}',
-                  ),
-                ),
-                const PopupMenuItem<String>(
-                  value: 'thread:inherit',
-                  child: Text('Follow channel'),
-                ),
-                const PopupMenuItem<String>(
-                  value: 'thread:default',
-                  child: Text('Bricks Default'),
-                ),
-                const PopupMenuItem<String>(
-                  value: 'thread:openclaw',
-                  child: Text('OpenClaw'),
-                ),
-              ],
-              icon: const Icon(Icons.alt_route),
-            ),
-            PopupMenuButton<String>(
-              popUpAnimationStyle: BricksTheme.menuPopupAnimationStyle,
               tooltip: 'Sub sections',
               onSelected: (value) {
                 if (value == '__new__') {
@@ -1835,7 +1780,7 @@ class _ChatScreenState extends State<ChatScreen> {
                       _activeSubSection == 'main'
                           ? '主区'
                           : (_subSectionNameById(_activeSubSection) ??
-                                _activeSubSection),
+                              _activeSubSection),
                     ),
                     const Icon(Icons.arrow_drop_down),
                   ],
@@ -1851,6 +1796,58 @@ class _ChatScreenState extends State<ChatScreen> {
             ComposerBar(
               activeAgent: _activeAgent,
               agents: _agents,
+              routerAction: PopupMenuButton<String>(
+                popUpAnimationStyle: BricksTheme.menuPopupAnimationStyle,
+                tooltip: 'Router settings',
+                onSelected: _handleRouterMenuSelection,
+                itemBuilder: (context) => [
+                  PopupMenuItem<String>(
+                    enabled: false,
+                    child: Text(
+                      'Channel router · ${_routerLabel(_channelRouters[_activeChannelId] ?? ChatRouter.defaultRoute)}',
+                    ),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: 'channel:default',
+                    child: Text('Bricks Default'),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: 'channel:openclaw',
+                    child: Text('OpenClaw'),
+                  ),
+                  const PopupMenuDivider(),
+                  PopupMenuItem<String>(
+                    enabled: false,
+                    child: Text(
+                      'Thread router · ${_threadRouterMenuLabel(_explicitThreadRouter())}',
+                    ),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: 'thread:inherit',
+                    child: Text('Follow channel'),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: 'thread:default',
+                    child: Text('Bricks Default'),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: 'thread:openclaw',
+                    child: Text('OpenClaw'),
+                  ),
+                ],
+                icon: SizedBox.square(
+                  dimension: 24,
+                  child: Center(
+                    child: _effectiveRouterForScope() == ChatRouter.openclaw
+                        ? const Text(
+                            '🦞',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(fontSize: 18, height: 1),
+                          )
+                        : const Icon(Icons.alt_route, size: 20),
+                  ),
+                ),
+              ),
               onAgentSelected: _selectAgent,
               onOpenModelSelection: _openRuntimeModelConfigDialog,
               onShowInfo: _showDebugInfoDialog,

--- a/apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
@@ -11,6 +11,7 @@ class ComposerBar extends StatefulWidget {
     super.key,
     required this.agents,
     this.activeAgent,
+    this.routerAction,
     this.onSend,
     this.onAgentSelected,
     this.onOpenModelSelection,
@@ -24,6 +25,9 @@ class ComposerBar extends StatefulWidget {
 
   /// The agent currently selected for replies.
   final AgentDefinition? activeAgent;
+
+  /// Optional router switch action displayed before composer action buttons.
+  final Widget? routerAction;
 
   /// Called when the user submits a message. Null while a send is in progress.
   final void Function(String text)? onSend;
@@ -194,6 +198,10 @@ class _ComposerBarState extends State<ComposerBar>
                     padding: const EdgeInsets.only(right: BricksSpacing.xs),
                     child: Row(
                       children: [
+                        if (widget.routerAction != null) ...[
+                          widget.routerAction!,
+                          const SizedBox(width: BricksSpacing.xs),
+                        ],
                         PopupMenuButton<ComposerMenuAction>(
                           popUpAnimationStyle:
                               BricksTheme.menuPopupAnimationStyle,

--- a/apps/mobile_chat_app/test/composer_bar_test.dart
+++ b/apps/mobile_chat_app/test/composer_bar_test.dart
@@ -156,8 +156,17 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.byTooltip('Router settings'), findsOneWidget);
-      expect(find.byType(PopupMenuButton<ComposerMenuAction>), findsOneWidget);
+      final routerActionFinder = find.byTooltip('Router settings');
+      final menuButtonFinder =
+          find.byType(PopupMenuButton<ComposerMenuAction>);
+
+      expect(routerActionFinder, findsOneWidget);
+      expect(menuButtonFinder, findsOneWidget);
+
+      final routerActionPosition = tester.getTopLeft(routerActionFinder);
+      final menuButtonPosition = tester.getTopLeft(menuButtonFinder);
+
+      expect(routerActionPosition.dx, lessThan(menuButtonPosition.dx));
     });
   });
 

--- a/apps/mobile_chat_app/test/composer_bar_test.dart
+++ b/apps/mobile_chat_app/test/composer_bar_test.dart
@@ -8,7 +8,9 @@ import 'package:mobile_chat_app/features/chat/widgets/composer_bar.dart';
 const _settle = Duration(milliseconds: 300);
 
 Widget _buildBar(
-        {VoidCallback? onOpenModelSelection, VoidCallback? onShowInfo}) =>
+        {VoidCallback? onOpenModelSelection,
+        VoidCallback? onShowInfo,
+        Widget? routerAction}) =>
     MaterialApp(
       home: Scaffold(
         body: Column(
@@ -16,6 +18,7 @@ Widget _buildBar(
           children: [
             ComposerBar(
               agents: const [],
+              routerAction: routerAction,
               onOpenModelSelection: onOpenModelSelection,
               onShowInfo: onShowInfo,
             ),
@@ -138,6 +141,23 @@ void main() {
       );
       expect(button.enabled, isFalse);
       expect(called, isFalse);
+    });
+
+    testWidgets('renders optional router action before composer menu button',
+        (tester) async {
+      await tester.pumpWidget(
+        _buildBar(
+          routerAction: const IconButton(
+            onPressed: null,
+            tooltip: 'Router settings',
+            icon: Icon(Icons.alt_route),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byTooltip('Router settings'), findsOneWidget);
+      expect(find.byType(PopupMenuButton<ComposerMenuAction>), findsOneWidget);
     });
   });
 

--- a/docs/plans/2026-04-18-15-06-UTC-chat-router-button-relocation.md
+++ b/docs/plans/2026-04-18-15-06-UTC-chat-router-button-relocation.md
@@ -1,0 +1,24 @@
+# Background
+The chat page currently shows a router switch popup button in the top-right AppBar area. The requested UX is to place the router switch control near the composer controls at the lower-left side, immediately to the left of the existing tune/config button, and to show route-specific icons (including a lobster icon for openclaw).
+
+# Goals
+- Move the router switch button from AppBar actions to the composer action row.
+- Place the router button to the left of the existing config/tune button.
+- Make the router button icon reflect the currently effective router:
+  - default route: suitable default routing icon
+  - openclaw route: lobster icon (🦞)
+- Keep button sizing/layout stable regardless of icon type.
+
+# Implementation Plan (phased)
+1. Extend `ComposerBar` API to accept an optional router menu button widget that can be rendered before the config button.
+2. In `ChatScreen`, remove the existing AppBar router popup button.
+3. In `ChatScreen`, build the router popup button and pass it into `ComposerBar` through the new slot.
+4. Implement dynamic icon rendering for router button based on `_effectiveRouterForScope()`, using a fixed-size container so emoji/icon changes do not alter layout.
+5. Run formatting and targeted Flutter tests.
+
+# Acceptance Criteria
+- Router popup button no longer appears in top-right AppBar.
+- Router popup button appears in composer controls, immediately left of the config/tune button.
+- Effective router icon changes with route state (default uses routing icon, openclaw shows 🦞).
+- Switching icon does not change button size or row layout.
+- Validation commands pass (at minimum: `dart format` on modified files and relevant Flutter test command).


### PR DESCRIPTION
### Motivation
- The router switch control currently lives in the `AppBar` and should be moved next to the composer controls for the requested UX change. 
- The router button must show a route-appropriate icon (default route vs `openclaw`) while preserving button size and layout. 
- Provide a stable injection point so the chat screen can place the router control immediately left of the composer config/tune button.

### Description
- Add an optional `routerAction` slot to `ComposerBar` via the new `routerAction` property so callers can inject a router control into the composer action row (`apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart`).
- Remove the router popup from the `AppBar` and instead construct a `PopupMenuButton` for router settings and pass it into `ComposerBar.routerAction` in `ChatScreen` (`apps/mobile_chat_app/lib/features/chat/chat_screen.dart`).
- Make the router icon reflect the effective router by rendering a fixed-size icon container (`SizedBox.square(dimension: 24)`) that shows `Icons.alt_route` for the default route and a lobster emoji `🦞` for `ChatRouter.openclaw`, keeping dimensions stable so icons do not affect layout. 
- Update widget tests in `apps/mobile_chat_app/test/composer_bar_test.dart` to accept and validate the optional `routerAction` rendering, and add a task plan file under `docs/plans/2026-04-18-15-06-UTC-chat-router-button-relocation.md` documenting the change.
- Reviewed `docs/code_maps/*` and did not change feature or logic map entries because this is a UI relocation within the same chat feature flow.

### Testing
- Ran environment bootstrap with `./tools/init_dev_env.sh` which completed successfully. 
- Ran formatter with `dart format` on modified files (`apps/mobile_chat_app/lib/features/chat/chat_screen.dart`, `apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart`, `apps/mobile_chat_app/test/composer_bar_test.dart`) and formatting succeeded. 
- Executed the targeted Flutter unit test `cd apps/mobile_chat_app && flutter test test/composer_bar_test.dart` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39ddf57f8832db3affcdd1d81254a)