### PR TITLE
Return created_at-ordered history window for /api/chat/history and add listSessionHistory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@
 - For each feature or task, create and save a markdown plan file in `docs/plans/`.
 - Name plan files with a `YYYY-MM-DD-HH-mm` prefix using 24-hour time (optionally appending a timezone such as `-UTC`).
 
+## Analysis and fix quality bar
+- Do not use probabilistic or guess-based analysis methods; use deterministic evidence from code paths, data flow, and reproducible checks.
+- Do not use probabilistic or speculative fix strategies; implement fixes with explicit invariants, clear causal reasoning, and regression tests.
+
 ## API debugging workflow
 - When debugging API/interface errors, try the `vercel-api-log-context` skill first to collect Vercel deployment log context before proposing fixes.
 

--- a/apps/node_backend/src/routes/chat.test.ts
+++ b/apps/node_backend/src/routes/chat.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 
 const {
   acceptTaskMock,
+  listSessionHistoryMock,
   listSessionMessagesForModelMock,
   syncMessagesMock,
   upsertMessagesMock,
@@ -19,6 +20,7 @@ const {
     state: 'accepted',
     acceptedAt: '2026-04-17T07:00:00.000Z',
   })),
+  listSessionHistoryMock: vi.fn(async () => ({ messages: [], lastSeqId: 0 })),
   listSessionMessagesForModelMock: vi.fn(async () => []),
   syncMessagesMock: vi.fn(async () => ({ messages: [], lastSeqId: 0 })),
   upsertMessagesMock: vi.fn(async () => ({ lastSeqId: 7 })),
@@ -43,6 +45,7 @@ const {
 
 vi.mock('../services/chatAsyncTransportService.js', () => ({
   acceptTask: acceptTaskMock,
+  listSessionHistory: listSessionHistoryMock,
   listSessionMessagesForModel: listSessionMessagesForModelMock,
   listUserScopes: listUserScopesMock,
   syncMessages: syncMessagesMock,
@@ -108,6 +111,7 @@ afterAll(async () => {
 describe('chat routes', () => {
   beforeEach(() => {
     acceptTaskMock.mockClear();
+    listSessionHistoryMock.mockClear();
     listSessionMessagesForModelMock.mockClear();
     syncMessagesMock.mockClear();
     upsertMessagesMock.mockClear();
@@ -182,6 +186,48 @@ describe('chat routes', () => {
       channelId: 'default',
       threadId: 'main',
     });
+  });
+
+  it('uses createdAt-ordered history window for /history endpoint', async () => {
+    listSessionHistoryMock.mockResolvedValueOnce({
+      messages: [
+        {
+          seqId: 21,
+          writeSeq: 40,
+          messageId: 'm-1',
+          taskId: 'task-1',
+          channelId: 'default',
+          sessionId: 'session:default:main',
+          threadId: null,
+          role: 'user',
+          content: 'hello',
+          taskState: 'accepted',
+          checkpointCursor: null,
+          metadata: null,
+          createdAt: '2026-04-20T08:00:00.000Z',
+          updatedAt: '2026-04-20T08:00:00.000Z',
+        },
+      ],
+      lastSeqId: 40,
+    });
+
+    const encodedSessionId = encodeURIComponent('session:default:main');
+    const response = await fetch(
+      `${baseUrl}/api/chat/history/${encodedSessionId}?limit=120`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(listSessionHistoryMock).toHaveBeenCalledWith(
+      'user-123',
+      'session:default:main',
+      { limit: 120 },
+    );
+    expect(syncMessagesMock).not.toHaveBeenCalledWith(
+      'user-123',
+      'session:default:main',
+      0,
+      expect.anything(),
+    );
   });
 
   it('rate limits sync polling per user and session after 120 requests per minute', async () => {

--- a/apps/node_backend/src/routes/chat.ts
+++ b/apps/node_backend/src/routes/chat.ts
@@ -3,6 +3,7 @@ import rateLimit from 'express-rate-limit';
 import { authenticate, AuthRequest } from '../middleware/auth.js';
 import {
   acceptTask,
+  listSessionHistory,
   listUserScopes,
   listSessionMessagesForModel,
   syncMessages,
@@ -371,7 +372,7 @@ router.get('/history/:sessionId', async (req: AuthRequest, res: Response) => {
       Math.min(Number.isNaN(parsedLimit) ? 100 : parsedLimit, 500),
     );
 
-    const synced = await syncMessages(userId, sessionId, 0, { limit });
+    const synced = await listSessionHistory(userId, sessionId, { limit });
     const latestCheckpointCursor =
       [...synced.messages].reverse().find((m) => m.checkpointCursor != null)
         ?.checkpointCursor ?? null;

--- a/apps/node_backend/src/services/chatAsyncTransportService.test.ts
+++ b/apps/node_backend/src/services/chatAsyncTransportService.test.ts
@@ -272,6 +272,58 @@ describe('chatAsyncTransportService', () => {
     expect(result.lastSeqId).toBe(51);
   });
 
+  it('listSessionHistory returns max writeSeq as lastSeqId when created_at and write_seq diverge', async () => {
+    // Simulate async session: user message created first but written later (higher write_seq),
+    // assistant reply created second but written first (lower write_seq).
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          seq_id: 10,
+          write_seq: 80,
+          message_id: 'user-msg',
+          task_id: 'task-1',
+          channel_id: 'default',
+          session_id: 'session:default:main',
+          thread_id: null,
+          role: 'user',
+          content: 'hello',
+          task_state: null,
+          checkpoint_cursor: null,
+          metadata: null,
+          created_at: '2026-04-20T08:00:00.000Z',
+          updated_at: '2026-04-20T08:00:00.000Z',
+        },
+        {
+          seq_id: 11,
+          write_seq: 50,
+          message_id: 'assistant-msg',
+          task_id: 'task-1',
+          channel_id: 'default',
+          session_id: 'session:default:main',
+          thread_id: null,
+          role: 'assistant',
+          content: 'world',
+          task_state: 'completed',
+          checkpoint_cursor: null,
+          metadata: null,
+          created_at: '2026-04-20T08:00:01.000Z',
+          updated_at: '2026-04-20T08:00:02.000Z',
+        },
+      ],
+      rowCount: 2,
+    });
+
+    const result = await listSessionHistory('u-1', 'session:default:main');
+
+    // Messages ordered by created_at ASC: user-msg first, assistant-msg second
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0].messageId).toBe('user-msg');
+    expect(result.messages[1].messageId).toBe('assistant-msg');
+    // lastSeqId must be the max writeSeq (80), not the last message's writeSeq (50),
+    // so subsequent sync calls don't re-fetch messages already in the window.
+    expect(result.lastSeqId).toBe(80);
+  });
+
   it('listUserScopes returns distinct scopes ordered by latest activity', async () => {
     queryMock.mockResolvedValueOnce({
       rows: [

--- a/apps/node_backend/src/services/chatAsyncTransportService.test.ts
+++ b/apps/node_backend/src/services/chatAsyncTransportService.test.ts
@@ -14,6 +14,7 @@ vi.mock('../db/index.js', () => ({
 
 import {
   acceptTask,
+  listSessionHistory,
   listUserScopes,
   syncMessages,
   upsertMessages,
@@ -233,6 +234,42 @@ describe('chatAsyncTransportService', () => {
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0].messageId).toBe('m-1');
     expect(result.messages[0].writeSeq).toBe(7);
+  });
+
+  it('listSessionHistory returns createdAt-ordered timeline window', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          seq_id: 12,
+          write_seq: 51,
+          message_id: 'a-1',
+          task_id: 'task-1',
+          channel_id: 'default',
+          session_id: 'session:default:main',
+          thread_id: null,
+          role: 'assistant',
+          content: 'reply',
+          task_state: 'completed',
+          checkpoint_cursor: null,
+          metadata: null,
+          created_at: '2026-04-20T08:00:01.000Z',
+          updated_at: '2026-04-20T08:00:02.000Z',
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const result = await listSessionHistory('u-1', 'session:default:main', {
+      limit: 100,
+    });
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('ORDER BY created_at DESC, seq_id DESC'),
+      ['u-1', 'session:default:main', 100],
+    );
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].messageId).toBe('a-1');
+    expect(result.lastSeqId).toBe(51);
   });
 
   it('listUserScopes returns distinct scopes ordered by latest activity', async () => {

--- a/apps/node_backend/src/services/chatAsyncTransportService.ts
+++ b/apps/node_backend/src/services/chatAsyncTransportService.ts
@@ -329,7 +329,7 @@ export async function listSessionHistory(
   );
 
   const messages = result.rows.map(toMessageDto);
-  const lastSeqId = messages.length > 0 ? messages[messages.length - 1].writeSeq : 0;
+  const lastSeqId = messages.reduce((max, m) => Math.max(max, m.writeSeq), 0);
   return { messages, lastSeqId };
 }
 

--- a/apps/node_backend/src/services/chatAsyncTransportService.ts
+++ b/apps/node_backend/src/services/chatAsyncTransportService.ts
@@ -308,6 +308,31 @@ export async function syncMessages(
   return { messages, lastSeqId };
 }
 
+export async function listSessionHistory(
+  userId: string,
+  sessionId: string,
+  options: { limit?: number } = {},
+): Promise<{ messages: ReturnType<typeof toMessageDto>[]; lastSeqId: number }> {
+  const limit = Math.max(1, Math.min(options.limit ?? 100, 500));
+  const result = await pool.query<ChatMessageRow>(
+    `SELECT * FROM (
+       SELECT seq_id, write_seq, message_id, task_id, channel_id, session_id, thread_id,
+              role, content, task_state, checkpoint_cursor, metadata, created_at, updated_at
+         FROM chat_messages
+        WHERE user_id = $1
+          AND session_id = $2
+        ORDER BY created_at DESC, seq_id DESC
+        LIMIT $3
+     ) recent
+     ORDER BY created_at ASC, seq_id ASC`,
+    [userId, sessionId, limit],
+  );
+
+  const messages = result.rows.map(toMessageDto);
+  const lastSeqId = messages.length > 0 ? messages[messages.length - 1].writeSeq : 0;
+  return { messages, lastSeqId };
+}
+
 
 export async function listSessionMessagesForModel(
   userId: string,

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: logic_map
 owner: bricks
-last_updated: 2026-04-19
+last_updated: 2026-04-20
 purpose: >
   为人类测试员、AI 测试员与 AI 工程师提供“功能 -> 代码/文档/关键词”映射，
   用于影响面分析、回归测试设计与遗留逻辑清理。
@@ -76,7 +76,8 @@ index:
       - 长文本折叠状态与流式更新叠加时，可能出现按钮闪烁或展开状态丢失。
       - 菜单动画时长或曲线调整不当可能导致菜单响应突兀或视觉跳变。
       - 频道重命名与新建时若未统一大小写/空白策略，可能出现“看似重复”名称并影响切换。
-      - 异步路由（如 OpenClaw）与默认路由混用时，若未按 createdAt 稳定排序可能导致历史消息时序错乱。
+      - 历史窗口若按 write_seq 截断而展示按 createdAt 排序，长会话中可能出现“回复与提问错位”的局部时序错觉。
+      - 异步路由（如 OpenClaw）与默认路由混用时，需保持 history 与 sync 的排序轴一致性（history: createdAt, sync: write_seq 增量）。
 
   - feature_id: model_settings
     capability: 模型配置读写

--- a/docs/plans/2026-04-20-03-33-UTC-history-window-order-fix.md
+++ b/docs/plans/2026-04-20-03-33-UTC-history-window-order-fix.md
@@ -1,0 +1,32 @@
+# Background
+
+Users observed chat history ordering where multiple assistant messages appear ahead of their corresponding user prompts after page refresh. The current history endpoint slices by recent write events (`write_seq`) and the client then re-sorts by `createdAt`, which can distort local chronology in long-running asynchronous sessions.
+
+# Goals
+
+1. Make `/api/chat/history/:sessionId` return a chronology-preserving window aligned with display ordering.
+2. Keep incremental sync (`/api/chat/sync/:sessionId`) unchanged so write-cursor semantics remain stable.
+3. Add regression tests for backend history behavior.
+
+# Implementation Plan (phased)
+
+## Phase 1: Backend history query alignment
+- Add a dedicated service method for history retrieval that selects by `created_at` window and returns ascending `created_at` order.
+- Update `/api/chat/history/:sessionId` route to use the new method instead of `syncMessages(...afterSeq=0...)`.
+
+## Phase 2: Regression coverage
+- Add service-level test to verify SQL ordering strategy for history.
+- Add route-level test to verify `/history` calls the new service path.
+
+## Phase 3: Code map maintenance
+- Update logic map metadata/risk text to reflect the new history window strategy.
+
+# Acceptance Criteria
+
+1. `/api/chat/history/:sessionId` no longer depends on `write_seq`-window slicing for initial history loads.
+2. Existing `/api/chat/sync/:sessionId` behavior remains cursor-based by `write_seq`.
+3. Backend tests pass with new route/service coverage.
+4. Logic map updated to capture the revised ordering risk and mitigation.
+
+Validation commands:
+- `cd apps/node_backend && npm test -- src/services/chatAsyncTransportService.test.ts src/routes/chat.test.ts`


### PR DESCRIPTION
### Motivation
- Fix incorrect local chronology when loading chat history where the backend sliced by `write_seq` but the UI displayed by `createdAt`, causing assistant messages to appear ahead of their prompts in long-running async sessions.
- Preserve existing incremental sync semantics that rely on `write_seq` while providing a stable chronology-preserving history window for initial loads.

### Description
- Add `listSessionHistory` service that selects a `created_at`-based window and returns messages in ascending `created_at, seq_id` order with a bounded `limit`.
- Update the `/api/chat/history/:sessionId` route to call `listSessionHistory` instead of `syncMessages(..., afterSeq = 0)` so history endpoints return a chronology-preserving window.
- Add unit tests for the new service (`listSessionHistory`) and a route-level test to assert `/history` calls the new service and behaves as expected, plus update existing tests and mocks accordingly.
- Update repository docs and metadata by modifying `AGENTS.md`, adjusting `docs/code_maps/logic_map.yaml` to reflect the change and risk notes, and adding an implementation plan `docs/plans/2026-04-20-03-33-UTC-history-window-order-fix.md`.

### Testing
- Ran backend unit tests for the chat service and routes with `cd apps/node_backend && npm test -- src/services/chatAsyncTransportService.test.ts src/routes/chat.test.ts` and both tests completed successfully.
- Verified the new `listSessionHistory` test asserts the SQL ordering contains `ORDER BY created_at DESC, seq_id DESC` and that the route-level test verifies `listSessionHistory` is invoked for `/api/chat/history/:sessionId`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4fe5f3f64832da841837c4a2644d1)