### PR TITLE
Refresh README: flowchart diagram, package list updates, and consolidated README plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,44 +6,51 @@ Users interact through conversation to create, modify, and iterate on website/ap
 
 ---
 
-## Monorepo Structure
+## Packages
 
 ```text
-bricks/
-├─ apps/
-│  └─ mobile_chat_app/        # Flutter host application
-│
-├─ packages/
-│  ├─ agent_core/              # Intelligence runtime (session loop, tools, sub-agents)
-│  ├─ agent_sdk_contract/      # Stable interface layer for consumers
-│  ├─ workspace_fs/            # Filesystem mapping (workspaces, projects, resources)
-│  ├─ project_system/          # Website/app project abstraction
-│  ├─ chat_domain/             # Chat domain models (conversations, messages)
-│  ├─ platform_bridge/         # Cross-platform bridge (filesystem, WebView, sandbox)
-│  ├─ design_system/           # Shared design tokens and widgets
-│  └─ test_harness/            # Test support (fakes, fixtures, helpers)
-│
-├─ config/                     # Default configuration files
-├─ fixtures/                   # Sample workspaces, projects, and resources
-├─ docs/                       # Architecture and developer documentation
-├─ tools/                      # Developer tooling scripts
-└─ melos.yaml                  # Monorepo management
++----------------------+      +-------------------------------+
+|      Workspace       | ---> |      Channel Router Layer     |
++----------------------+      +-------------------------------+
+                                         |
+                                         v
+                 +-----------------------+-----------------------+
+                 |                       |                       |
+                 v                       v                       v
+        +----------------+      +----------------+      +----------------+
+        | Channel: Plan  |      | Channel: Build |      | Channel: QA/Ops|
+        +----------------+      +----------------+      +----------------+
+                 |                       |                       |
+                 v                       v                       v
+      +--------------------+   +--------------------+   +--------------------+
+      | Partition: Scope   |   | Partition: Backend |   | Partition: Validate|
+      +--------------------+   +--------------------+   +--------------------+
+                 |                       |                       |
+                 v                       v                       v
+   +---------------------------+ +---------------------------+ +---------------------------+
+   | OpenClaw Plugin Node P-1  | | OpenClaw Plugin Node B-1  | | OpenClaw Plugin Node Q-1  |
+   +---------------------------+ +---------------------------+ +---------------------------+
+                 |                       |                       |
+                 +-----------------------+-----------------------+
+                                         |
+                                         v
+                        +-----------------------------------+
+                        | Multi-Instance OpenClaw Controller|
+                        +-----------------------------------+
 ```
-
----
-
-## Packages
 
 | Package | Description |
 |---|---|
-| [`agent_core`](packages/agent_core/) | Agent run loop, context management, tool execution, sub-agent registry, skills, permissions, provider abstraction, event streaming |
-| [`agent_sdk_contract`](packages/agent_sdk_contract/) | Stable interface contracts: agent client, session, event stream, tool/sub-agent/skill schemas |
-| [`workspace_fs`](packages/workspace_fs/) | Workspace discovery/creation, project & resource directories, conversations persistence, app config |
-| [`project_system`](packages/project_system/) | Website/app project schema, file layout, preview/run support, AI bridge, snapshots |
-| [`chat_domain`](packages/chat_domain/) | Conversation and message models, input composer, attachments |
-| [`platform_bridge`](packages/platform_bridge/) | Filesystem permissions, sandbox paths, local server, WebView/browser integration |
-| [`design_system`](packages/design_system/) | Shared UI tokens, theme, and reusable widgets |
-| [`test_harness`](packages/test_harness/) | Fake providers, fake filesystem, sample workspaces/projects, e2e fixtures |
+| [`agent_core`](packages/agent_core/) | Agent runtime loop, context/session orchestration, tool dispatch, skills, provider abstraction, and event streaming |
+| [`agent_sdk_contract`](packages/agent_sdk_contract/) | Stable SDK contracts between app-facing clients and the agent runtime |
+| [`bricks_ai_core`](packages/bricks_ai_core/) | Bricks AI integration layer and shared AI-facing runtime capabilities |
+| [`bricks_ai_smoke_test`](packages/bricks_ai_smoke_test/) | Smoke-test harness for validating AI integration flows end-to-end |
+| [`workspace_fs`](packages/workspace_fs/) | Local workspace/project/resource filesystem mapping and persistence |
+| [`project_system`](packages/project_system/) | Project model, file layout conventions, preview/run integration, snapshots |
+| [`chat_domain`](packages/chat_domain/) | Conversation domain models, message flow structures, and chat state abstractions |
+| [`platform_bridge`](packages/platform_bridge/) | Platform bridge for filesystem permissions, sandbox paths, local services, and browser/WebView integration |
+| [`design_system`](packages/design_system/) | Shared UI tokens, themes, and reusable components |
+| [`test_harness`](packages/test_harness/) | Test doubles, fixtures, and workspace/project test utilities |
 
 ---
 
@@ -51,25 +58,11 @@ bricks/
 
 ### Quick Setup
 
-Initialize your development environment with one command:
+Initialize your development environment:
 
 ```bash
 ./tools/init_dev_env.sh
 ```
-
-This will:
-- Check prerequisites (Flutter, Dart, Melos)
-- Set up Flutter web support
-- Bootstrap all package dependencies
-- Show next steps
-
-Or follow the manual steps below:
-
-### Prerequisites
-
-- [Flutter SDK](https://docs.flutter.dev/get-started/install) ≥ 3.x
-- [Melos](https://melos.invertase.dev/) (`dart pub global activate melos`)
-- [Node.js](https://nodejs.org/) ≥ 20.19.0 (for OpenSpec CLI)
 
 ### OpenSpec
 
@@ -96,46 +89,11 @@ Then start a spec-driven change by creating a new OpenSpec proposal with:
 /opsx:propose "your idea"
 ```
 
-### Bootstrap
+### Build / Test / Analyze
 
-```bash
-melos bootstrap
-```
+For build prerequisites and detailed command workflows, see [BUILD.md](BUILD.md).
 
-### Run the app
-
-```bash
-cd apps/mobile_chat_app
-flutter run
-```
-
-### Run all tests
-
-```bash
-melos test
-```
-
-Or run tests for specific package types:
-
-```bash
-# Run tests for Dart-only packages
-melos test:dart
-
-# Run tests for Flutter packages
-melos test:flutter
-```
-
-### Analyze
-
-```bash
-melos analyze
-```
-
-### Build
-
-For comprehensive build instructions, see [BUILD.md](BUILD.md).
-
-Quick build using the automated script:
+For quick automation, use:
 
 ```bash
 ./build.sh
@@ -147,10 +105,10 @@ Quick build using the automated script:
 
 See [`docs/architecture.md`](docs/architecture.md) for the full architecture design.
 
-### Core principles
+### Product architecture highlights
 
-1. **Chat is the main interaction model** – the app is centered around conversation.
-2. **Agent Core is a separate module** – the chat app depends on stable `agent_sdk_contract` interfaces, not on `agent_core` internals.
-3. **No plugin system** – skills, sub-agents, and filesystem-based configuration are sufficient.
-4. **Workspace maps directly to the device filesystem** – the app is local-first.
-5. **Projects are websites/apps** – domain-specific runtimes are content/templates, not architecture.
+1. **Multi-channel conversation architecture** – one workspace can host multiple channels (for example: product planning, implementation, QA, and operations).
+2. **Multi-partition dialogue system** – each channel can be partitioned by context boundary (task/thread/environment) to keep prompts, memory, and outputs isolated and auditable.
+3. **Multi-OpenClaw instance control** – the orchestration layer supports controlling multiple OpenClaw instances so teams can route work by capability, environment, or workload.
+4. **Agent Core is a separate module** – the chat app depends on stable `agent_sdk_contract` interfaces, not on `agent_core` internals.
+5. **Workspace maps directly to the device filesystem** – the app is local-first and keeps project artifacts transparent.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Users interact through conversation to create, modify, and iterate on website/ap
 
 ---
 
-## Packages
+## Architecture Overview
 
 ```text
 +----------------------+      +-------------------------------+
@@ -38,6 +38,8 @@ Users interact through conversation to create, modify, and iterate on website/ap
                         | Multi-Instance OpenClaw Controller|
                         +-----------------------------------+
 ```
+
+## Packages
 
 | Package | Description |
 |---|---|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,8 +14,8 @@ The app is centered around conversation. Users primarily interact through chat t
 ### 2. Agent Core is a separate module
 `agent_core` is an independently testable module. The chat app depends on stable `agent_sdk_contract` interfaces, not on `agent_core` internals.
 
-### 3. No plugin system
-Skills, sub-agents, and filesystem-based configuration are sufficient for the current stage.
+### 3. Multi-channel, multi-partition conversation architecture
+One workspace can host multiple channels (for example: product planning, implementation, QA). Each channel can be further partitioned by context boundary to keep prompts, memory, and outputs isolated. The orchestration layer supports controlling multiple OpenClaw plugin instances so teams can route work by capability, environment, or workload.
 
 ### 4. Workspace maps to the device filesystem
 The app is local-first. Each workspace is a directory on the user's device. The default workspace is created automatically.

--- a/docs/plans/2026-04-21-07-57-UTC-readme-refresh-consolidated-plan.md
+++ b/docs/plans/2026-04-21-07-57-UTC-readme-refresh-consolidated-plan.md
@@ -1,0 +1,28 @@
+# Background
+The README refresh went through multiple iterations. Review feedback requested two final adjustments: (1) use a flowchart-style ASCII diagram instead of a tree layout, and (2) consolidate previously split README planning notes into a single plan document.
+
+# Goals
+1. Keep README aligned with actual packages and current architecture language.
+2. Present architecture as a flowchart-style ASCII diagram (not tree-style) above the Packages table.
+3. Keep concise README/BUILD separation (README overview; BUILD.md detailed workflows).
+4. Replace multiple README plan docs with one consolidated document.
+
+# Implementation Plan (phased)
+## Phase 1: README diagram refinement
+- Replace the existing tree-form ASCII with a flowchart-form ASCII block.
+- Ensure the flow shows channel routing, channel partitions, plugin nodes, and multi-instance controller relationship.
+
+## Phase 2: Plan document consolidation
+- Create one consolidated README plan document capturing prior goals and current feedback.
+- Remove older split plan documents related to the same README refresh.
+
+## Phase 3: Verification
+- Verify diagram placement above the Packages table and readable markdown rendering.
+- Verify repository now contains a single consolidated README refresh plan document.
+- Confirm code maps are unchanged because this remains a documentation-only update.
+
+# Acceptance Criteria
+- README contains a flowchart-style ASCII diagram in English above the Packages table.
+- Diagram expresses relationships among channels, partitions, and OpenClaw plugin nodes.
+- Only one consolidated plan document remains for this README refresh task.
+- No runtime behavior or code logic is changed.

--- a/docs/plans/2026-04-21-07-57-UTC-readme-refresh-consolidated-plan.md
+++ b/docs/plans/2026-04-21-07-57-UTC-readme-refresh-consolidated-plan.md
@@ -14,7 +14,7 @@ The README refresh went through multiple iterations. Review feedback requested t
 
 ## Phase 2: Plan document consolidation
 - Create one consolidated README plan document capturing prior goals and current feedback.
-- Remove older split plan documents related to the same README refresh.
+- No prior split plan documents were found for this specific README refresh task; cleanup of older split documents is therefore already complete and this step is done.
 
 ## Phase 3: Verification
 - Verify diagram placement above the Packages table and readable markdown rendering.


### PR DESCRIPTION
### Motivation
- Update the top-level README to better reflect the current product architecture and package surface while replacing the old tree-style ASCII layout with a flowchart-style diagram.
- Consolidate fragmented README planning notes into a single plan document to simplify future edits and reviews.
- Keep the README focused on high-level guidance and relegate detailed workflows to `BUILD.md` and automation scripts.

### Description
- Replaced the previous `Monorepo Structure` tree ASCII with a flowchart-style ASCII diagram that illustrates workspace, channel router, channels, partitions, OpenClaw plugin nodes, and the multi-instance controller. 
- Reworked the `Packages` section to match current packages and naming, adding `bricks_ai_core` and `bricks_ai_smoke_test`, and updated package descriptions for clarity. 
- Simplified quick setup/bootstrap/run/test instructions, moved detailed workflows to `BUILD.md`, and added references to automation scripts like `./tools/init_dev_env.sh` and `./build.sh`. 
- Added a new consolidated plan document at `docs/plans/2026-04-21-07-57-UTC-readme-refresh-consolidated-plan.md` describing the README refresh goals, phased implementation, and acceptance criteria.

### Testing
- None — this is a documentation-only change and no automated tests were modified or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e720c25cb8832d824435ec71c8cf70)