### PR TITLE
Add OpenClaw plugin refresh skill

### DIFF
--- a/.codex/skills/openclaw-plugin-refresh/SKILL.md
+++ b/.codex/skills/openclaw-plugin-refresh/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: openclaw-plugin-refresh
+description: Rebuild, reinstall, and restart the local Bricks OpenClaw plugin after pulling repository updates. Use when the user wants their local OpenClaw install to pick up new code from apps/node_openclaw_plugin.
+---
+
+Reapply the locally checked out Bricks OpenClaw plugin to a local OpenClaw installation.
+
+## When to use this skill
+
+Use this skill when the user:
+
+- pulled or merged new repository changes and wants OpenClaw to use the updated plugin code
+- asks how to apply local changes under `apps/node_openclaw_plugin`
+- needs the safest repo-specific rebuild + reinstall + restart workflow
+- wants to know whether a rebuild alone is enough or a plugin reinstall is needed
+
+## Repository-specific facts
+
+- The plugin package lives at `apps/node_openclaw_plugin`.
+- OpenClaw loads the built extension from `dist/openclawExtension.js`, so source-only edits do not apply until the package is rebuilt.
+- The package declares `engines.node >=22.14.0`.
+- This repository recommends linked local install for development:
+  ```bash
+  openclaw plugins install -l ./apps/node_openclaw_plugin
+  ```
+- In the normal flow, the Bricks runner is managed by `openclaw gateway`; do not rely on manual `npm start` unless explicitly doing standalone runner debugging.
+
+## Default workflow (safe path)
+
+From the repository root:
+
+```bash
+cd apps/node_openclaw_plugin
+npm install
+npm run build
+
+cd ../..
+openclaw plugins install -l ./apps/node_openclaw_plugin
+openclaw gateway restart
+```
+
+Use this path when:
+
+- you are not sure whether the plugin was previously installed with `-l`
+- plugin metadata may have changed
+- you want the least surprising workflow after updating `main`
+
+## Fast path
+
+If the plugin was already installed with `-l ./apps/node_openclaw_plugin` and only code changed:
+
+```bash
+cd apps/node_openclaw_plugin
+npm run build
+
+cd ../..
+openclaw gateway restart
+```
+
+Use this only when you are confident the existing install is already linked to the repo checkout.
+
+## Config update path
+
+If the Bricks connection settings changed, refresh the stored channel config before restarting:
+
+```bash
+openclaw config set channels.dev-askman-bricks.BRICKS_BASE_URL https://your-bricks-api.example.com
+openclaw config set channels.dev-askman-bricks.BRICKS_PLUGIN_ID dev-askman-bricks
+openclaw config set channels.dev-askman-bricks.BRICKS_PLATFORM_TOKEN 'your-jwt-token'
+openclaw config validate
+openclaw gateway restart
+```
+
+If the user prefers the interactive flow:
+
+```bash
+openclaw onboard
+# or
+openclaw configure
+```
+
+## Verification
+
+After restart, inspect gateway logs:
+
+```bash
+tail -f ~/.openclaw/logs/gateway.log
+```
+
+Expected signals include lines such as:
+
+- `starting Bricks pull runner`
+- `[node_openclaw_plugin] started with cursor: ...`
+
+If needed, also inspect:
+
+```bash
+tail -f ~/.openclaw/logs/gateway.err.log
+```
+
+## Troubleshooting
+
+- If the new code is not taking effect, rebuild first; OpenClaw reads `dist/*`, not `src/*`.
+- If behavior still looks stale, rerun:
+  ```bash
+  openclaw plugins install -l ./apps/node_openclaw_plugin
+  openclaw gateway restart
+  ```
+- If the gateway reports invalid or missing `BRICKS_*` values, refresh `channels.dev-askman-bricks.*` via `openclaw config set` or rerun `openclaw configure`.
+- If startup fails on Node version, upgrade Node to `>=22.14.0`.
+- If logs show transient `fetch failed` / `ENOTFOUND`, treat that as connectivity or DNS trouble against the configured Bricks base URL and check the current gateway logs for recovery/backoff behavior.
+
+## Response pattern
+
+When using this skill, tailor the answer to the user's install state:
+
+- prefer the fast path only if linked install is already confirmed
+- otherwise recommend the safe path
+- mention config refresh only if credentials or base URL changed
+- include a short verification step so the user knows the new plugin code is actually running

--- a/.codex/skills/openclaw-plugin-refresh/SKILL.md
+++ b/.codex/skills/openclaw-plugin-refresh/SKILL.md
@@ -61,23 +61,26 @@ Use this only when you are confident the existing install is already linked to t
 
 ## Config update path
 
-If the Bricks connection settings changed, refresh the stored channel config before restarting:
+If the Bricks connection settings changed, refresh the stored channel config before restarting.
 
-```bash
-openclaw config set channels.dev-askman-bricks.BRICKS_BASE_URL https://your-bricks-api.example.com
-openclaw config set channels.dev-askman-bricks.BRICKS_PLUGIN_ID dev-askman-bricks
-openclaw config set channels.dev-askman-bricks.BRICKS_PLATFORM_TOKEN 'your-jwt-token'
-openclaw config validate
-openclaw gateway restart
-```
-
-If the user prefers the interactive flow:
+**Preferred: use the interactive flow to avoid exposing secrets in shell history or process listings:**
 
 ```bash
 openclaw onboard
 # or
 openclaw configure
 ```
+
+If you need to set non-secret values (base URL, plugin ID) via CLI, you can use `config set` for those:
+
+```bash
+openclaw config set channels.dev-askman-bricks.BRICKS_BASE_URL https://your-bricks-api.example.com
+openclaw config set channels.dev-askman-bricks.BRICKS_PLUGIN_ID dev-askman-bricks
+openclaw config validate
+openclaw gateway restart
+```
+
+> **Security note:** Do not pass `BRICKS_PLATFORM_TOKEN` as a literal argument to `openclaw config set` — it will appear in shell history and process listings. Use `openclaw onboard` or `openclaw configure` to supply the token interactively, or export it as an environment variable if the CLI supports reading it from the environment.
 
 ## Verification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@
 ## API debugging workflow
 - When debugging API/interface errors, try the `vercel-api-log-context` skill first to collect Vercel deployment log context before proposing fixes.
 
+## OpenClaw plugin refresh
+- When users ask how to apply newly pulled local code under `apps/node_openclaw_plugin` to their local OpenClaw install, use the `openclaw-plugin-refresh` skill first.
+- The repository skill lives at `.codex/skills/openclaw-plugin-refresh/SKILL.md` and covers rebuild, linked reinstall, gateway restart, and log verification.
+
 ## GitHub webhook / Cloudflare worker
 - When working on Copilot PR automation that must avoid GitHub Actions approval gates, use the `github-webhook-cloudflare-worker` skill first.
 - The repository's external webhook worker source lives in `.github/cloudflare/` and is managed as a Wrangler project.

--- a/docs/plans/2026-04-21-05-36-UTC-openclaw-plugin-refresh-skill.md
+++ b/docs/plans/2026-04-21-05-36-UTC-openclaw-plugin-refresh-skill.md
@@ -1,0 +1,36 @@
+# OpenClaw plugin refresh skill
+
+## Problem
+
+This repository already has a repeatable workflow for applying updated local
+`apps/node_openclaw_plugin` code to a real OpenClaw install, but there is no
+dedicated `.codex/skills` entry that captures the repo-specific safe path,
+fast path, config refresh path, and verification steps.
+
+## Approach
+
+- Add a new custom skill under `.codex/skills/openclaw-plugin-refresh/`.
+- Document the repository-specific facts that matter for this workflow:
+  - plugin source location
+  - `dist/*` build requirement
+  - linked local install path
+  - gateway-managed runtime behavior
+  - Node version requirement
+- Cover both the safe reinstall workflow and the fast path for existing linked
+  installs.
+- Include the config refresh path and log-based verification steps.
+- Surface the new skill from `AGENTS.md` so future agents are more likely to
+  discover and use it.
+
+## Validation
+
+- Review the new skill content against:
+  - `apps/node_openclaw_plugin/README.md`
+  - `apps/node_openclaw_plugin/package.json`
+- Verify the new skill path appears under `.codex/skills/`.
+- Verify `AGENTS.md` points future agents at the new skill.
+
+## Notes
+
+- This is a documentation/automation-surface change only; no application code
+  or runtime behavior should change.


### PR DESCRIPTION
## Summary
- add a repository-local `openclaw-plugin-refresh` skill under `.codex/skills/`
- document the safe path, fast path, config refresh path, and log verification flow for applying local `apps/node_openclaw_plugin` updates
- surface the new skill from `AGENTS.md` so future agents discover it when users ask how to apply pulled plugin changes

## Testing
- Not run (documentation / agent-guidance only)
