### PR TITLE
docs: remove Packages section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,6 @@ Users interact through conversation to create, modify, and iterate on website/ap
    +--------------------+                                   +---------------------+
 ```
 
-## Packages
-
-| Package | Description |
-|---|---|
-| [`agent_core`](packages/agent_core/) | Agent runtime loop, context/session orchestration, tool dispatch, skills, provider abstraction, and event streaming |
-| [`agent_sdk_contract`](packages/agent_sdk_contract/) | Stable SDK contracts between app-facing clients and the agent runtime |
-| [`bricks_ai_core`](packages/bricks_ai_core/) | Bricks AI integration layer and shared AI-facing runtime capabilities |
-| [`bricks_ai_smoke_test`](packages/bricks_ai_smoke_test/) | Smoke-test harness for validating AI integration flows end-to-end |
-| [`workspace_fs`](packages/workspace_fs/) | Local workspace/project/resource filesystem mapping and persistence |
-| [`project_system`](packages/project_system/) | Project model, file layout conventions, preview/run integration, snapshots |
-| [`chat_domain`](packages/chat_domain/) | Conversation domain models, message flow structures, and chat state abstractions |
-| [`platform_bridge`](packages/platform_bridge/) | Platform bridge for filesystem permissions, sandbox paths, local services, and browser/WebView integration |
-| [`design_system`](packages/design_system/) | Shared UI tokens, themes, and reusable components |
-| [`test_harness`](packages/test_harness/) | Test doubles, fixtures, and workspace/project test utilities |
-
----
-
 ## Getting Started
 
 ### Quick Setup

--- a/docs/plans/2026-04-22-03-04-UTC-remove-readme-packages-section.md
+++ b/docs/plans/2026-04-22-03-04-UTC-remove-readme-packages-section.md
@@ -1,0 +1,23 @@
+# Background
+The repository README currently includes a "Packages" section listing package directories and descriptions. The user requested removing the packages section from the README.
+
+# Goals
+- Remove the entire "Packages" section from README content.
+- Keep the rest of the README intact and readable.
+
+# Implementation Plan (phased)
+## Phase 1: Inspect current README structure
+- Locate the "Packages" heading and the associated table content.
+
+## Phase 2: Apply documentation update
+- Delete the "Packages" section block from the README.
+- Verify surrounding sections still flow naturally.
+
+## Phase 3: Validate and finalize
+- Run a quick diff/stat check to confirm only intended docs changes were made.
+- Commit the change with a clear message.
+
+# Acceptance Criteria
+- The README no longer contains a "Packages" section heading.
+- The package listing table is fully removed.
+- Only the expected documentation and plan files are changed for this task.


### PR DESCRIPTION
### Motivation
- The README included a "Packages" heading and table that should be removed to simplify the top-level documentation.

### Description
- Deleted the `## Packages` heading and the packages table from `README.md` and added a plan file at `docs/plans/2026-04-22-03-04-UTC-remove-readme-packages-section.md` describing the change.

### Testing
- Verified the change with repository checks and commands including `rg -n '^## Packages' README.md`, `git status --short`, and `git add README.md docs/plans/2026-04-22-03-04-UTC-remove-readme-packages-section.md && git commit -m "docs: remove packages section from README"`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83ac18b64832da6be307cd962cb11)