### PR TITLE
Fix mobile chat web compile regressions (agent mapping + composer wiring)

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -89,6 +89,8 @@ class _ChatScreenState extends State<ChatScreen> {
   int _respondGeneration = 0;
   int _idCounter = 0;
 
+  static const List<String> _openClawSlashCommands = <String>[];
+
   @override
   void initState() {
     super.initState();
@@ -474,6 +476,16 @@ class _ChatScreenState extends State<ChatScreen> {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text('Session now uses $selectedModel')));
+  }
+
+  String _currentComposerModelLabel() {
+    if (_effectiveRouterForScope() == ChatRouter.openclaw) {
+      return 'OpenClaw';
+    }
+    final selectedConfig = _activeLlmConfig;
+    return _sessionModelOverride ??
+        selectedConfig?.defaultModel ??
+        _resolveModelId(_activeAgent?.model);
   }
 
   String _resolveModelId(String? model) {
@@ -1748,14 +1760,15 @@ class _ChatScreenState extends State<ChatScreen> {
           child: SafeArea(
             child: ChatNavigationPage(
               agents: _agents
-                  .map(
+                  .map<ChatAgentItem>(
                     (agent) => ChatAgentItem(
                       name: agent.name,
+                      prompt: agent.systemPrompt,
                       description: agent.description,
                       isBuiltIn: _builtInAgentNames.contains(agent.name),
                     ),
                   )
-                  .toList(),
+                  .toList(growable: false),
               channels: _channels
                   .map(
                     (item) => ChatChannelItem(

--- a/docs/plans/2026-04-22-09-24-UTC-chat-web-build-fix.md
+++ b/docs/plans/2026-04-22-09-24-UTC-chat-web-build-fix.md
@@ -1,0 +1,23 @@
+# Chat web build fix plan
+
+## Background
+The mobile chat app web build currently fails during dart2js compilation with errors in chat navigation and chat screen code. Reported failures include a missing required `prompt` parameter when constructing `ChatAgentItem`, a list type mismatch for mapped agent items, and missing `_openClawSlashCommands` / `_currentComposerModelLabel` members in `_ChatScreenState`.
+
+## Goals
+- Restore a successful web compile for `apps/mobile_chat_app`.
+- Ensure chat navigation agent construction matches current model signatures.
+- Ensure chat screen references only defined state fields/methods.
+- Keep behavior coherent for OpenClaw and non-OpenClaw chat contexts.
+
+## Implementation Plan (phased)
+1. Inspect the relevant Dart files and model definitions to identify signature and type expectations.
+2. Patch `chat_navigation_page.dart` to provide required fields and resolve list typing.
+3. Patch `chat_screen.dart` to replace/restore missing members for slash commands and composer model labels.
+4. Run bootstrap (`./tools/init_dev_env.sh`) and then targeted verification commands from the correct package directory.
+5. If functionality changed, evaluate and update code maps; otherwise document why updates are unnecessary.
+
+## Acceptance Criteria
+- `flutter` analysis/build checks for `apps/mobile_chat_app` no longer report the listed compile errors.
+- `ChatAgentItem` construction includes required named parameters expected by the current type.
+- `_ChatScreenState` has valid references for slash command source and composer model label.
+- Any code map update decision is documented in the final report.


### PR DESCRIPTION
### Motivation
- Web builds were failing due to compile-time regressions in the chat UI: `ChatAgentItem` was constructed without the now-required `prompt` named parameter, mapped agent lists had a type mismatch, and the composer referenced undefined members for OpenClaw and model labeling.

### Description
- Update `apps/mobile_chat_app/lib/features/chat/chat_screen.dart` to map `_agents` to `ChatAgentItem` with the required `prompt: agent.systemPrompt`, enforce the concrete `List<ChatAgentItem>` type, and return a non-growable list via `.toList(growable: false)`.
- Restore missing `_ChatScreenState` members by adding `static const List<String> _openClawSlashCommands = <String>[]` and `String _currentComposerModelLabel()` to provide the composer with a valid model label and OpenClaw handling.
- Add a task plan document at `docs/plans/2026-04-22-09-24-UTC-chat-web-build-fix.md` describing background, goals, and the implementation plan as required by repository guidelines.
- No code map updates were made because this change only re-establishes correct wiring/signatures and does not add or change feature entry points or observable behavior.

### Testing
- Ran environment bootstrap with `./tools/init_dev_env.sh`, which completed successfully.
- Ran `cd apps/mobile_chat_app && flutter analyze`, which completed but reported pre-existing plugin warnings and a small number of lint/warning issues; these warnings are unrelated to the introduced fixes.
- Ran `cd apps/mobile_chat_app && flutter build web --release`, which completed successfully and produced a working web build.
- Ran `dart format` on the modified Dart file (succeeded for the Dart file), but a later attempt to format a Markdown plan file with `dart format` produced an expected error and was ignored.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e893c5bbd8832da5d441478eb7e641)