### PR TITLE
style(chat): match chat AppBar background with content area

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -1714,6 +1714,8 @@ class _ChatScreenState extends State<ChatScreen> {
         ),
         appBar: AppBar(
           backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+          scrolledUnderElevation: 0,
+          surfaceTintColor: Colors.transparent,
           centerTitle: false,
           titleSpacing: 0,
           leading: Builder(

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -1713,6 +1713,7 @@ class _ChatScreenState extends State<ChatScreen> {
           ),
         ),
         appBar: AppBar(
+          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
           centerTitle: false,
           titleSpacing: 0,
           leading: Builder(

--- a/docs/plans/2026-04-21-14-45-UTC-chat-appbar-bg.md
+++ b/docs/plans/2026-04-21-14-45-UTC-chat-appbar-bg.md
@@ -1,0 +1,16 @@
+# Background
+用户希望将对话页面顶部 AppBar 的背景色改为与内容区一致，消除顶部与主体区域的视觉色差。
+
+# Goals
+- 让聊天页 AppBar 背景与内容区（Scaffold 背景）保持一致。
+- 不改变聊天页现有交互行为与布局结构。
+
+# Implementation Plan (phased)
+1. 定位 `chat_screen.dart` 中聊天页 `AppBar` 的定义位置。
+2. 为 `AppBar` 显式设置与内容区一致的背景色（基于主题的 `scaffoldBackgroundColor`）。
+3. 运行格式化与最小化测试/检查，确认无回归。
+
+# Acceptance Criteria
+- 打开聊天页时，顶部 AppBar 背景色与内容区背景色一致。
+- 聊天页现有菜单、切换子区、发送消息等功能不受影响。
+- `flutter test`（在 `apps/mobile_chat_app` 目录下执行）通过。


### PR DESCRIPTION
### Motivation
- Make the chat screen top `AppBar` visually match the content area by removing the header/content background color mismatch.

### Description
- Set `AppBar.backgroundColor` to `Theme.of(context).scaffoldBackgroundColor` in `apps/mobile_chat_app/lib/features/chat/chat_screen.dart` and add a short plan file at `docs/plans/2026-04-21-14-45-UTC-chat-appbar-bg.md`; the code map was not updated because this is a pure visual/style tweak with no behavioral changes.

### Testing
- Ran `./tools/init_dev_env.sh`, ran `dart format` on the changed file, and executed `cd apps/mobile_chat_app && flutter test test/app_test.dart`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78c2db728832dbee55f98a76d2550)