### PR TITLE
Remove client-side batch persistence of active-scope messages from ChatScreen

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -79,7 +79,6 @@ class _ChatScreenState extends State<ChatScreen> {
   String? _latestCheckpointCursor;
   int _lastSyncedSeq = 0;
   final ChatHistoryApiService _chatHistoryApiService = ChatHistoryApiService();
-  Timer? _persistDebounce;
   Timer? _syncTimer;
   bool _syncInFlight = false;
   static const Duration _syncPollInterval = Duration(seconds: 2);
@@ -98,9 +97,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
   @override
   void dispose() {
-    _persistDebounce?.cancel();
     _cancelSyncPolling(resetDelay: false);
-    _doPersistActiveScopeMessages();
     Timer(const Duration(seconds: 5), _chatHistoryApiService.dispose);
     _currentSubscription?.cancel();
     for (final session in _sessions.values) {
@@ -609,7 +606,6 @@ class _ChatScreenState extends State<ChatScreen> {
           _latestCheckpointCursor = null;
           _lastSyncedSeq = 0;
         });
-        _persistActiveScopeMessages();
         _configureActiveScopeSync();
         ScaffoldMessenger.of(
           context,
@@ -652,10 +648,10 @@ class _ChatScreenState extends State<ChatScreen> {
           unawaited(
             _chatHistoryApiService
                 .saveChannelName(
-                  token: token,
-                  channelId: channelId,
-                  displayName: name,
-                )
+              token: token,
+              channelId: channelId,
+              displayName: name,
+            )
                 .catchError((Object error, StackTrace stackTrace) {
               debugPrint('Failed to save channel name "$channelId": $error');
             }),
@@ -698,10 +694,10 @@ class _ChatScreenState extends State<ChatScreen> {
       unawaited(
         _chatHistoryApiService
             .saveChannelName(
-              token: token,
-              channelId: channelId,
-              displayName: null,
-            )
+          token: token,
+          channelId: channelId,
+          displayName: null,
+        )
             .catchError((Object error, StackTrace stackTrace) {
           debugPrint('Failed to archive channel "$channelId": $error');
         }),
@@ -1087,34 +1083,6 @@ class _ChatScreenState extends State<ChatScreen> {
     return null;
   }
 
-  void _persistActiveScopeMessages({bool immediate = false}) {
-    _persistDebounce?.cancel();
-    if (immediate) {
-      _doPersistActiveScopeMessages();
-      return;
-    }
-    // Debounce to avoid request storms on streaming deltas.
-    _persistDebounce = Timer(const Duration(milliseconds: 500), () {
-      _doPersistActiveScopeMessages();
-    });
-  }
-
-  void _doPersistActiveScopeMessages() {
-    final token = _authToken;
-    if (token == null || token.isEmpty) return;
-    unawaited(
-      _chatHistoryApiService
-          .upsertMessages(token: token, messages: _messages)
-          .then((lastSeq) {
-        if (!mounted || lastSeq <= 0) return;
-        // Only advance the cursor, never move it backwards.
-        setState(() {
-          if (lastSeq > _lastSyncedSeq) _lastSyncedSeq = lastSeq;
-        });
-      }).catchError((_) {}),
-    );
-  }
-
   bool _hasPendingAssistantTasks() {
     return _messages.any(
       (message) =>
@@ -1273,7 +1241,6 @@ class _ChatScreenState extends State<ChatScreen> {
       _latestCheckpointCursor = null;
       _lastSyncedSeq = 0;
     });
-    _persistActiveScopeMessages();
     _configureActiveScopeSync();
   }
 
@@ -1298,7 +1265,6 @@ class _ChatScreenState extends State<ChatScreen> {
         isStreaming: isStreaming,
       );
     });
-    _persistActiveScopeMessages();
   }
 
   int _appendMessage(ChatMessage message) {
@@ -1317,9 +1283,6 @@ class _ChatScreenState extends State<ChatScreen> {
         _activeScope.threadId,
       )] = messageTime;
     });
-    final shouldPersistImmediately =
-        normalized.role == 'user' || (!normalized.isStreaming);
-    _persistActiveScopeMessages(immediate: shouldPersistImmediately);
     return _messages.length - 1;
   }
 
@@ -1380,36 +1343,34 @@ class _ChatScreenState extends State<ChatScreen> {
     );
     final ack = _taskProtocol.acknowledge(envelope);
     _latestCheckpointCursor = ack.checkpointCursor;
-    _persistActiveScopeMessages();
 
     final scoreSummary = arbitration.candidateScores
         .map((item) => '${item.botId}:${item.score.toStringAsFixed(2)}')
         .join(', ');
-    _appendMessage(
-      ChatMessage(
-        messageId: userMessageId,
-        role: 'user',
-        content: text,
-        taskId: taskId,
-        taskState: ChatTaskState.accepted,
-        idempotencyKey: idempotencyKey,
-        createdAt: envelope.createdAt,
-        acknowledgedAt: ack.acceptedAt,
-        checkpointCursor: ack.checkpointCursor,
-        channelId: envelope.channelId,
-        sessionId: envelope.sessionId,
-        threadId: envelope.threadId,
-        resolvedBotId: resolvedBotId,
-        resolvedSkillId: resolvedSkillId,
-        arbitrationMode: arbitrationMode,
-        tieDetected: arbitration.tieDetected,
-        tieBotIds: arbitration.tieBotIds,
-        selectedScore: arbitration.selectedScore,
-        candidateScoreSummary: scoreSummary.isEmpty ? null : scoreSummary,
-        decisionReason: arbitration.reason,
-        traceId: arbitrationMode ? traceId : null,
-      ),
+    final userMessage = ChatMessage(
+      messageId: userMessageId,
+      role: 'user',
+      content: text,
+      taskId: taskId,
+      taskState: ChatTaskState.accepted,
+      idempotencyKey: idempotencyKey,
+      createdAt: envelope.createdAt,
+      acknowledgedAt: ack.acceptedAt,
+      checkpointCursor: ack.checkpointCursor,
+      channelId: envelope.channelId,
+      sessionId: envelope.sessionId,
+      threadId: envelope.threadId,
+      resolvedBotId: resolvedBotId,
+      resolvedSkillId: resolvedSkillId,
+      arbitrationMode: arbitrationMode,
+      tieDetected: arbitration.tieDetected,
+      tieBotIds: arbitration.tieBotIds,
+      selectedScore: arbitration.selectedScore,
+      candidateScoreSummary: scoreSummary.isEmpty ? null : scoreSummary,
+      decisionReason: arbitration.reason,
+      traceId: arbitrationMode ? traceId : null,
     );
+    _appendMessage(userMessage);
     _appendMessage(
       ChatMessage(
         messageId: assistantMessageId,
@@ -1559,7 +1520,6 @@ class _ChatScreenState extends State<ChatScreen> {
         });
         return;
       }
-      _persistActiveScopeMessages(immediate: true);
     });
   }
 
@@ -1584,7 +1544,6 @@ class _ChatScreenState extends State<ChatScreen> {
           }
         }
       });
-      _persistActiveScopeMessages(immediate: true);
     }
   }
 

--- a/docs/plans/2026-04-20-08-57-UTC-controlled-user-query-commit.md
+++ b/docs/plans/2026-04-20-08-57-UTC-controlled-user-query-commit.md
@@ -1,0 +1,28 @@
+# Background
+The chat frontend currently persists messages by repeatedly upserting the whole in-memory message list. During streaming and state transitions this causes replay writes, write sequence churn, and potential ordering side effects. Failures also silently auto-retry through repeated UI-triggered persistence calls.
+
+# Goals
+1. Persist only the current user query as a controlled, single-message commit (`length = 1`) per send action.
+2. Block new user-query persistence attempts while one commit is pending/in-flight.
+3. Replace implicit repeated retries with explicit user-triggered retry and visible toast/snackbar feedback.
+4. Reduce unnecessary historical message upserts to improve write sequence stability and ordering signal quality.
+
+# Implementation Plan (phased)
+1. Add controlled user-query persistence state to `chat_screen.dart`:
+   - Track in-flight and failed-pending user query commit.
+   - Add helpers for pending checks, commit execution, and failure snackbar with retry action.
+2. Refactor send flow:
+   - Build user message payload once and append locally.
+   - Execute exactly one commit attempt for the user message (`upsertMessages` with singleton list).
+   - Prevent additional sends when a pending user-query commit exists.
+3. Remove whole-list auto persistence triggers from normal message updates/streaming paths.
+4. Add/adjust tests in `chat_history_api_service_test.dart` to validate singleton upsert payload behavior.
+5. Run targeted Dart/Flutter tests and formatting for touched files.
+6. Review code-map impact and update maps only if feature/logic/test entry indexing changed.
+
+# Acceptance Criteria
+- A send action results in one user-query persistence attempt with exactly one message in request payload.
+- While a user-query commit is pending/in-flight, additional sends are rejected with visible feedback.
+- On commit failure, no automatic retry loop occurs; retry requires explicit user action from snackbar/toast.
+- Streaming assistant updates no longer trigger full-history upsert requests.
+- Existing chat history API service tests pass for updated behavior.

--- a/docs/plans/2026-04-20-09-46-UTC-remove-redundant-user-query-batch-commit.md
+++ b/docs/plans/2026-04-20-09-46-UTC-remove-redundant-user-query-batch-commit.md
@@ -1,0 +1,19 @@
+# Background
+Feedback from validation indicates no observable `/api/chat/messages/batch` call in the real send path, while `/api/chat/respond` is consistently observed. The previous refactor introduced extra client-side controlled commit logic that may be redundant versus backend-owned persistence in `respond`.
+
+# Goals
+1. Remove redundant client-side user-query batch commit logic from the send path.
+2. Keep send semantics simple and observable: one send action -> one backend `respond` orchestration request.
+3. Avoid introducing hidden persistence side effects or UX gates that are not verifiable in production testing.
+
+# Implementation Plan (phased)
+1. Remove `_userQueryCommitInFlight`, `_pendingUserQueryCommit`, and related helper methods from `chat_screen.dart`.
+2. Remove `_sendMessage` guards and async calls tied to `_commitUserQuery`.
+3. Preserve existing backend-driven `respond` flow and error handling.
+4. Run formatting, targeted tests, and analyzer checks.
+5. Update code maps only if behavior/index descriptions need alignment.
+
+# Acceptance Criteria
+- Sending a message only triggers `/api/chat/respond` from `ChatScreen` send path.
+- No code path in `ChatScreen` send flow invokes `upsertMessages`.
+- Chat send UI behavior remains functional without new blocking states.


### PR DESCRIPTION
### Motivation
- Prevent repeated whole-history upserts and write storms during streaming and state transitions by removing automatic client-side persistence of the in-memory message list.
- Simplify the send flow to avoid redundant/hidden persistence and rely on backend-driven `respond` orchestration for message persistence.

### Description
- Removed `_persistDebounce` and the `_persistActiveScopeMessages` / `_doPersistActiveScopeMessages` helpers from `apps/mobile_chat_app/lib/features/chat/chat_screen.dart` and deleted all calls to them throughout the file.
- Stopped performing immediate `upsertMessages` calls from send, update, streaming, stop/cancel, subsection/channel create/rename/archive paths so streaming assistant updates no longer trigger full-history upserts.
- Adjusted send flow to build and append the user message locally before appending the assistant placeholder and removed the client-side commit trigger; kept existing task/ack logic intact.
- Added planning docs under `docs/plans/` that describe the controlled user-query commit proposal and the subsequent decision to remove the redundant client-side batch commit.

### Testing
- Ran static checks and the project's automated test suite (`flutter analyze` and `flutter test`); the existing tests passed against these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ea489be8832d92290cc176e60378)