### PR TITLE
fix(platform): support Turso event acks

### DIFF
--- a/apps/node_backend/src/services/platformIntegrationService.test.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.test.ts
@@ -26,6 +26,7 @@ describe('platformIntegrationService', () => {
   beforeEach(() => {
     queryMock.mockReset();
     upsertMessagesMock.mockClear();
+    delete process.env.TURSO_DATABASE_URL;
   });
 
   it('lists only OpenClaw-ready user events with pending assistant metadata', async () => {
@@ -134,6 +135,30 @@ describe('platformIntegrationService', () => {
     expect(sql).toContain("SET task_state = 'completed'");
     expect(sql).toContain("AND task_state IN ('accepted', 'dispatched')");
     expect(sql).toContain('UNNEST($1::text[], $2::int[])');
+    expect(sql).toContain('jsonb_set(');
     expect(params).toEqual([['msg-user-1'], [5], 'plugin_local_main', 'u-1']);
+  });
+
+  it('ack uses Turso-compatible JSON patch SQL when libsql is enabled', async () => {
+    process.env.TURSO_DATABASE_URL = 'libsql://example.turso.io';
+    queryMock.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const result = await ackPlatformEvents({
+      pluginId: 'plugin_local_main',
+      userId: 'u-1',
+      cursor: 'cur_5',
+      ackedEventIds: ['evt_msg_msg-user-1_5', 'evt_msg_msg-user-2_8'],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("SET task_state = 'completed'");
+    expect(sql).toContain("AND task_state IN ('accepted', 'dispatched')");
+    expect(sql).toContain('json_patch(');
+    expect(sql).toContain("json_object('pluginReadBy', json_object($1, CURRENT_TIMESTAMP))");
+    expect(sql).not.toContain('UNNEST(');
+    expect(sql).not.toContain('::jsonb');
+    expect(params).toEqual(['plugin_local_main', 'msg-user-1', 5, 'msg-user-2', 8, 'u-1']);
   });
 });

--- a/apps/node_backend/src/services/platformIntegrationService.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.ts
@@ -170,11 +170,30 @@ export async function ackPlatformEvents(params: {
     return { ok: true };
   }
 
+  if (process.env.TURSO_DATABASE_URL) {
+    const queryParams: unknown[] = [params.pluginId];
+    const ackedMessageFilter = appendAckedMessageFilter(ackedMessages, queryParams);
+    const userFilter = appendUserIdFilter(params.userId, queryParams);
+    await pool.query(
+      `UPDATE chat_messages
+          SET task_state = 'completed',
+              metadata = json_patch(
+                COALESCE(metadata, '{}'),
+                json_object('pluginReadBy', json_object($1, CURRENT_TIMESTAMP))
+              ),
+              updated_at = CURRENT_TIMESTAMP
+        WHERE (${ackedMessageFilter})
+          AND role = 'user'
+          AND task_state IN ('accepted', 'dispatched')${userFilter}`,
+      queryParams,
+    );
+    return { ok: true };
+  }
+
   const messageIds = ackedMessages.map((item) => item.messageId);
   const writeSeqs = ackedMessages.map((item) => item.writeSeq);
   const queryParams: unknown[] = [messageIds, writeSeqs, params.pluginId];
   const userFilter = appendUserIdFilter(params.userId, queryParams);
-
   await pool.query(
     `UPDATE chat_messages
         SET task_state = 'completed',
@@ -313,6 +332,19 @@ export async function patchPlatformMessage(input: {
 function appendUserIdFilter(userId: string | undefined, queryParams: unknown[]): string {
   if (!userId) return '';
   return ` AND user_id = $${queryParams.push(userId)}`;
+}
+
+function appendAckedMessageFilter(
+  ackedMessages: Array<{ messageId: string; writeSeq: number }>,
+  queryParams: unknown[],
+): string {
+  return ackedMessages
+    .map((item) => {
+      const messageIdRef = `$${queryParams.push(item.messageId)}`;
+      const writeSeqRef = `$${queryParams.push(item.writeSeq)}`;
+      return `(message_id = ${messageIdRef} AND write_seq = ${writeSeqRef})`;
+    })
+    .join(' OR ');
 }
 
 export async function resolveConversation(params: {

--- a/docs/plans/2026-04-20-10-19-UTC-openclaw-reply-failure-db-analysis.md
+++ b/docs/plans/2026-04-20-10-19-UTC-openclaw-reply-failure-db-analysis.md
@@ -1,0 +1,65 @@
+# OpenClaw reply failure DB analysis
+
+## Problem
+
+The current async OpenClaw flow can persist a delayed assistant reply, but the
+database model does not express the reply relationship explicitly. Core async
+workflow state is also encoded in message metadata (`pendingAssistantMessageId`)
+and exported with a text search, which is brittle.
+
+## Proposed approach
+
+Keep `chat_messages` as the source of truth for visible conversation history and
+preserve `write_seq` ordering for late replies. Normalize the async reply
+contract into first-class columns so the backend and plugin do not depend on
+metadata string matching for routing or reply linkage.
+
+Recommended schema direction:
+
+1. Add `reply_to_message_id` on assistant messages to explicitly link `A1 -> A`.
+2. Add `source_message_id` on `chat_tasks` so each async/OpenClaw task records
+   which user message triggered it.
+3. Keep pending async execution state on `chat_tasks` (or a future task-specific
+   table), rather than encoding a one-to-one future reply id on the message row.
+4. Add indexes/constraints so reply linkage stays intra-user and lookup remains
+   efficient.
+
+## Todos
+
+- Confirm the exact schema migration shape for `reply_to_message_id` and
+  `chat_tasks.source_message_id`.
+- Update platform export/create/patch logic to read/write first-class reply
+  columns instead of metadata-only workflow markers.
+- Decide whether transient assistant placeholder rows should remain visible in
+  `chat_messages` or move to a non-message status path.
+- Add tests covering delayed OpenClaw replies, explicit reply references, and
+  mixed default/OpenClaw ordering.
+
+## Notes
+
+- `write_seq` already gives the desired DB ordering for late replies like
+  `A, B, B reply, A reply`.
+- The active client ordering bug is primarily a UI merge issue, not a DB
+  ordering limitation.
+- A separate relation table is possible, but likely overkill for the current
+  one-reply-per-user-message model.
+- `expected_reply_message_id` on `chat_messages` is no longer recommended,
+  because future branching can produce multiple child replies for a single
+  source message.
+- Runtime evidence from local OpenClaw + platform API:
+  - Plugin state shows processed event IDs and assistant client-token mappings
+    for five historical OpenClaw events, so those events reached
+    `handleMessageCreated(...)`.
+  - The state file still contains `pendingAck` and the persisted cursor remains
+    `cur_0`.
+  - Direct `GET /api/v1/platform/events` with the configured plugin token works,
+    but direct `POST /api/v1/platform/events/ack` returns `500 INTERNAL_ERROR`.
+  - Querying events after the pending cursor shows newer events waiting
+    unprocessed, so the runner is currently blocked on ack retry before it can
+    fetch subsequent messages.
+  - Vercel error logs confirm the server-side cause: `ackPlatformEvents()`
+    emitted PostgreSQL-only SQL that Turso/libSQL rejects with
+    `SQL_PARSE_ERROR`.
+  - Implemented fix: keep the existing PostgreSQL `jsonb_set + UNNEST` batch
+    update for Postgres, and use a Turso/libSQL-specific atomic
+    `json_patch(json_object(...))` batch update instead.


### PR DESCRIPTION
## Summary
- fix `/api/v1/platform/events/ack` so it works on both Postgres and Turso/libSQL
- keep the existing Postgres batch `jsonb_set + UNNEST` path and add a Turso-compatible atomic `json_patch` path
- add regression coverage for the Turso ack SQL shape and record the investigation notes for the OpenClaw reply failure

## Root cause
- OpenClaw plugin polling was getting stuck on `pendingAck`
- Vercel logs showed `/api/v1/platform/events/ack` failing with `SQL_PARSE_ERROR` on libSQL because the backend emitted PostgreSQL-only SQL
- when ack failed, the plugin cursor did not advance, so newer OpenClaw messages were never processed

## Validation
- `cd apps/node_backend && npm test -- src/services/platformIntegrationService.test.ts src/routes/platform.test.ts`
- `cd apps/node_backend && npm run type-check`
- `cd apps/node_backend && npm run build`

## Notes
- no database migration is required
- after deploy, the running plugin should retry the pending ack on its next tick and then continue processing queued events