### PR TITLE
Limit platform ack batches and share DB dialect

### DIFF
--- a/apps/node_backend/src/db/index.ts
+++ b/apps/node_backend/src/db/index.ts
@@ -11,12 +11,15 @@ type QueryResult<T = any> = {
   rowCount: number;
 };
 
+export type DatabaseDialect = 'postgres' | 'turso';
+
 type QueryableClient = {
   query: <T = any>(text: string, params?: unknown[]) => Promise<QueryResult<T>>;
   release: () => void;
 };
 
 type QueryablePool = {
+  dialect: DatabaseDialect;
   query: <T = any>(text: string, params?: unknown[]) => Promise<QueryResult<T>>;
   connect: () => Promise<QueryableClient>;
   end: () => Promise<void>;
@@ -82,6 +85,7 @@ function createTursoPool(): QueryablePool {
   };
 
   return {
+    dialect: 'turso',
     query,
     connect: async () => {
       let activeTx: Awaited<ReturnType<typeof tursoClient.transaction>> | null = null;
@@ -153,6 +157,7 @@ function createPostgresPool(): QueryablePool {
   });
 
   return {
+    dialect: 'postgres',
     query: async <T = any>(text: string, params: unknown[] = []): Promise<QueryResult<T>> => {
       const result = await pgPool.query(text, params);
       return {

--- a/apps/node_backend/src/routes/platform.test.ts
+++ b/apps/node_backend/src/routes/platform.test.ts
@@ -145,6 +145,25 @@ describe('platform route auth and ack constraints', () => {
     expect(vi.mocked(ackPlatformEvents)).not.toHaveBeenCalled();
   });
 
+  it('returns 400 when service throws INVALID_ACKED_EVENT_IDS', async () => {
+    vi.mocked(ackPlatformEvents).mockRejectedValueOnce(new Error('INVALID_ACKED_EVENT_IDS'));
+
+    const response = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-platform-key',
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({ ackedEventIds: ['bad-id'], cursor: 'cur_1' }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error?: { code?: string; message?: string } };
+    expect(body.error?.code).toBe('INVALID_PAYLOAD');
+    expect(body.error?.message).toContain('malformed');
+  });
+
   it('accepts user-scoped JWT platform token', async () => {
     const jwtToken = issuePlatformAccessToken({
       userId: 'user-123',

--- a/apps/node_backend/src/routes/platform.test.ts
+++ b/apps/node_backend/src/routes/platform.test.ts
@@ -4,12 +4,14 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { vi } from 'vitest';
 import { issuePlatformAccessToken } from '../middleware/platformAuth.js';
 import {
+  MAX_PLATFORM_ACK_BATCH_SIZE,
   ackPlatformEvents,
   listPlatformEvents,
   createPlatformMessage,
 } from '../services/platformIntegrationService.js';
 
 vi.mock('../services/platformIntegrationService.js', () => ({
+  MAX_PLATFORM_ACK_BATCH_SIZE: 200,
   listPlatformEvents: vi.fn(async () => ({ nextCursor: 'cur_0', events: [] })),
   ackPlatformEvents: vi.fn(async () => ({ ok: true })),
   createPlatformMessage: vi.fn(async () => ({ messageId: 'msg_test', conversationId: 'conv_1', revision: 1 })),
@@ -118,6 +120,29 @@ describe('platform route auth and ack constraints', () => {
 
     const body = (await second.json()) as { ok?: boolean };
     expect(body.ok).toBe(true);
+  });
+
+  it('rejects oversized ack payloads before calling the service', async () => {
+    vi.mocked(ackPlatformEvents).mockClear();
+
+    const response = await fetch(`${baseUrl}/api/v1/platform/events/ack`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-platform-key',
+        'Content-Type': 'application/json',
+        'X-Bricks-Plugin-Id': 'plugin_local_main',
+      },
+      body: JSON.stringify({
+        ackedEventIds: Array.from({ length: MAX_PLATFORM_ACK_BATCH_SIZE + 1 }, (_, index) => `evt_${index + 1}`),
+        cursor: 'cur_1',
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error?: { code?: string; message?: string } };
+    expect(body.error?.code).toBe('INVALID_PAYLOAD');
+    expect(body.error?.message).toContain(String(MAX_PLATFORM_ACK_BATCH_SIZE));
+    expect(vi.mocked(ackPlatformEvents)).not.toHaveBeenCalled();
   });
 
   it('accepts user-scoped JWT platform token', async () => {

--- a/apps/node_backend/src/routes/platform.ts
+++ b/apps/node_backend/src/routes/platform.ts
@@ -6,6 +6,7 @@ import {
   type PlatformAuthRequest,
 } from '../middleware/platformAuth.js';
 import {
+  MAX_PLATFORM_ACK_BATCH_SIZE,
   ackPlatformEvents,
   createPlatformMessage,
   listPlatformEvents,
@@ -175,6 +176,16 @@ export function createPlatformRouter(options: {
           return;
         }
 
+        if (ackedEventIds.length > MAX_PLATFORM_ACK_BATCH_SIZE) {
+          sendError(
+            res,
+            400,
+            'INVALID_PAYLOAD',
+            `ackedEventIds must contain no more than ${MAX_PLATFORM_ACK_BATCH_SIZE} items`,
+          );
+          return;
+        }
+
         await ackPlatformEvents({
           pluginId: req.platformPluginId ?? 'unknown',
           userId: req.platformUserId,
@@ -185,6 +196,15 @@ export function createPlatformRouter(options: {
       } catch (error) {
         if (error instanceof Error && error.message === 'INVALID_CURSOR') {
           sendError(res, 400, 'INVALID_CURSOR', 'cursor is malformed');
+          return;
+        }
+        if (error instanceof Error && error.message === 'TOO_MANY_ACKED_EVENT_IDS') {
+          sendError(
+            res,
+            400,
+            'INVALID_PAYLOAD',
+            `ackedEventIds must contain no more than ${MAX_PLATFORM_ACK_BATCH_SIZE} items`,
+          );
           return;
         }
         console.error('platform ack error:', error);

--- a/apps/node_backend/src/routes/platform.ts
+++ b/apps/node_backend/src/routes/platform.ts
@@ -207,6 +207,10 @@ export function createPlatformRouter(options: {
           );
           return;
         }
+        if (error instanceof Error && error.message === 'INVALID_ACKED_EVENT_IDS') {
+          sendError(res, 400, 'INVALID_PAYLOAD', 'one or more ackedEventIds are malformed');
+          return;
+        }
         console.error('platform ack error:', error);
         sendError(res, 500, 'INTERNAL_ERROR', 'internal server error', true);
       }

--- a/apps/node_backend/src/services/platformIntegrationService.test.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.test.ts
@@ -1,14 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { queryMock, upsertMessagesMock } = vi.hoisted(() => ({
-  queryMock: vi.fn(),
-  upsertMessagesMock: vi.fn(async () => ({ lastSeqId: 99 })),
-}));
+const { poolMock, queryMock, upsertMessagesMock } = vi.hoisted(() => {
+  const queryMock = vi.fn();
+  const upsertMessagesMock = vi.fn(async () => ({ lastSeqId: 99 }));
+  return {
+    poolMock: {
+      dialect: 'postgres' as 'postgres' | 'turso',
+      query: queryMock,
+    },
+    queryMock,
+    upsertMessagesMock,
+  };
+});
 
 vi.mock('../db/index.js', () => ({
-  default: {
-    query: queryMock,
-  },
+  default: poolMock,
 }));
 
 vi.mock('./chatAsyncTransportService.js', () => ({
@@ -26,7 +32,7 @@ describe('platformIntegrationService', () => {
   beforeEach(() => {
     queryMock.mockReset();
     upsertMessagesMock.mockClear();
-    delete process.env.TURSO_DATABASE_URL;
+    poolMock.dialect = 'postgres';
   });
 
   it('lists only OpenClaw-ready user events with pending assistant metadata', async () => {
@@ -139,8 +145,8 @@ describe('platformIntegrationService', () => {
     expect(params).toEqual([['msg-user-1'], [5], 'plugin_local_main', 'u-1']);
   });
 
-  it('ack uses Turso-compatible JSON patch SQL when libsql is enabled', async () => {
-    process.env.TURSO_DATABASE_URL = 'libsql://example.turso.io';
+  it('ack uses Turso-compatible JSON patch SQL when database dialect is turso', async () => {
+    poolMock.dialect = 'turso';
     queryMock.mockResolvedValueOnce({ rowCount: 1, rows: [] });
 
     const result = await ackPlatformEvents({
@@ -160,5 +166,45 @@ describe('platformIntegrationService', () => {
     expect(sql).not.toContain('UNNEST(');
     expect(sql).not.toContain('::jsonb');
     expect(params).toEqual(['plugin_local_main', 'msg-user-1', 5, 'msg-user-2', 8, 'u-1']);
+  });
+
+  it('chunks Turso ack updates into smaller statements', async () => {
+    poolMock.dialect = 'turso';
+    queryMock.mockResolvedValue({ rowCount: 1, rows: [] });
+
+    const ackedEventIds = Array.from(
+      { length: 51 },
+      (_, index) => `evt_msg_msg-user-${index + 1}_${index + 1}`,
+    );
+
+    const result = await ackPlatformEvents({
+      pluginId: 'plugin_local_main',
+      userId: 'u-1',
+      cursor: 'cur_51',
+      ackedEventIds,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    expect(queryMock.mock.calls[0]?.[1]).toHaveLength(102);
+    expect(queryMock.mock.calls[1]?.[1]).toEqual(['plugin_local_main', 'msg-user-51', 51, 'u-1']);
+  });
+
+  it('rejects oversized ack batches before querying', async () => {
+    const ackedEventIds = Array.from(
+      { length: 201 },
+      (_, index) => `evt_msg_msg-user-${index + 1}_${index + 1}`,
+    );
+
+    await expect(
+      ackPlatformEvents({
+        pluginId: 'plugin_local_main',
+        userId: 'u-1',
+        cursor: 'cur_201',
+        ackedEventIds,
+      }),
+    ).rejects.toThrow('TOO_MANY_ACKED_EVENT_IDS');
+
+    expect(queryMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/node_backend/src/services/platformIntegrationService.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.ts
@@ -40,10 +40,10 @@ export interface PlatformEvent {
       userId: string;
       displayName: string;
     };
-       text: string;
-       attachments: unknown[];
-       metadata?: Record<string, unknown>;
-      };
+    text: string;
+    attachments: unknown[];
+    metadata?: Record<string, unknown>;
+  };
 }
 
 export const MAX_PLATFORM_EVENTS_LIMIT = 200;

--- a/apps/node_backend/src/services/platformIntegrationService.ts
+++ b/apps/node_backend/src/services/platformIntegrationService.ts
@@ -43,8 +43,13 @@ export interface PlatformEvent {
        text: string;
        attachments: unknown[];
        metadata?: Record<string, unknown>;
-     };
+      };
 }
+
+export const MAX_PLATFORM_EVENTS_LIMIT = 200;
+export const MAX_PLATFORM_ACK_BATCH_SIZE = MAX_PLATFORM_EVENTS_LIMIT;
+const DEFAULT_PLATFORM_EVENTS_LIMIT = 50;
+const TURSO_ACK_UPDATE_CHUNK_SIZE = 50;
 
 function cursorToSeq(cursor?: string): number {
   if (!cursor) return 0;
@@ -83,7 +88,7 @@ export async function listPlatformEvents(params: {
   workspaceId?: string;
   userId?: string;
 }): Promise<{ nextCursor: string; events: PlatformEvent[] }> {
-  const limit = Math.min(200, Math.max(1, params.limit ?? 50));
+  const limit = Math.min(MAX_PLATFORM_EVENTS_LIMIT, Math.max(1, params.limit ?? DEFAULT_PLATFORM_EVENTS_LIMIT));
   const afterSeq = cursorToSeq(params.cursor);
   const workspaceId = params.workspaceId ?? process.env.BRICKS_PLATFORM_WORKSPACE_ID ?? 'ws_local';
 
@@ -170,23 +175,29 @@ export async function ackPlatformEvents(params: {
     return { ok: true };
   }
 
-  if (process.env.TURSO_DATABASE_URL) {
-    const queryParams: unknown[] = [params.pluginId];
-    const ackedMessageFilter = appendAckedMessageFilter(ackedMessages, queryParams);
-    const userFilter = appendUserIdFilter(params.userId, queryParams);
-    await pool.query(
-      `UPDATE chat_messages
-          SET task_state = 'completed',
-              metadata = json_patch(
-                COALESCE(metadata, '{}'),
-                json_object('pluginReadBy', json_object($1, CURRENT_TIMESTAMP))
-              ),
-              updated_at = CURRENT_TIMESTAMP
-        WHERE (${ackedMessageFilter})
-          AND role = 'user'
-          AND task_state IN ('accepted', 'dispatched')${userFilter}`,
-      queryParams,
-    );
+  if (ackedMessages.length > MAX_PLATFORM_ACK_BATCH_SIZE) {
+    throw new Error('TOO_MANY_ACKED_EVENT_IDS');
+  }
+
+  if (pool.dialect === 'turso') {
+    for (const ackedMessageChunk of chunkItems(ackedMessages, TURSO_ACK_UPDATE_CHUNK_SIZE)) {
+      const queryParams: unknown[] = [params.pluginId];
+      const ackedMessageFilter = appendAckedMessageFilter(ackedMessageChunk, queryParams);
+      const userFilter = appendUserIdFilter(params.userId, queryParams);
+      await pool.query(
+        `UPDATE chat_messages
+            SET task_state = 'completed',
+                metadata = json_patch(
+                  COALESCE(metadata, '{}'),
+                  json_object('pluginReadBy', json_object($1, CURRENT_TIMESTAMP))
+                ),
+                updated_at = CURRENT_TIMESTAMP
+          WHERE (${ackedMessageFilter})
+            AND role = 'user'
+            AND task_state IN ('accepted', 'dispatched')${userFilter}`,
+        queryParams,
+      );
+    }
     return { ok: true };
   }
 
@@ -345,6 +356,17 @@ function appendAckedMessageFilter(
       return `(message_id = ${messageIdRef} AND write_seq = ${writeSeqRef})`;
     })
     .join(' OR ');
+}
+
+function chunkItems<T>(items: readonly T[], chunkSize: number): T[][] {
+  if (chunkSize <= 0) {
+    throw new Error('INVALID_CHUNK_SIZE');
+  }
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += chunkSize) {
+    chunks.push(items.slice(index, index + chunkSize));
+  }
+  return chunks;
 }
 
 export async function resolveConversation(params: {

--- a/docs/plans/2026-04-20-19-29-UTC-platform-ack-scaling-dialect-cleanup.md
+++ b/docs/plans/2026-04-20-19-29-UTC-platform-ack-scaling-dialect-cleanup.md
@@ -1,0 +1,34 @@
+# Platform ack scaling and dialect cleanup
+
+## Problem
+
+Two follow-up issues remain in the platform ack path:
+
+1. The Turso/libSQL ack update builds a large `OR` predicate with two bind
+   parameters per acked message and the `/api/v1/platform/events/ack` route
+   does not currently cap `ackedEventIds`.
+2. `platformIntegrationService.ts` re-reads `process.env.TURSO_DATABASE_URL`
+   even though the DB module already selects the active pool/dialect.
+
+## Approach
+
+- Add a clear server-side batch cap for `ackedEventIds`, aligned with the
+  platform events page-size limit.
+- Chunk Turso ack updates into smaller SQL statements so large valid batches do
+  not build oversized statements.
+- Expose DB dialect metadata from the DB module and branch on that instead of
+  duplicating env-var checks in service code.
+- Add/adjust backend tests for route validation, Turso SQL chunking, and
+  dialect-driven behavior.
+
+## Validation
+
+- `cd apps/node_backend && npm test -- --run src/routes/platform.test.ts src/services/platformIntegrationService.test.ts`
+- `cd apps/node_backend && npm run type-check`
+- `cd apps/node_backend && npm run build`
+
+## Notes
+
+- This task is a follow-up to review feedback after the OpenClaw/platform
+  handoff work already merged.
+- The intended PR should be a fresh branch from latest `main`.


### PR DESCRIPTION
## Summary
- cap `/api/v1/platform/events/ack` payloads to the same 200-item ceiling used by platform event paging
- chunk Turso/libSQL ack updates into smaller statements and branch on `pool.dialect` instead of re-reading `TURSO_DATABASE_URL`
- add backend coverage for the new route validation and Turso chunking behavior

## Testing
- `cd apps/node_backend && npm test`
- `cd apps/node_backend && npm run type-check`
- `cd apps/node_backend && npm run build`
