### PR TITLE
Fix message chronology when switching between OpenClaw and default router

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
@@ -62,8 +62,8 @@ class ChatAcceptedTask {
 
 class ChatHistoryApiService {
   ChatHistoryApiService({http.Client? httpClient})
-    : _httpClient = httpClient ?? http.Client(),
-      _ownsHttpClient = httpClient == null;
+      : _httpClient = httpClient ?? http.Client(),
+        _ownsHttpClient = httpClient == null;
 
   final http.Client _httpClient;
   final bool _ownsHttpClient;
@@ -90,12 +90,12 @@ class ChatHistoryApiService {
   String get _base => LlmConfigService.resolveBaseUrl();
 
   Uri _historyUri(String sessionId, {required int limit}) => Uri.parse(
-    '$_base/api/chat/history/${Uri.encodeComponent(sessionId)}?limit=$limit',
-  );
+        '$_base/api/chat/history/${Uri.encodeComponent(sessionId)}?limit=$limit',
+      );
 
   Uri _syncUri(String sessionId, {required int afterSeq}) => Uri.parse(
-    '$_base/api/chat/sync/${Uri.encodeComponent(sessionId)}?afterSeq=$afterSeq',
-  );
+        '$_base/api/chat/sync/${Uri.encodeComponent(sessionId)}?afterSeq=$afterSeq',
+      );
 
   Uri get _acceptTaskUri => Uri.parse('$_base/api/chat/tasks/accept');
 
@@ -109,6 +109,18 @@ class ChatHistoryApiService {
       if (state.name == value) return state;
     }
     return null;
+  }
+
+  int _compareMessagesByCreatedTime(ChatMessage a, ChatMessage b) {
+    final aTime = a.createdAt ?? a.timestamp;
+    final bTime = b.createdAt ?? b.timestamp;
+    final byTime = aTime.compareTo(bTime);
+    if (byTime != 0) return byTime;
+    if (a.role != b.role) {
+      if (a.role == 'user') return -1;
+      if (b.role == 'user') return 1;
+    }
+    return (a.messageId ?? '').compareTo(b.messageId ?? '');
   }
 
   Future<List<ChatPersistedScope>> loadScopes({required String token}) async {
@@ -158,21 +170,20 @@ class ChatHistoryApiService {
         .whereType<Map>()
         .map((item) => Map<String, dynamic>.from(item))
         .map((item) {
-          final scopeType = chatScopeTypeFromApi(item['scopeType'] as String?);
-          if (scopeType == null) {
-            throw const FormatException('Invalid scopeType');
-          }
-          return ChatScopeSetting(
-            scopeType: scopeType,
-            channelId: (item['channelId'] as String?) ?? 'default',
-            threadId: item['threadId'] as String?,
-            router: chatRouterFromApi(item['router'] as String?),
-            updatedAt: item['updatedAt'] is String
-                ? DateTime.tryParse(item['updatedAt'] as String)
-                : null,
-          );
-        })
-        .toList(growable: false);
+      final scopeType = chatScopeTypeFromApi(item['scopeType'] as String?);
+      if (scopeType == null) {
+        throw const FormatException('Invalid scopeType');
+      }
+      return ChatScopeSetting(
+        scopeType: scopeType,
+        channelId: (item['channelId'] as String?) ?? 'default',
+        threadId: item['threadId'] as String?,
+        router: chatRouterFromApi(item['router'] as String?),
+        updatedAt: item['updatedAt'] is String
+            ? DateTime.tryParse(item['updatedAt'] as String)
+            : null,
+      );
+    }).toList(growable: false);
   }
 
   Future<ChatHistorySnapshot> load({
@@ -199,6 +210,7 @@ class ChatHistoryApiService {
         .map((item) => Map<String, Object?>.from(item))
         .map(_messageFromServerMap)
         .toList();
+    messages.sort(_compareMessagesByCreatedTime);
 
     return ChatHistorySnapshot(
       messages: messages,
@@ -229,6 +241,7 @@ class ChatHistoryApiService {
         .map((item) => Map<String, Object?>.from(item))
         .map(_messageFromServerMap)
         .toList();
+    messages.sort(_compareMessagesByCreatedTime);
 
     return ChatHistorySnapshot(
       messages: messages,
@@ -280,9 +293,8 @@ class ChatHistoryApiService {
     }
 
     final raw = jsonDecode(response.body);
-    final map = raw is Map
-        ? Map<String, dynamic>.from(raw)
-        : const <String, dynamic>{};
+    final map =
+        raw is Map ? Map<String, dynamic>.from(raw) : const <String, dynamic>{};
     return ChatRespondResult(
       text: (map['text'] as String?) ?? '',
       lastSeqId: (map['lastSeqId'] as num?)?.toInt() ?? 0,
@@ -347,9 +359,8 @@ class ChatHistoryApiService {
     }
 
     final raw = jsonDecode(response.body);
-    final map = raw is Map
-        ? Map<String, dynamic>.from(raw)
-        : const <String, dynamic>{};
+    final map =
+        raw is Map ? Map<String, dynamic>.from(raw) : const <String, dynamic>{};
     return ChatAcceptedTask(
       taskId: (map['taskId'] as String?) ?? taskId,
       sessionId: (map['sessionId'] as String?) ?? scope.sessionId,
@@ -365,10 +376,9 @@ class ChatHistoryApiService {
     // meaningful content.
     return messages
         .where(
-          (message) =>
-              !(message.role == 'assistant' &&
-                  message.isStreaming &&
-                  message.content.trim().isEmpty),
+          (message) => !(message.role == 'assistant' &&
+              message.isStreaming &&
+              message.content.trim().isEmpty),
         )
         .toList(growable: false);
   }

--- a/apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 
 import '../settings/llm_config_service.dart';
 import 'chat_message.dart';
+import 'chat_message_sort.dart';
 import 'chat_topology.dart';
 
 class ChatHistorySnapshot {
@@ -111,18 +112,6 @@ class ChatHistoryApiService {
     return null;
   }
 
-  int _compareMessagesByCreatedTime(ChatMessage a, ChatMessage b) {
-    final aTime = a.createdAt ?? a.timestamp;
-    final bTime = b.createdAt ?? b.timestamp;
-    final byTime = aTime.compareTo(bTime);
-    if (byTime != 0) return byTime;
-    if (a.role != b.role) {
-      if (a.role == 'user') return -1;
-      if (b.role == 'user') return 1;
-    }
-    return (a.messageId ?? '').compareTo(b.messageId ?? '');
-  }
-
   Future<List<ChatPersistedScope>> loadScopes({required String token}) async {
     final response = await _client.get(
       _scopesUri,
@@ -210,7 +199,7 @@ class ChatHistoryApiService {
         .map((item) => Map<String, Object?>.from(item))
         .map(_messageFromServerMap)
         .toList();
-    messages.sort(_compareMessagesByCreatedTime);
+    messages.sort(compareChatMessagesByCreatedTime);
 
     return ChatHistorySnapshot(
       messages: messages,
@@ -241,7 +230,7 @@ class ChatHistoryApiService {
         .map((item) => Map<String, Object?>.from(item))
         .map(_messageFromServerMap)
         .toList();
-    messages.sort(_compareMessagesByCreatedTime);
+    messages.sort(compareChatMessagesByCreatedTime);
 
     return ChatHistorySnapshot(
       messages: messages,

--- a/apps/mobile_chat_app/lib/features/chat/chat_message_sort.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_message_sort.dart
@@ -15,3 +15,56 @@ int compareChatMessagesByCreatedTime(ChatMessage a, ChatMessage b) {
   }
   return (a.messageId ?? '').compareTo(b.messageId ?? '');
 }
+
+/// Normalises the task state for a server-provided message.
+///
+/// If the server explicitly set a task state, that value is returned.
+/// Otherwise, a completed assistant message with non-empty content is treated
+/// as [ChatTaskState.completed], and [fallback] is returned in all other cases.
+ChatTaskState? normalizedServerTaskState(
+  ChatMessage message, {
+  ChatTaskState? fallback,
+}) {
+  if (message.taskState != null) return message.taskState;
+  if (message.role == 'assistant' && message.content.trim().isNotEmpty) {
+    return ChatTaskState.completed;
+  }
+  return fallback;
+}
+
+/// Merges a locally-tracked [current] message with its [incoming] server
+/// counterpart, preserving client-side metadata and conversation-position
+/// timestamps.
+///
+/// The local [current.createdAt] and [current.timestamp] are always preferred
+/// over the server's values.  For async routers (e.g. OpenClaw) the server
+/// assigns `createdAt` at processing / completion time, which can be
+/// significantly later than messages the user sent while waiting for the reply.
+/// Anchoring to the local (submission) time keeps this message in its correct
+/// conversation position after the chronological sort step.
+ChatMessage mergeServerMessage(ChatMessage current, ChatMessage incoming) {
+  return incoming.copyWith(
+    createdAt: current.createdAt,
+    timestamp: current.timestamp,
+    agentId: incoming.agentId ?? current.agentId,
+    agentName: incoming.agentName ?? current.agentName,
+    idempotencyKey: current.idempotencyKey,
+    acknowledgedAt: incoming.acknowledgedAt ?? current.acknowledgedAt,
+    checkpointCursor: incoming.checkpointCursor ?? current.checkpointCursor,
+    resolvedBotId: incoming.resolvedBotId ?? current.resolvedBotId,
+    resolvedSkillId: incoming.resolvedSkillId ?? current.resolvedSkillId,
+    arbitrationMode: current.arbitrationMode,
+    fallbackToDefaultBot: current.fallbackToDefaultBot,
+    decisionReason: current.decisionReason,
+    traceId: current.traceId,
+    tieDetected: current.tieDetected,
+    tieBotIds: current.tieBotIds,
+    selectedScore: current.selectedScore,
+    candidateScoreSummary: current.candidateScoreSummary,
+    isStreaming: false,
+    taskState: normalizedServerTaskState(
+      incoming,
+      fallback: current.taskState,
+    ),
+  );
+}

--- a/apps/mobile_chat_app/lib/features/chat/chat_message_sort.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_message_sort.dart
@@ -1,0 +1,17 @@
+import 'chat_message.dart';
+
+/// Compares two [ChatMessage]s by creation time for deterministic ordering.
+///
+/// Primary sort key: `createdAt` falling back to `timestamp`.
+/// Tie-breakers (in order): `role` (user before assistant) then `messageId`.
+int compareChatMessagesByCreatedTime(ChatMessage a, ChatMessage b) {
+  final aTime = a.createdAt ?? a.timestamp;
+  final bTime = b.createdAt ?? b.timestamp;
+  final byTime = aTime.compareTo(bTime);
+  if (byTime != 0) return byTime;
+  if (a.role != b.role) {
+    if (a.role == 'user') return -1;
+    if (b.role == 'user') return 1;
+  }
+  return (a.messageId ?? '').compareTo(b.messageId ?? '');
+}

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:workspace_fs/workspace_fs.dart';
 
 import 'chat_history_api_service.dart';
+import 'chat_message_sort.dart';
 
 import '../auth/auth_service.dart';
 import '../settings/llm_config_service.dart';
@@ -1142,17 +1143,6 @@ class _ChatScreenState extends State<ChatScreen> {
     );
   }
 
-  int _compareChatMessages(ChatMessage a, ChatMessage b) {
-    final aTime = a.createdAt ?? a.timestamp;
-    final bTime = b.createdAt ?? b.timestamp;
-    final byTime = aTime.compareTo(bTime);
-    if (byTime != 0) return byTime;
-    if (a.role != b.role) {
-      if (a.role == 'user') return -1;
-      if (b.role == 'user') return 1;
-    }
-    return (a.messageId ?? '').compareTo(b.messageId ?? '');
-  }
 
   List<ChatMessage> _mergeSyncedMessages(
     List<ChatMessage> current,
@@ -1184,7 +1174,7 @@ class _ChatScreenState extends State<ChatScreen> {
       }
     }
 
-    merged.sort(_compareChatMessages);
+    merged.sort(compareChatMessagesByCreatedTime);
     return merged;
   }
 

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -1107,43 +1107,6 @@ class _ChatScreenState extends State<ChatScreen> {
     _scheduleSync(triggerNow ? Duration.zero : _nextSyncDelay);
   }
 
-  ChatTaskState? _normalizedServerTaskState(
-    ChatMessage message, {
-    ChatTaskState? fallback,
-  }) {
-    if (message.taskState != null) return message.taskState;
-    if (message.role == 'assistant' && message.content.trim().isNotEmpty) {
-      return ChatTaskState.completed;
-    }
-    return fallback;
-  }
-
-  ChatMessage _mergeServerMessage(ChatMessage current, ChatMessage incoming) {
-    return incoming.copyWith(
-      agentId: incoming.agentId ?? current.agentId,
-      agentName: incoming.agentName ?? current.agentName,
-      idempotencyKey: current.idempotencyKey,
-      acknowledgedAt: incoming.acknowledgedAt ?? current.acknowledgedAt,
-      checkpointCursor: incoming.checkpointCursor ?? current.checkpointCursor,
-      resolvedBotId: incoming.resolvedBotId ?? current.resolvedBotId,
-      resolvedSkillId: incoming.resolvedSkillId ?? current.resolvedSkillId,
-      arbitrationMode: current.arbitrationMode,
-      fallbackToDefaultBot: current.fallbackToDefaultBot,
-      decisionReason: current.decisionReason,
-      traceId: current.traceId,
-      tieDetected: current.tieDetected,
-      tieBotIds: current.tieBotIds,
-      selectedScore: current.selectedScore,
-      candidateScoreSummary: current.candidateScoreSummary,
-      isStreaming: false,
-      taskState: _normalizedServerTaskState(
-        incoming,
-        fallback: current.taskState,
-      ),
-    );
-  }
-
-
   List<ChatMessage> _mergeSyncedMessages(
     List<ChatMessage> current,
     List<ChatMessage> incoming,
@@ -1160,12 +1123,12 @@ class _ChatScreenState extends State<ChatScreen> {
     for (final message in incoming) {
       final normalized = message.copyWith(
         isStreaming: false,
-        taskState: _normalizedServerTaskState(message),
+        taskState: normalizedServerTaskState(message),
       );
       final messageId = normalized.messageId;
       if (messageId != null && byId.containsKey(messageId)) {
         final index = byId[messageId]!;
-        merged[index] = _mergeServerMessage(merged[index], normalized);
+        merged[index] = mergeServerMessage(merged[index], normalized);
         continue;
       }
       merged.add(normalized);

--- a/apps/mobile_chat_app/test/chat_history_api_service_test.dart
+++ b/apps/mobile_chat_app/test/chat_history_api_service_test.dart
@@ -88,6 +88,46 @@ void main() {
     expect(snapshot.messages.last.messageId, equals('assistant-late'));
   });
 
+  test('sorts synced messages by createdAt to keep chronology stable',
+      () async {
+    final client = MockClient((request) async {
+      expect(request.method, equals('GET'));
+      expect(request.url.path, contains('/chat/sync/'));
+      return http.Response(
+        jsonEncode({
+          'messages': [
+            {
+              'messageId': 'assistant-async',
+              'role': 'assistant',
+              'content': 'async openclaw reply',
+              'createdAt': '2026-04-19T12:00:20.000Z',
+            },
+            {
+              'messageId': 'user-second',
+              'role': 'user',
+              'content': 'second message',
+              'createdAt': '2026-04-19T12:00:15.000Z',
+            },
+          ],
+          'lastSeqId': 15,
+        }),
+        200,
+      );
+    });
+
+    final service = ChatHistoryApiService(httpClient: client);
+    final snapshot = await service.sync(
+      token: 'token-1',
+      sessionId: 'session:default:main',
+      afterSeq: 10,
+    );
+
+    expect(snapshot.messages, hasLength(2));
+    expect(snapshot.messages.first.messageId, equals('user-second'));
+    expect(snapshot.messages.last.messageId, equals('assistant-async'));
+    expect(snapshot.lastSeqId, equals(15));
+  });
+
   test('accepts task and upserts messages', () async {
     final client = MockClient((request) async {
       if (request.url.path.endsWith('/tasks/accept')) {

--- a/apps/mobile_chat_app/test/chat_history_api_service_test.dart
+++ b/apps/mobile_chat_app/test/chat_history_api_service_test.dart
@@ -52,6 +52,42 @@ void main() {
     expect(snapshot.lastSeqId, equals(2));
   });
 
+  test('sorts loaded history by createdAt to keep chronology stable', () async {
+    final client = MockClient((request) async {
+      expect(request.method, equals('GET'));
+      return http.Response(
+        jsonEncode({
+          'messages': [
+            {
+              'messageId': 'assistant-late',
+              'role': 'assistant',
+              'content': 'openclaw delayed reply',
+              'createdAt': '2026-04-19T11:38:15.000Z',
+            },
+            {
+              'messageId': 'user-earlier',
+              'role': 'user',
+              'content': 'return to default route',
+              'createdAt': '2026-04-19T11:38:10.000Z',
+            },
+          ],
+          'lastSeqId': 9,
+        }),
+        200,
+      );
+    });
+
+    final service = ChatHistoryApiService(httpClient: client);
+    final snapshot = await service.load(
+      token: 'token-1',
+      sessionId: 'session:default:main',
+    );
+
+    expect(snapshot.messages, hasLength(2));
+    expect(snapshot.messages.first.messageId, equals('user-earlier'));
+    expect(snapshot.messages.last.messageId, equals('assistant-late'));
+  });
+
   test('accepts task and upserts messages', () async {
     final client = MockClient((request) async {
       if (request.url.path.endsWith('/tasks/accept')) {
@@ -104,8 +140,8 @@ void main() {
       final client = MockClient((request) async {
         expect(request.url.path.endsWith('/messages/batch'), isTrue);
         final decoded = jsonDecode(request.body) as Map<String, dynamic>;
-        final messages = (decoded['messages'] as List)
-            .cast<Map<String, dynamic>>();
+        final messages =
+            (decoded['messages'] as List).cast<Map<String, dynamic>>();
         expect(messages, hasLength(1));
         expect(messages.single['messageId'], equals('msg-user'));
         return http.Response(jsonEncode({'lastSeqId': 8}), 200);

--- a/apps/mobile_chat_app/test/chat_message_sort_test.dart
+++ b/apps/mobile_chat_app/test/chat_message_sort_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_chat_app/features/chat/chat_message.dart';
+import 'package:mobile_chat_app/features/chat/chat_message_sort.dart';
+
+void main() {
+  group('mergeServerMessage', () {
+    test(
+      'preserves local createdAt when server async reply has later timestamp',
+      () {
+        // Simulate OpenClaw async scenario:
+        //   - User sends message M1 at T=20 and assistant placeholder is
+        //     created at the same task-submission time.
+        //   - After routing switch the user sends M2 at T=30 and gets an
+        //     immediate reply.
+        //   - OpenClaw completes and the server stores the assistant reply with
+        //     createdAt = T=35 (completion time).
+        //   - Without the fix, mergeServerMessage would adopt T=35, causing the
+        //     sort to place the OpenClaw reply AFTER M2/A2 (T=30) in the list.
+        final t20 = DateTime.utc(2026, 4, 19, 12, 0, 20);
+        final t35 = DateTime.utc(2026, 4, 19, 12, 0, 35);
+
+        final localPlaceholder = ChatMessage(
+          messageId: 'a1',
+          role: 'assistant',
+          content: '',
+          isStreaming: true,
+          createdAt: t20,
+          taskState: ChatTaskState.accepted,
+          channelId: 'default',
+          sessionId: 'session:default:main',
+        );
+        final serverReply = ChatMessage(
+          messageId: 'a1',
+          role: 'assistant',
+          content: 'openclaw async reply',
+          createdAt: t35,
+          taskState: ChatTaskState.completed,
+          channelId: 'default',
+          sessionId: 'session:default:main',
+        );
+
+        final merged = mergeServerMessage(localPlaceholder, serverReply);
+
+        // createdAt must be the local (submission) time, not completion time.
+        expect(merged.createdAt, equals(t20));
+        // timestamp must also be preserved for the display clock in MessageList.
+        expect(merged.timestamp, equals(localPlaceholder.timestamp));
+        // Content and task state come from the server.
+        expect(merged.content, equals('openclaw async reply'));
+        expect(merged.taskState, equals(ChatTaskState.completed));
+        expect(merged.isStreaming, isFalse);
+      },
+    );
+
+    test(
+      'async reply with preserved createdAt sorts before later messages',
+      () {
+        final t20 = DateTime.utc(2026, 4, 19, 12, 0, 20);
+        final t30 = DateTime.utc(2026, 4, 19, 12, 0, 30);
+        final t35 = DateTime.utc(2026, 4, 19, 12, 0, 35);
+
+        final localPlaceholder = ChatMessage(
+          messageId: 'a1',
+          role: 'assistant',
+          content: '',
+          createdAt: t20,
+          taskState: ChatTaskState.accepted,
+        );
+        final serverReply = ChatMessage(
+          messageId: 'a1',
+          role: 'assistant',
+          content: 'openclaw async reply',
+          createdAt: t35, // server completion time > messages sent later
+          taskState: ChatTaskState.completed,
+        );
+        final laterUserMsg = ChatMessage(
+          messageId: 'u2',
+          role: 'user',
+          content: 'message sent while waiting',
+          createdAt: t30,
+        );
+        final laterAssistantMsg = ChatMessage(
+          messageId: 'a2',
+          role: 'assistant',
+          content: 'default router reply',
+          createdAt: t30,
+          taskState: ChatTaskState.completed,
+        );
+
+        final mergedReply = mergeServerMessage(localPlaceholder, serverReply);
+        final messages = [mergedReply, laterUserMsg, laterAssistantMsg]
+          ..sort(compareChatMessagesByCreatedTime);
+
+        // openClaw reply (originally T=20) must come before messages at T=30.
+        expect(messages.first.messageId, equals('a1'));
+        expect(messages[1].messageId, equals('u2'));
+        expect(messages.last.messageId, equals('a2'));
+      },
+    );
+
+    test('uses server createdAt when no local createdAt is set', () {
+      final tServer = DateTime.utc(2026, 4, 19, 12, 0, 10);
+
+      final local = ChatMessage(
+        messageId: 'm1',
+        role: 'user',
+        content: 'hello',
+        // createdAt intentionally omitted
+      );
+      final server = ChatMessage(
+        messageId: 'm1',
+        role: 'user',
+        content: 'hello',
+        createdAt: tServer,
+      );
+
+      final merged = mergeServerMessage(local, server);
+
+      expect(merged.createdAt, equals(tServer));
+    });
+  });
+
+  group('normalizedServerTaskState', () {
+    test('returns explicit taskState from server', () {
+      final msg = ChatMessage(
+        role: 'assistant',
+        content: 'hi',
+        taskState: ChatTaskState.failed,
+      );
+      expect(normalizedServerTaskState(msg), equals(ChatTaskState.failed));
+    });
+
+    test('infers completed for non-empty assistant content with no taskState',
+        () {
+      final msg = ChatMessage(role: 'assistant', content: 'hi');
+      expect(normalizedServerTaskState(msg), equals(ChatTaskState.completed));
+    });
+
+    test('returns fallback when no taskState and empty content', () {
+      final msg = ChatMessage(role: 'assistant', content: '');
+      expect(
+        normalizedServerTaskState(msg, fallback: ChatTaskState.dispatched),
+        equals(ChatTaskState.dispatched),
+      );
+    });
+  });
+}

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: feature_map
 owner: bricks
-last_updated: 2026-04-18
+last_updated: 2026-04-19
 purpose: >
   为人类测试员和 AI 测试员提供产品功能清单与进入路径，作为回归测试与变更影响评估的入口索引。
 
@@ -39,6 +39,7 @@ products:
           - 发送一条消息后可以看到消息列表更新。
           - 将路由切到 openclaw 后发送消息，在插件离线时应呈现“已发送但未完成（未读）”。
           - 启动并配置 openclaw 插件后再次发送，消息应完成并出现 assistant 回复。
+          - 在 openclaw 离线后切回默认路由继续发送时，历史消息应按 createdAt 时间顺序渲染，后到达回复显示在列表末尾。
           - Openclaw 异步模式下不应额外持久化 assistant 站位消息行；“已读”应由用户消息状态属性反映。
           - 发送消息后，最新 user 消息会定位在可见区域首条，assistant 回复显示在其后。
           - 打开或切换到已有历史的会话后，列表按“最新 user 消息优先”定位而非强制到底部。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: logic_map
 owner: bricks
-last_updated: 2026-04-18
+last_updated: 2026-04-19
 purpose: >
   为人类测试员、AI 测试员与 AI 工程师提供“功能 -> 代码/文档/关键词”映射，
   用于影响面分析、回归测试设计与遗留逻辑清理。
@@ -76,6 +76,7 @@ index:
       - 长文本折叠状态与流式更新叠加时，可能出现按钮闪烁或展开状态丢失。
       - 菜单动画时长或曲线调整不当可能导致菜单响应突兀或视觉跳变。
       - 频道重命名与新建时若未统一大小写/空白策略，可能出现“看似重复”名称并影响切换。
+      - 异步路由（如 OpenClaw）与默认路由混用时，若未按 createdAt 稳定排序可能导致历史消息时序错乱。
 
   - feature_id: model_settings
     capability: 模型配置读写

--- a/docs/plans/2026-04-19-11-46-UTC-openclaw-history-ordering-fix.md
+++ b/docs/plans/2026-04-19-11-46-UTC-openclaw-history-ordering-fix.md
@@ -1,0 +1,19 @@
+# Background
+Users reported incorrect chat history rendering when switching router to OpenClaw for one turn (with no OpenClaw server response yet), then switching back to the default router and sending another message. The delayed or pending OpenClaw assistant message can appear out of expected order in the message list.
+
+# Goals
+- Ensure chat history rendering is consistently ordered by message creation timestamp across mixed router usage.
+- Prevent stale/pending OpenClaw task messages from disrupting visual chronology after switching routers.
+- Add regression tests that cover unsorted backend payloads and verify stable chronological rendering expectations.
+
+# Implementation Plan (phased)
+1. Inspect chat history hydration and sync merge paths in `chat_screen.dart` and `chat_history_api_service.dart`.
+2. Introduce deterministic chronological sorting for history snapshots (especially initial load) using createdAt/timestamp with stable tie-breakers.
+3. Add/extend unit tests in mobile chat app history service tests to validate sorting behavior for unsorted message payloads.
+4. Run repository bootstrap and targeted Flutter tests for the modified package.
+5. Check code maps and update if behavior/indexing expectations changed.
+
+# Acceptance Criteria
+- On history load, messages are ordered by creation time (oldest to newest), with deterministic tie-breakers.
+- Mixed default/OpenClaw scenarios with pending and later-delivered messages no longer render in incorrect order.
+- `flutter test` for `apps/mobile_chat_app` passes for affected test files.


### PR DESCRIPTION
### Motivation
- Users saw chat history render out-of-order when switching into an async OpenClaw router (no server reply yet) and then back to the default router, because backend payload arrival order could differ from messages' creation timestamps.
- Make history rendering deterministic by ensuring server-provided message lists are ordered by message creation time with stable tie-breakers.

### Description
- Add a comparator `_compareMessagesByCreatedTime` that compares `createdAt` (falling back to `timestamp`) and uses `role`/`messageId` as deterministic tie-breakers in `ChatHistoryApiService` (`apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart`).
- Sort parsed message lists in both `load()` and `sync()` paths using the new comparator so snapshots from `/history` and `/sync` are chronologically ordered before being returned.
- Add a regression unit test `sorts loaded history by createdAt to keep chronology stable` in `apps/mobile_chat_app/test/chat_history_api_service_test.dart` that simulates an unsorted backend payload and asserts chronological ordering.
- Add a plan document under `docs/plans/2026-04-19-11-46-UTC-openclaw-history-ordering-fix.md` and update `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` to reflect the change and risk note.

### Testing
- Ran environment bootstrap with `./tools/init_dev_env.sh` successfully.
- Formatted files with `dart format` (succeeded).
- Ran the targeted Flutter unit tests with `cd apps/mobile_chat_app && flutter test test/chat_history_api_service_test.dart` and all tests in that file passed (console showed unrelated `file_picker` plugin warnings but tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bfd2db88832d919e4941f629dfe8)