### PR TITLE
fix(openclaw): scope account by token user

### DIFF
--- a/apps/node_openclaw_plugin/README.md
+++ b/apps/node_openclaw_plugin/README.md
@@ -98,5 +98,6 @@ npm run dev
 
 - ACK body 仅包含 `cursor` 与 `ackedEventIds`，不发送 `pluginId` 字段。
 - 启动阶段会校验 JWT claims：`typ=platform_plugin`、`pluginId` 与 `BRICKS_PLUGIN_ID` 一致、且必须包含 `userId`。
+- OpenClaw channel account scoping uses the stored platform token's `userId` claim. If `BRICKS_PLUGIN_ID` / `BRICKS_PLATFORM_TOKEN` are missing or invalid, OpenClaw status/config flows now fail loudly so the user fixes the stored config instead of silently falling back to `default`.
 - 收到 `message.created` 时会先写入一条 streaming 消息，随后通过 PATCH 更新消息的 `text`/`metadata`；当前不会将 `status` patch 为 `completed`。
 - 收到 `conversation.binding_changed` 时当前仅记录日志（MVP noop）。

--- a/apps/node_openclaw_plugin/src/bricksChannelPlugin.ts
+++ b/apps/node_openclaw_plugin/src/bricksChannelPlugin.ts
@@ -230,6 +230,19 @@ function missingBricksConfigMessage(config: BricksStoredConfig): string | undefi
   return `Missing required Bricks config: ${missingKeys.join(', ')}`;
 }
 
+function validateBricksChannelConfig(config: BricksStoredConfig): { configured: boolean; warning?: string } {
+  if (!isBricksChannelConfigured(config)) {
+    return { configured: false, warning: missingBricksConfigMessage(config) };
+  }
+  try {
+    parseAndValidatePlatformTokenClaims(config.BRICKS_PLATFORM_TOKEN!, config.BRICKS_PLUGIN_ID!);
+    return { configured: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown token error';
+    return { configured: false, warning: `Invalid Bricks platform token: ${message}` };
+  }
+}
+
 function readInputValue(input: ChannelSetupInput, key: BricksConfigKey): string | undefined {
   return readOptionalString(input[key]);
 }
@@ -350,22 +363,22 @@ const bricksConfigAdapter: ChannelConfigAdapter = {
     };
   },
   isConfigured(_account, cfg) {
-    return isBricksChannelConfigured(readStoredChannelConfig(cfg));
+    return validateBricksChannelConfig(readStoredChannelConfig(cfg)).configured;
   },
   describeAccount(account, cfg) {
     const accountLike = account as BricksAccountLike | undefined;
     const config = readStoredChannelConfig(cfg);
-    const warning = missingBricksConfigMessage(config);
+    const validation = validateBricksChannelConfig(config);
 
     return {
       enabled: typeof accountLike?.enabled === 'boolean'
         ? accountLike.enabled
         : true,
-      configured: isBricksChannelConfigured(config),
+      configured: validation.configured,
       extra: {
         baseUrl: config.BRICKS_BASE_URL ?? null,
         pluginId: config.BRICKS_PLUGIN_ID ?? null,
-        ...(warning ? { warning } : {}),
+        ...(validation.warning ? { warning: validation.warning } : {}),
       },
     };
   },
@@ -418,7 +431,7 @@ const bricksSetupWizard: ChannelSetupWizard = {
     unconfiguredHint: 'requires Bricks base URL, plugin id, and platform token',
     configuredScore: 1,
     unconfiguredScore: 0,
-    resolveConfigured: ({ cfg }) => isBricksChannelConfigured(readStoredChannelConfig(cfg)),
+    resolveConfigured: ({ cfg }) => validateBricksChannelConfig(readStoredChannelConfig(cfg)).configured,
     resolveSelectionHint: ({ cfg, configured }) =>
       configured
         ? 'configured'

--- a/apps/node_openclaw_plugin/src/bricksChannelPlugin.ts
+++ b/apps/node_openclaw_plugin/src/bricksChannelPlugin.ts
@@ -1,3 +1,5 @@
+import { parseAndValidatePlatformTokenClaims } from './jwtClaims.js';
+
 export const CHANNEL_ID = 'dev-askman-bricks';
 export const CHANNEL_NAME = 'Bricks OpenClaw Plugin';
 export const CHANNEL_DESCRIPTION = 'Bricks pull-only OpenClaw channel plugin with interactive onboarding.';
@@ -21,6 +23,10 @@ interface BricksStoredConfig {
   BRICKS_BASE_URL?: string;
   BRICKS_PLUGIN_ID?: string;
   BRICKS_PLATFORM_TOKEN?: string;
+}
+
+interface BricksAccountLike {
+  enabled?: unknown;
 }
 
 interface BricksResolvedAccount {
@@ -166,8 +172,8 @@ function readOptionalString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function readStoredChannelConfig(cfg: OpenClawConfig): BricksStoredConfig {
-  const channels = isRecord(cfg.channels) ? cfg.channels : {};
+function readStoredChannelConfig(cfg?: OpenClawConfig | null): BricksStoredConfig {
+  const channels = isRecord(cfg?.channels) ? cfg.channels : {};
   const rawChannelConfig = channels[CHANNEL_ID];
   const channelConfig = isRecord(rawChannelConfig) ? rawChannelConfig : {};
 
@@ -178,13 +184,50 @@ function readStoredChannelConfig(cfg: OpenClawConfig): BricksStoredConfig {
   };
 }
 
-function hasStoredChannelSection(cfg: OpenClawConfig): boolean {
-  const channels = isRecord(cfg.channels) ? cfg.channels : {};
+function hasStoredChannelSection(cfg?: OpenClawConfig | null): boolean {
+  const channels = isRecord(cfg?.channels) ? cfg.channels : {};
   return isRecord(channels[CHANNEL_ID]);
 }
 
 function isBricksChannelConfigured(config: BricksStoredConfig): boolean {
   return Boolean(config.BRICKS_BASE_URL && config.BRICKS_PLUGIN_ID && config.BRICKS_PLATFORM_TOKEN);
+}
+
+function resolveStoredAccountId(cfg?: OpenClawConfig | null): string {
+  if (!hasStoredChannelSection(cfg)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+
+  const config = readStoredChannelConfig(cfg);
+  if (!config.BRICKS_PLUGIN_ID) {
+    throw new Error('BRICKS_PLUGIN_ID is required to derive Bricks accountId');
+  }
+  if (!config.BRICKS_PLATFORM_TOKEN) {
+    throw new Error('BRICKS_PLATFORM_TOKEN is required to derive Bricks accountId');
+  }
+  try {
+    return parseAndValidatePlatformTokenClaims(
+      config.BRICKS_PLATFORM_TOKEN,
+      config.BRICKS_PLUGIN_ID,
+    ).userId;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown token error';
+    throw new Error(`Invalid Bricks platform token config: ${message}`);
+  }
+}
+
+function missingBricksConfigMessage(config: BricksStoredConfig): string | undefined {
+  const missingKeys = [
+    !config.BRICKS_BASE_URL ? 'BRICKS_BASE_URL' : null,
+    !config.BRICKS_PLUGIN_ID ? 'BRICKS_PLUGIN_ID' : null,
+    !config.BRICKS_PLATFORM_TOKEN ? 'BRICKS_PLATFORM_TOKEN' : null,
+  ].filter((key): key is string => key !== null);
+
+  if (missingKeys.length === 0) {
+    return undefined;
+  }
+
+  return `Missing required Bricks config: ${missingKeys.join(', ')}`;
 }
 
 function readInputValue(input: ChannelSetupInput, key: BricksConfigKey): string | undefined {
@@ -279,43 +322,50 @@ export const BRICKS_CHANNEL_CONFIG_SCHEMA: ChannelConfigSchema = {
 
 const bricksConfigAdapter: ChannelConfigAdapter = {
   listAccountIds(cfg) {
-    return hasStoredChannelSection(cfg) ? [DEFAULT_ACCOUNT_ID] : [];
+    return hasStoredChannelSection(cfg) ? [resolveStoredAccountId(cfg)] : [];
   },
-  resolveAccount(cfg, accountId) {
-    const resolvedAccountId = readOptionalString(accountId) ?? DEFAULT_ACCOUNT_ID;
+  resolveAccount(cfg, _accountId) {
     const config = readStoredChannelConfig(cfg);
 
     return {
-      accountId: resolvedAccountId,
+      accountId: resolveStoredAccountId(cfg),
       enabled: true,
       configured: isBricksChannelConfigured(config),
       config,
     };
   },
-  defaultAccountId() {
-    return DEFAULT_ACCOUNT_ID;
+  defaultAccountId(cfg) {
+    return resolveStoredAccountId(cfg);
   },
   inspectAccount(cfg, accountId) {
     const account = this.resolveAccount(cfg, accountId);
+    const warning = missingBricksConfigMessage(account.config);
     return {
       enabled: account.enabled,
       configured: account.configured,
       tokenStatus: account.config.BRICKS_PLATFORM_TOKEN ? 'available' : 'missing',
       pluginId: account.config.BRICKS_PLUGIN_ID ?? null,
       baseUrl: account.config.BRICKS_BASE_URL ?? null,
+      ...(warning ? { warning } : {}),
     };
   },
-  isConfigured(account) {
-    return account.configured;
+  isConfigured(_account, cfg) {
+    return isBricksChannelConfigured(readStoredChannelConfig(cfg));
   },
-  describeAccount(account) {
+  describeAccount(account, cfg) {
+    const accountLike = account as BricksAccountLike | undefined;
+    const config = readStoredChannelConfig(cfg);
+    const warning = missingBricksConfigMessage(config);
+
     return {
-      accountId: account.accountId,
-      enabled: account.enabled,
-      configured: account.configured,
+      enabled: typeof accountLike?.enabled === 'boolean'
+        ? accountLike.enabled
+        : true,
+      configured: isBricksChannelConfigured(config),
       extra: {
-        baseUrl: account.config.BRICKS_BASE_URL ?? null,
-        pluginId: account.config.BRICKS_PLUGIN_ID ?? null,
+        baseUrl: config.BRICKS_BASE_URL ?? null,
+        pluginId: config.BRICKS_PLUGIN_ID ?? null,
+        ...(warning ? { warning } : {}),
       },
     };
   },
@@ -369,8 +419,10 @@ const bricksSetupWizard: ChannelSetupWizard = {
     configuredScore: 1,
     unconfiguredScore: 0,
     resolveConfigured: ({ cfg }) => isBricksChannelConfigured(readStoredChannelConfig(cfg)),
-    resolveSelectionHint: ({ configured }) =>
-      configured ? 'configured' : 'Bricks pull-only platform channel',
+    resolveSelectionHint: ({ cfg, configured }) =>
+      configured
+        ? 'configured'
+        : missingBricksConfigMessage(readStoredChannelConfig(cfg)) ?? 'Bricks pull-only platform channel',
   },
   credentials: [
     {

--- a/apps/node_openclaw_plugin/test/openclawExtension.test.ts
+++ b/apps/node_openclaw_plugin/test/openclawExtension.test.ts
@@ -6,6 +6,12 @@ import pluginEntry, {
   bricksChannelPlugin,
 } from '../src/openclawExtension.js';
 
+function makePlatformJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.signature`;
+}
+
 describe('openclawExtension channel entry', () => {
   it('reuses the Bricks channel config schema', () => {
     expect(pluginEntry.configSchema).toEqual(BRICKS_CHANNEL_CONFIG_SCHEMA);
@@ -86,6 +92,30 @@ describe('bricksChannelPlugin setup', () => {
 
 describe('bricksChannelPlugin config and wizard', () => {
   it('reports configured state from stored channel config', async () => {
+    const token = makePlatformJwt({
+      typ: 'platform_plugin',
+      pluginId: 'plugin-id',
+      userId: 'user_1',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    const cfg = {
+      channels: {
+        [CHANNEL_ID]: {
+          BRICKS_BASE_URL: 'https://api.example.com',
+          BRICKS_PLUGIN_ID: 'plugin-id',
+          BRICKS_PLATFORM_TOKEN: token,
+        },
+      },
+    };
+
+    expect(bricksChannelPlugin.config.listAccountIds(cfg)).toEqual(['user_1']);
+    expect(bricksChannelPlugin.config.defaultAccountId?.(cfg)).toBe('user_1');
+    expect(bricksChannelPlugin.config.resolveAccount(cfg).accountId).toBe('user_1');
+    expect(bricksChannelPlugin.config.resolveAccount(cfg).configured).toBe(true);
+    expect(await bricksChannelPlugin.setupWizard.status.resolveConfigured({ cfg })).toBe(true);
+  });
+
+  it('describes accounts safely without inventing a default account id', () => {
     const cfg = {
       channels: {
         [CHANNEL_ID]: {
@@ -96,9 +126,72 @@ describe('bricksChannelPlugin config and wizard', () => {
       },
     };
 
-    expect(bricksChannelPlugin.config.listAccountIds(cfg)).toEqual([DEFAULT_ACCOUNT_ID]);
-    expect(bricksChannelPlugin.config.resolveAccount(cfg).configured).toBe(true);
-    expect(await bricksChannelPlugin.setupWizard.status.resolveConfigured({ cfg })).toBe(true);
+    expect(
+      bricksChannelPlugin.config.describeAccount?.(
+        {
+          enabled: true,
+        } as never,
+        cfg,
+      ),
+    ).toEqual({
+      enabled: true,
+      configured: true,
+      extra: {
+        baseUrl: 'https://api.example.com',
+        pluginId: 'plugin-id',
+      },
+    });
+  });
+
+  it('marks partial accounts as unconfigured when required config is missing', () => {
+    const cfg = {
+      channels: {
+        [CHANNEL_ID]: {
+          BRICKS_BASE_URL: 'https://api.example.com',
+          BRICKS_PLATFORM_TOKEN: 'jwt-token',
+        },
+      },
+    };
+
+    expect(
+      bricksChannelPlugin.config.describeAccount?.(
+        {
+          enabled: true,
+          configured: true,
+        } as never,
+        cfg,
+      ),
+    ).toEqual({
+      enabled: true,
+      configured: false,
+      extra: {
+        baseUrl: 'https://api.example.com',
+        pluginId: null,
+        warning: 'Missing required Bricks config: BRICKS_PLUGIN_ID',
+      },
+    });
+  });
+
+  it('throws when stored token config cannot derive a real account id', () => {
+    const cfg = {
+      channels: {
+        [CHANNEL_ID]: {
+          BRICKS_BASE_URL: 'https://api.example.com',
+          BRICKS_PLUGIN_ID: 'plugin-id',
+          BRICKS_PLATFORM_TOKEN: 'not-a-jwt',
+        },
+      },
+    };
+
+    expect(() => bricksChannelPlugin.config.listAccountIds(cfg)).toThrow(
+      'Invalid Bricks platform token config: BRICKS_PLATFORM_TOKEN must be a JWT with 3 segments',
+    );
+    expect(() => bricksChannelPlugin.config.defaultAccountId?.(cfg)).toThrow(
+      'Invalid Bricks platform token config: BRICKS_PLATFORM_TOKEN must be a JWT with 3 segments',
+    );
+    expect(() => bricksChannelPlugin.config.resolveAccount(cfg)).toThrow(
+      'Invalid Bricks platform token config: BRICKS_PLATFORM_TOKEN must be a JWT with 3 segments',
+    );
   });
 
   it('stores wizard text and credential fields through channel config helpers', async () => {

--- a/apps/node_openclaw_plugin/test/openclawExtension.test.ts
+++ b/apps/node_openclaw_plugin/test/openclawExtension.test.ts
@@ -135,10 +135,11 @@ describe('bricksChannelPlugin config and wizard', () => {
       ),
     ).toEqual({
       enabled: true,
-      configured: true,
+      configured: false,
       extra: {
         baseUrl: 'https://api.example.com',
         pluginId: 'plugin-id',
+        warning: expect.stringContaining('Invalid Bricks platform token'),
       },
     });
   });

--- a/docs/plans/2026-04-20-09-40-UTC-openclaw-accountid-userid-scoping.md
+++ b/docs/plans/2026-04-20-09-40-UTC-openclaw-accountid-userid-scoping.md
@@ -1,0 +1,15 @@
+# Problem
+
+The Bricks OpenClaw plugin currently uses a fixed `DEFAULT_ACCOUNT_ID` for its single account slot. When the configured `BRICKS_PLATFORM_TOKEN` changes to a different Bricks user, OpenClaw still sees the same account id, so its internal per-account routing/session scoping can overlap across users.
+
+# Proposed approach
+
+- Keep the plugin's flat channel config model as-is.
+- Derive the OpenClaw `accountId` from the configured platform token's `userId` claim.
+- If the stored `BRICKS_PLUGIN_ID` / `BRICKS_PLATFORM_TOKEN` cannot produce a valid user-scoped identity, surface an explicit error instead of silently falling back to `DEFAULT_ACCOUNT_ID`.
+- Do not change the plugin state file layout in this step.
+
+# Notes
+
+- This fixes OpenClaw's account-slot scoping only; it does not yet isolate the plugin's own persisted state file.
+- Validation for this step is limited to the plugin package checks and local `openclaw status`.


### PR DESCRIPTION
## Summary\n- derive the Bricks OpenClaw accountId from the stored platform token userId claim\n- fail loudly when BRICKS_PLUGIN_ID / BRICKS_PLATFORM_TOKEN cannot produce a valid scoped account id\n- keep the OpenClaw status compatibility fix and add regression tests\n\n## Validation\n- npm test\n- npm run type-check\n- npm run build\n- openclaw gateway restart\n- openclaw status\n\n## Follow-up\n- plugin state file scoping is still global and intentionally left for a later change