### PR TITLE
Back off OpenClaw network transport failures

### DIFF
--- a/apps/node_openclaw_plugin/src/pluginRunner.ts
+++ b/apps/node_openclaw_plugin/src/pluginRunner.ts
@@ -44,6 +44,17 @@ const defaultRunnerLog: RunnerLogSink = {
   error: (message) => console.error(message),
 };
 
+const RETRYABLE_NETWORK_ERROR_CODES = new Set([
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'EHOSTUNREACH',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+]);
+
 export class NodeOpenClawPluginRunner {
   private readonly client: PlatformClientLike;
   private readonly stateStore: StateStoreLike;
@@ -101,7 +112,7 @@ export class NodeOpenClawPluginRunner {
           if (retryDelayMs !== null) {
             this.nextPollDelayMs = retryDelayMs;
             this.log.warn(
-              `[node_openclaw_plugin] retryable platform failure; backing off for ${retryDelayMs}ms: ${formatRunnerError(error)}`,
+              `[node_openclaw_plugin] retryable platform/network failure; backing off for ${retryDelayMs}ms: ${formatRunnerError(error)}`,
             );
           } else {
             this.log.error(`[node_openclaw_plugin] tick failed: ${formatRunnerError(error)}`);
@@ -400,11 +411,17 @@ function isAbortError(error: unknown): boolean {
 }
 
 export function shouldBackoffPlatformError(error: unknown): error is PlatformHttpError {
-  return error instanceof PlatformHttpError && (
-    error.status === 429
-    || error.retryable === true
-    || error.status >= 500
-  );
+  return error instanceof PlatformHttpError;
+}
+
+export function shouldBackoffRunnerError(error: unknown): boolean {
+  if (error instanceof PlatformHttpError) {
+    return error.status === 429
+      || error.retryable === true
+      || error.status >= 500;
+  }
+
+  return hasRetryableNetworkCause(error);
 }
 
 export function nextBackoffDelayMs(
@@ -431,11 +448,16 @@ export function resolveRetryDelayMs(
   baseDelayMs: number,
   capDelayMs = 10_000,
 ): number | null {
-  if (!shouldBackoffPlatformError(error)) {
+  if (!shouldBackoffRunnerError(error)) {
     return null;
   }
 
-  if (typeof error.retryAfterMs === 'number' && Number.isFinite(error.retryAfterMs) && error.retryAfterMs > 0) {
+  if (
+    error instanceof PlatformHttpError
+    && typeof error.retryAfterMs === 'number'
+    && Number.isFinite(error.retryAfterMs)
+    && error.retryAfterMs > 0
+  ) {
     return Math.max(baseDelayMs, error.retryAfterMs);
   }
 
@@ -461,6 +483,33 @@ function formatErrorChain(error: Error): string {
   }
 
   return parts.join('\nCaused by: ');
+}
+
+function hasRetryableNetworkCause(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const candidate = current as {
+      code?: unknown;
+      name?: unknown;
+      message?: unknown;
+      cause?: unknown;
+    };
+
+    if (typeof candidate.code === 'string' && RETRYABLE_NETWORK_ERROR_CODES.has(candidate.code)) {
+      return true;
+    }
+
+    if (candidate.name === 'TypeError' && candidate.message === 'fetch failed') {
+      return true;
+    }
+
+    current = candidate.cause;
+  }
+
+  return false;
 }
 
 async function sleepUntilNextTick(delayMs: number, abortSignal?: AbortSignal): Promise<void> {

--- a/apps/node_openclaw_plugin/src/pluginRunner.ts
+++ b/apps/node_openclaw_plugin/src/pluginRunner.ts
@@ -411,7 +411,12 @@ function isAbortError(error: unknown): boolean {
 }
 
 export function shouldBackoffPlatformError(error: unknown): error is PlatformHttpError {
-  return error instanceof PlatformHttpError;
+  return error instanceof PlatformHttpError
+    && (
+      error.status === 429
+      || error.retryable === true
+      || error.status >= 500
+    );
 }
 
 export function shouldBackoffRunnerError(error: unknown): boolean {

--- a/apps/node_openclaw_plugin/test/pluginRunner.test.ts
+++ b/apps/node_openclaw_plugin/test/pluginRunner.test.ts
@@ -8,7 +8,7 @@ import {
   nextBackoffDelayMs,
   NodeOpenClawPluginRunner,
   resolveRetryDelayMs,
-  shouldBackoffPlatformError,
+  shouldBackoffRunnerError,
   shouldProcessEvent,
 } from '../src/pluginRunner.js';
 import { PlatformHttpError } from '../src/platformClient.js';
@@ -21,6 +21,14 @@ import type {
   PluginPersistentState,
   ResolveConversationResponse,
 } from '../src/types.js';
+
+function makeRetryableFetchError(
+  code = 'ENOTFOUND',
+  message = 'getaddrinfo ENOTFOUND bricks.askman.dev',
+): Error {
+  const cause = Object.assign(new Error(message), { code });
+  return Object.assign(new TypeError('fetch failed'), { cause });
+}
 
 describe('extractIncomingText', () => {
   it('returns top-level text first', () => {
@@ -171,10 +179,11 @@ describe('buildNoVisibleReplyText', () => {
 });
 
 describe('platform retry backoff helpers', () => {
-  it('treats 429 and retryable failures as backoff signals', () => {
-    expect(shouldBackoffPlatformError(new PlatformHttpError(429, 'limited'))).toBe(true);
-    expect(shouldBackoffPlatformError(new PlatformHttpError(500, 'server', undefined, true))).toBe(true);
-    expect(shouldBackoffPlatformError(new Error('boom'))).toBe(false);
+  it('treats retryable platform and network failures as backoff signals', () => {
+    expect(shouldBackoffRunnerError(new PlatformHttpError(429, 'limited'))).toBe(true);
+    expect(shouldBackoffRunnerError(new PlatformHttpError(500, 'server', undefined, true))).toBe(true);
+    expect(shouldBackoffRunnerError(makeRetryableFetchError())).toBe(true);
+    expect(shouldBackoffRunnerError(new Error('boom'))).toBe(false);
   });
 
   it('advances the capped retry ladder from the current delay', () => {
@@ -200,6 +209,8 @@ describe('platform retry backoff helpers', () => {
         2000,
       ),
     ).toBe(4000);
+
+    expect(resolveRetryDelayMs(makeRetryableFetchError(), 2000, 2000)).toBe(4000);
   });
 });
 
@@ -348,6 +359,47 @@ describe('NodeOpenClawPluginRunner', () => {
     await runner.runUntilAbort(abortController.signal);
 
     expect(getEvents).not.toHaveBeenCalled();
+  });
+
+  it('backs off and keeps running when fetch fails before any HTTP response arrives', async () => {
+    const getEvents = vi.fn<() => Promise<GetEventsResponse>>()
+      .mockRejectedValueOnce(makeRetryableFetchError())
+      .mockImplementationOnce(async () => {
+        abortController.abort();
+        return {
+          nextCursor: 'cur_1',
+          events: [],
+        };
+      });
+    const abortController = new AbortController();
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const runner = new NodeOpenClawPluginRunner(config, {
+      client: {
+        getEvents,
+        ackEvents: vi.fn(),
+        resolveConversation: vi.fn(),
+        createMessage: vi.fn(),
+        patchMessage: vi.fn(),
+      } as never,
+      stateStore: {
+        load: vi.fn().mockResolvedValue(createDefaultState('cur_0')),
+        save: vi.fn().mockResolvedValue(undefined),
+      },
+      log,
+    });
+
+    await runner.runUntilAbort(abortController.signal);
+
+    expect(getEvents).toHaveBeenCalledTimes(2);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('retryable platform/network failure; backing off for 2ms'),
+    );
+    expect(log.error).not.toHaveBeenCalled();
   });
 
   it('finalizes an existing placeholder when a retry yields no visible reply', async () => {

--- a/apps/node_openclaw_plugin/test/pluginRunner.test.ts
+++ b/apps/node_openclaw_plugin/test/pluginRunner.test.ts
@@ -395,9 +395,13 @@ describe('NodeOpenClawPluginRunner', () => {
 
     await runner.runUntilAbort(abortController.signal);
 
+    const expectedRetryDelayMs = nextBackoffDelayMs(0, config.pollIntervalMs);
+
     expect(getEvents).toHaveBeenCalledTimes(2);
     expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining('retryable platform/network failure; backing off for 2ms'),
+      expect.stringContaining(
+        `retryable platform/network failure; backing off for ${expectedRetryDelayMs}ms`,
+      ),
     );
     expect(log.error).not.toHaveBeenCalled();
   });

--- a/docs/plans/2026-04-21-03-23-UTC-openclaw-network-retry-hardening.md
+++ b/docs/plans/2026-04-21-03-23-UTC-openclaw-network-retry-hardening.md
@@ -1,0 +1,31 @@
+# OpenClaw network retry hardening
+
+## Problem
+
+The Bricks OpenClaw plugin runner already survives ordinary tick failures, but
+DNS/connectivity failures such as `TypeError: fetch failed` with
+`getaddrinfo ENOTFOUND ...` are not currently classified as retryable. That
+means the runner keeps looping, but it logs an error every poll interval and
+does not enter the same bounded backoff path used for retryable platform HTTP
+failures.
+
+## Approach
+
+- Keep the runner alive on transient network failures as it already does today.
+- Treat pre-response fetch/network failures as retryable runner failures.
+- Reuse the existing bounded backoff ladder so DNS/connectivity outages recover
+  automatically once the network or DNS issue clears.
+- Add regression coverage proving both the helper classification and the
+  `runUntilAbort()` loop behavior.
+
+## Validation
+
+- `cd apps/node_openclaw_plugin && npm test`
+- `cd apps/node_openclaw_plugin && npm run type-check`
+- `cd apps/node_openclaw_plugin && npm run build`
+
+## Notes
+
+- This hardening is intentionally narrow: it does not change message dispatch
+  semantics or state handling, only how the runner classifies and retries
+  transport-level failures before an HTTP response exists.


### PR DESCRIPTION
## Summary
- treat pre-response fetch/DNS/connectivity failures in the OpenClaw plugin runner as retryable
- reuse the existing bounded backoff path instead of logging every poll interval without delay
- add regression coverage for both retry classification and run loop behavior

## Testing
- `cd apps/node_openclaw_plugin && npm test`
- `cd apps/node_openclaw_plugin && npm run type-check`
- `cd apps/node_openclaw_plugin && npm run build`
