### PR TITLE
Prepare OpenClaw Bricks plugin for public release as @askman-dev/bricks-openclaw-plugin

### DIFF
--- a/apps/node_openclaw_plugin/README.md
+++ b/apps/node_openclaw_plugin/README.md
@@ -1,57 +1,46 @@
-# @bricks/node-openclaw-plugin
+# @askman-dev/bricks-openclaw-plugin
 
-`@bricks/node-openclaw-plugin` 是一个 Node.js 的 Bricks/OpenClaw 集成插件，包含两部分能力：
+`@askman-dev/bricks-openclaw-plugin` is the Bricks channel plugin for OpenClaw.
 
-1. **OpenClaw 插件安装 + onboarding 配置**（channel id: `dev-askman-bricks`）
-2. **pull-only 运行时**（轮询 `events`、ACK、OpenClaw handoff、消息回写）
+- **Canonical channel/plugin id**: `dev-askman-bricks` (must stay unchanged)
+- **Distribution target**: npm + ClawHub
+- **Runtime mode**: pull-only Bricks event runner managed by OpenClaw gateway
 
-## 1) 作为 OpenClaw 插件安装（子目录安装）
+## Public install flow (external users)
 
-> 本仓库场景下，插件在子目录 `apps/node_openclaw_plugin`。
+Install from package registry (OpenClaw resolves ClawHub first, then npm):
 
 ```bash
-openclaw plugins install ./apps/node_openclaw_plugin
+openclaw plugins install @askman-dev/bricks-openclaw-plugin
 openclaw gateway restart
 ```
 
-也可使用链接安装（便于开发联调）：
+Inspect the installed plugin metadata:
 
 ```bash
-openclaw plugins install -l ./apps/node_openclaw_plugin
-openclaw gateway restart
+openclaw plugins inspect dev-askman-bricks
 ```
 
-## 2) 作为真实 channel plugin 写入 `channels.dev-askman-bricks`
+> Development-only local install is still supported, but external users should
+> prefer package install instead of cloning this repository.
 
-安装后运行：
+## Configure / onboarding flow
+
+After install, run one of:
 
 ```bash
 openclaw onboard
-# 或
+# or
 openclaw configure
 ```
 
-在向导中选择 `dev-askman-bricks`（Bricks）后，插件会提示输入：
+Choose `dev-askman-bricks` (Bricks), then provide:
 
 - `BRICKS_BASE_URL`
-- `BRICKS_PLUGIN_ID`
+- `BRICKS_PLUGIN_ID` (normally `dev-askman-bricks`)
 - `BRICKS_PLATFORM_TOKEN`
 
-完成后会自动写入 `~/.openclaw/openclaw.json` 的：
-
-```json
-{
-  "channels": {
-    "dev-askman-bricks": {
-      "BRICKS_BASE_URL": "https://your-bricks-api.example.com",
-      "BRICKS_PLUGIN_ID": "dev-askman-bricks",
-      "BRICKS_PLATFORM_TOKEN": "<JWT token>"
-    }
-  }
-}
-```
-
-如果只想改 Bricks 这一项，不想重新跑整套 onboarding，也可以直接写 channel 配置：
+Equivalent direct config commands:
 
 ```bash
 openclaw config set channels.dev-askman-bricks.BRICKS_BASE_URL https://your-bricks-api.example.com
@@ -61,60 +50,78 @@ openclaw config validate
 openclaw gateway restart
 ```
 
-### 注意
+## Update flow
 
-`openclaw plugins install` 会使用 `npm install --ignore-scripts`，因此不要依赖 npm `postinstall` 写配置；应使用 channel setup/onboarding 或 `openclaw config set channels.dev-askman-bricks.*` 完成配置。
-
-## 3) OpenClaw 托管运行时（默认）
-
-安装并配置完成后，Bricks pull runner 会由 OpenClaw gateway 通过 channel
-`gateway.startAccount/stopAccount` 生命周期自动托管：
-
-1. `openclaw gateway restart` / gateway 启动时自动拉起 Bricks runner
-2. runner 轮询 `GET /api/v1/platform/events`
-3. 调用 `POST /api/v1/platform/events/ack` 进行 ACK
-4. 将 Bricks 用户消息转交给 OpenClaw 内部 session/reply pipeline
-5. 通过 `POST/PATCH /api/v1/platform/messages` 回写 OpenClaw 的可见输出
-6. gateway 停止或重启时，通过 `AbortSignal` 优雅停止 runner
-
-### OpenClaw 控制
-
-推荐测试方式：
+Update an existing installation:
 
 ```bash
+openclaw plugins update dev-askman-bricks
 openclaw gateway restart
 ```
 
-不再需要为了真实回复而手工 `npm start` 这个插件；只要 OpenClaw gateway 正常运行，Bricks runner 会由 OpenClaw 宿主自动管理。
+If you changed channel credentials or endpoint, re-run `openclaw configure` (or
+`openclaw config set ...`) and then restart gateway.
 
-### 可选环境变量
+## Runtime behavior summary
 
-| 变量 | 必填 | 说明 |
-|---|---|---|
-| `OPENCLAW_PLUGIN_POLL_INTERVAL_MS` | 否 | 轮询间隔，默认 `2000` |
-| `OPENCLAW_PLUGIN_DEFAULT_CURSOR` | 否 | 初始游标，默认 `cur_0` |
-| `OPENCLAW_PLUGIN_STATE_FILE` | 否 | 本地状态文件路径，默认 `~/.bricks/node_openclaw_plugin_state.json` |
-| `OPENCLAW_PLUGIN_ASSISTANT_NAME` | 否 | 回写消息中的助手名，默认 `Node OpenClaw Plugin` |
+When OpenClaw gateway starts/restarts, the plugin runner is host-managed:
 
-Bricks 连接参数 (`BRICKS_BASE_URL`、`BRICKS_PLUGIN_ID`、`BRICKS_PLATFORM_TOKEN`) 在 OpenClaw 托管模式下优先从 `channels.dev-askman-bricks` 的已配置 channel account 读取，而不是要求手工导出 shell 环境变量。
+1. Starts on gateway account lifecycle (`startAccount`)
+2. Polls `GET /api/v1/platform/events`
+3. ACKs events via `POST /api/v1/platform/events/ack`
+4. Hands user messages to OpenClaw inbound/session pipeline
+5. Writes assistant output via `POST/PATCH /api/v1/platform/messages`
+6. Stops gracefully on gateway shutdown via `AbortSignal`
 
-## 4) 本地独立调试（仅开发用）
+## Troubleshooting
 
-如果只是脱离 OpenClaw gateway 单独调试 runner，仍可手工运行：
+### Plugin installed but channel not responding
+
+- Verify config exists under `channels.dev-askman-bricks`.
+- Validate config and restart gateway:
+
+```bash
+openclaw config validate
+openclaw gateway restart
+```
+
+### Auth / token errors
+
+The plugin validates platform token claims at startup (`typ=platform_plugin`,
+matching `pluginId`, and required `userId`). Regenerate token if claims are
+invalid.
+
+### Packaging caveat
+
+`openclaw plugins install` uses `npm install --ignore-scripts`. Do not rely on
+npm `postinstall` to write configuration; always configure via OpenClaw
+onboarding/config commands.
+
+## Development-only local flow
+
+Use local path or linked install only while developing this repository:
+
+```bash
+openclaw plugins install ./apps/node_openclaw_plugin
+# or
+openclaw plugins install -l ./apps/node_openclaw_plugin
+openclaw gateway restart
+```
+
+Standalone runner debug (outside gateway lifecycle):
 
 ```bash
 cd apps/node_openclaw_plugin
 npm install
+npm run build
 npm start
 ```
 
-## 行为说明
+## Optional runtime environment variables
 
-- ACK body 仅包含 `cursor` 与 `ackedEventIds`，不发送 `pluginId` 字段。
-- 启动阶段会校验 JWT claims：`typ=platform_plugin`、`pluginId` 与 `BRICKS_PLUGIN_ID` 一致、且必须包含 `userId`。
-- OpenClaw channel account scoping uses the stored platform token's `userId` claim. If `BRICKS_PLUGIN_ID` / `BRICKS_PLATFORM_TOKEN` are missing or invalid, OpenClaw status/config flows now fail loudly so the user fixes the stored config instead of silently falling back to `default`.
-- 收到 `message.created` 时会先写入一条 streaming 消息，再把用户输入交给 OpenClaw 的真实 inbound/session pipeline；OpenClaw 的可见输出会逐段累积并 PATCH 回同一条 assistant 消息。
-- OpenClaw session key 按 Bricks `channelId` / `threadId` 作用域稳定映射：channel 走基础 session，thread 走 `:thread:<threadId>` 后缀，这样 OpenClaw 本地 transcript 会按 Bricks 会话边界保留 history。
-- 回写时当前仍聚合到同一条 assistant message；OpenClaw 返回的媒体暂时会退化为可见 URL 文本，便于先把真实 handoff 跑通。
-- 当前真实回复路径由 OpenClaw gateway 托管：gateway restart 时会停止旧 runner 并重新拉起新 runner，runner 复用同一个本地 state/cursor 文件继续轮询。
-- 收到 `conversation.binding_changed` 时当前仅记录日志（MVP noop）。
+| Variable | Required | Description |
+|---|---|---|
+| `OPENCLAW_PLUGIN_POLL_INTERVAL_MS` | No | Poll interval in ms (default `2000`) |
+| `OPENCLAW_PLUGIN_DEFAULT_CURSOR` | No | Initial cursor (default `cur_0`) |
+| `OPENCLAW_PLUGIN_STATE_FILE` | No | Local state file path (default `~/.bricks/node_openclaw_plugin_state.json`) |
+| `OPENCLAW_PLUGIN_ASSISTANT_NAME` | No | Assistant name in output messages (default `Node OpenClaw Plugin`) |

--- a/apps/node_openclaw_plugin/package-lock.json
+++ b/apps/node_openclaw_plugin/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@bricks/node-openclaw-plugin",
+  "name": "@askman-dev/bricks-openclaw-plugin",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@bricks/node-openclaw-plugin",
+      "name": "@askman-dev/bricks-openclaw-plugin",
       "version": "0.1.0",
       "dependencies": {
         "openclaw": "2026.4.15"

--- a/apps/node_openclaw_plugin/package.json
+++ b/apps/node_openclaw_plugin/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "@bricks/node-openclaw-plugin",
+  "name": "@askman-dev/bricks-openclaw-plugin",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "description": "Reference pull-only OpenClaw plugin runtime for Bricks platform APIs",
   "main": "dist/index.js",
@@ -42,8 +41,32 @@
       ]
     },
     "install": {
-      "localPath": "apps/node_openclaw_plugin",
-      "defaultChoice": "local"
+      "defaultChoice": "package"
     }
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/askman-dev/bricks.git",
+    "directory": "apps/node_openclaw_plugin"
+  },
+  "homepage": "https://github.com/askman-dev/bricks/tree/main/apps/node_openclaw_plugin",
+  "bugs": {
+    "url": "https://github.com/askman-dev/bricks/issues"
+  },
+  "keywords": [
+    "openclaw",
+    "plugin",
+    "bricks",
+    "channel"
+  ],
+  "files": [
+    "dist",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./dist/index.js"
   }
 }

--- a/docs/plans/2026-04-22-09-22-UTC-openclaw-plugin-public-release-final.md
+++ b/docs/plans/2026-04-22-09-22-UTC-openclaw-plugin-public-release-final.md
@@ -1,0 +1,92 @@
+# OpenClaw plugin public release final plan
+
+## Background
+
+`apps/node_openclaw_plugin` is being prepared for external distribution to
+OpenClaw users. Product decisions are finalized:
+
+- Distribution target: npm + ClawHub
+- Canonical OpenClaw plugin id remains: `dev-askman-bricks`
+- npm package name for public install: `@askman-dev/bricks-openclaw-plugin`
+- Final registry publication is a manual operator step (no auto publish)
+
+The plugin should be installable through standard OpenClaw package flow without
+requiring repository cloning.
+
+## Goals
+
+1. Keep package metadata in a publishable state for npm + ClawHub.
+2. Keep OpenClaw runtime metadata aligned to built `dist/*` entrypoints for
+   packaged installs.
+3. Keep release-facing documentation aligned to the final public package name
+   and external install/config/update flow.
+4. Keep release validation commands and manual publish handoff explicit.
+
+## Implementation Plan (phased)
+
+### Phase 1: Public package metadata and identity
+
+- Ensure `apps/node_openclaw_plugin/package.json` stays public publishable:
+  - package name `@askman-dev/bricks-openclaw-plugin`
+  - no `private: true`
+  - release metadata (`license`, `repository`, `homepage`, `bugs`, `keywords`)
+  - packaging controls (`files`, `exports`)
+- Keep `apps/node_openclaw_plugin/package-lock.json` root package identity
+  consistent with `package.json`.
+
+### Phase 2: OpenClaw packaged-install metadata
+
+- Preserve plugin/channel identity as `dev-askman-bricks`.
+- Keep OpenClaw metadata pointing to built runtime outputs (`dist/*`).
+- Keep packaged install preference (`openclaw.install.defaultChoice=package`).
+- Preserve native plugin manifest inclusion (`openclaw.plugin.json`) in package
+  artifact.
+
+### Phase 3: External-user documentation
+
+- Keep `apps/node_openclaw_plugin/README.md` aligned to public package flow:
+  - install: `openclaw plugins install @askman-dev/bricks-openclaw-plugin`
+  - onboarding/configure steps
+  - update flow
+  - troubleshooting notes
+  - clear separation from local dev-only install workflow
+
+### Phase 4: Validation and artifact inspection
+
+Run and record:
+
+- `cd apps/node_openclaw_plugin && npm test`
+- `cd apps/node_openclaw_plugin && npm run type-check`
+- `cd apps/node_openclaw_plugin && npm run build`
+- `cd apps/node_openclaw_plugin && npm pack`
+- inspect tarball contents and confirm:
+  - `dist/*`
+  - `openclaw.plugin.json`
+  - `package.json`
+  - `README.md`
+
+### Phase 5: Manual operator handoff (explicit)
+
+Do not auto-publish from agent flow. Human operator runs:
+
+- npm publish:
+  - `cd apps/node_openclaw_plugin && npm publish --access public`
+- ClawHub publish:
+  - `clawhub package publish apps/node_openclaw_plugin --dry-run`
+  - `clawhub package publish apps/node_openclaw_plugin`
+- clean-install verification:
+  - `openclaw plugins install @askman-dev/bricks-openclaw-plugin`
+  - `openclaw plugins inspect dev-askman-bricks`
+  - `openclaw configure`
+  - `openclaw gateway restart`
+  - `openclaw plugins update dev-askman-bricks`
+
+## Acceptance Criteria
+
+- Public package identity is finalized as
+  `@askman-dev/bricks-openclaw-plugin`.
+- Plugin id remains `dev-askman-bricks`.
+- Packaged artifact includes built runtime files and plugin manifest.
+- README/install commands match the final public package name.
+- Manual npm + ClawHub publication and clean-install verification commands are
+  explicitly documented.


### PR DESCRIPTION
### Motivation

- Make `apps/node_openclaw_plugin` publishable to npm/ClawHub under the public package name `@askman-dev/bricks-openclaw-plugin` while preserving the OpenClaw channel id `dev-askman-bricks`.
- Align end-user documentation and install/update flows for packaged installs instead of local-only development installs.
- Ensure package metadata and packaging controls are present so the plugin can be published and consumed by OpenClaw's package flow.

### Description

- Renamed the package from `@bricks/node-openclaw-plugin` to `@askman-dev/bricks-openclaw-plugin` in `package.json` and `package-lock.json`, removed `private: true`, and added `license`, `repository`, `homepage`, `bugs`, `keywords`, `files`, and `exports` fields to make the package publishable.
- Updated OpenClaw metadata in `package.json` to prefer packaged installs by changing `openclaw.install.defaultChoice` to `package` and preserved runtime entrypoints (`dist/*`) and channel id `dev-askman-bricks`.
- Rewrote `apps/node_openclaw_plugin/README.md` into a public-facing English README that documents package-based install (`openclaw plugins install @askman-dev/bricks-openclaw-plugin`), onboarding/configure/update flows, runtime behavior, troubleshooting, development-only local install instructions, and optional env vars.
- Added public release plan `docs/plans/2026-04-22-09-22-UTC-openclaw-plugin-public-release-final.md` that documents goals, phased implementation, validation steps, and manual publish handoff.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e887017f9c832d8ed29a80d1b68a93)