### PR TITLE
Align OpenClaw plugin lockfile engine

### DIFF
--- a/apps/node_openclaw_plugin/package-lock.json
+++ b/apps/node_openclaw_plugin/package-lock.json
@@ -17,7 +17,7 @@
         "vitest": "^4.1.2"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.14.0"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {


### PR DESCRIPTION
## Summary
- align the `apps/node_openclaw_plugin/package-lock.json` root engine metadata with the already-updated package.json requirement
- keep the plugin package consistent with the `openclaw` runtime dependency requirement of Node >=22.14.0

## Validation
- `cd apps/node_openclaw_plugin && npm test`
- `cd apps/node_openclaw_plugin && npm run type-check`
- `cd apps/node_openclaw_plugin && npm run build`