### PR TITLE
Copy OpenClaw config commands for node tokens

### DIFF
--- a/apps/mobile_chat_app/lib/features/settings/node_settings_screen.dart
+++ b/apps/mobile_chat_app/lib/features/settings/node_settings_screen.dart
@@ -109,14 +109,20 @@ class _NodeSettingsScreenState extends State<NodeSettingsScreen> {
         .showSnackBar(SnackBar(content: Text(successMessage)));
   }
 
-  String _buildInstallInstruction(PlatformTokenBundle bundle) {
-    final scopes = bundle.scopes.join(', ');
+  String _shellQuote(String value) {
+    if (value.isEmpty) return "''";
+    return "'${value.replaceAll("'", "'\"'\"'")}'";
+  }
+
+  String _buildOpenClawCommands(PlatformTokenBundle bundle) {
     return [
-      'Node: ${bundle.nodeName.isEmpty ? bundle.nodeId : bundle.nodeName}',
-      'Plugin ID: ${bundle.pluginId}',
-      'Base URL: ${bundle.baseUrl}',
-      'Scopes: $scopes',
-      'Token: ${bundle.token}',
+      'openclaw config set channels.dev-askman-bricks.BRICKS_BASE_URL ${_shellQuote(bundle.baseUrl)}',
+      'openclaw config set channels.dev-askman-bricks.BRICKS_PLUGIN_ID ${_shellQuote(bundle.pluginId)}',
+      'openclaw config set channels.dev-askman-bricks.BRICKS_PLATFORM_TOKEN ${_shellQuote(bundle.token)}',
+      '',
+      'openclaw config validate',
+      'openclaw gateway restart',
+      'openclaw plugins inspect dev-askman-bricks',
     ].join('\n');
   }
 
@@ -216,15 +222,15 @@ class _NodeSettingsScreenState extends State<NodeSettingsScreen> {
                       ),
                     if (_bundle != null) ...[
                       const SizedBox(height: 12),
-                      SelectableText(_buildInstallInstruction(_bundle!)),
+                      SelectableText(_buildOpenClawCommands(_bundle!)),
                       const SizedBox(height: 8),
                       OutlinedButton.icon(
                         onPressed: () => _copyText(
-                          _buildInstallInstruction(_bundle!),
-                          'Install instructions copied',
+                          _buildOpenClawCommands(_bundle!),
+                          'OpenClaw commands copied',
                         ),
                         icon: const Icon(Icons.copy_all_outlined),
-                        label: const Text('复制安装信息'),
+                        label: const Text('复制 OpenClaw 命令'),
                       ),
                     ],
                   ],

--- a/apps/mobile_chat_app/test/node_settings_screen_test.dart
+++ b/apps/mobile_chat_app/test/node_settings_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_chat_app/features/settings/llm_config_service.dart';
 import 'package:mobile_chat_app/features/settings/node_settings_screen.dart';
@@ -70,6 +71,8 @@ class _FakeNodeService extends LlmConfigService {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   testWidgets('shows empty-state create button when no nodes', (tester) async {
     final service = _FakeNodeService(empty: true);
     await tester
@@ -79,8 +82,21 @@ void main() {
     expect(find.text('创建第一个节点'), findsOneWidget);
   });
 
-  testWidgets('renders node and can generate token instructions',
+  testWidgets('renders node and can copy OpenClaw config commands',
       (tester) async {
+    final clipboardCalls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.setData') {
+        clipboardCalls.add(call);
+      }
+      return null;
+    });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
     final service = _FakeNodeService();
     await tester
         .pumpWidget(MaterialApp(home: NodeSettingsScreen(service: service)));
@@ -90,7 +106,41 @@ void main() {
     await tester.tap(find.widgetWithText(OutlinedButton, '生成 Token'));
     await tester.pumpAndSettle();
 
-    expect(find.textContaining('Node: openclaw 1'), findsOneWidget);
-    expect(find.textContaining('Token: token-123'), findsOneWidget);
+    expect(
+      find.textContaining(
+        'openclaw config set channels.dev-askman-bricks.BRICKS_BASE_URL',
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining("'https://example.com'"), findsOneWidget);
+    expect(find.textContaining("'plugin_node_1'"), findsOneWidget);
+    expect(find.textContaining("'token-123'"), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(OutlinedButton, '复制 OpenClaw 命令'));
+    await tester.pumpAndSettle();
+
+    expect(clipboardCalls, hasLength(1));
+    final copiedCommands = clipboardCalls.single.arguments['text'] as String;
+    expect(
+      copiedCommands,
+      contains(
+        "openclaw config set channels.dev-askman-bricks.BRICKS_BASE_URL 'https://example.com'",
+      ),
+    );
+    expect(
+      copiedCommands,
+      contains(
+        "openclaw config set channels.dev-askman-bricks.BRICKS_PLUGIN_ID 'plugin_node_1'",
+      ),
+    );
+    expect(
+      copiedCommands,
+      contains(
+        "openclaw config set channels.dev-askman-bricks.BRICKS_PLATFORM_TOKEN 'token-123'",
+      ),
+    );
+    expect(copiedCommands, contains('openclaw config validate'));
+    expect(copiedCommands, contains('openclaw gateway restart'));
+    expect(find.text('OpenClaw commands copied'), findsOneWidget);
   });
 }

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: feature_map
 owner: bricks
-last_updated: 2026-04-22
+last_updated: 2026-04-23
 purpose: >
   为人类测试员和 AI 测试员提供产品功能清单与进入路径，作为回归测试与变更影响评估的入口索引。
 
@@ -108,7 +108,7 @@ products:
 
       - feature_id: node_settings
         name: 节点（Node）管理与节点级 Token
-        user_value: 用户可管理多个节点（本地/云端运行时），并为指定节点生成专属 Token 与安装信息。
+        user_value: 用户可管理多个节点（本地/云端运行时），并为指定节点生成专属 Token 与可直接执行的 OpenClaw 配置命令。
         entry_paths:
           - screen: SettingsScreen
             route_hint: apps/mobile_chat_app/lib/features/settings/settings_screen.dart
@@ -124,7 +124,8 @@ products:
           - 设置页可看到“节点”入口并进入节点列表页面。
           - 当节点列表为空时，显示“创建第一个节点”按钮并可创建节点。
           - 节点创建后可展示默认名称（openclaw 1 / openclaw 2 ...）并支持重命名。
-          - 每个节点可复制 plugin id，可为该节点生成 token 与安装说明。
+          - 每个节点可复制 plugin id，可为该节点生成 token 与只写入 `channels.dev-askman-bricks` 的 OpenClaw CLI 配置命令。
+          - 点击“复制 OpenClaw 命令”后，剪贴板内容可直接粘贴到 shell 执行，并包含 base URL / plugin id / platform token / validate / gateway restart / inspect。
           - 使用指定 nodeId 请求 platform-token 时，返回 payload 包含 nodeId / nodeName / pluginId / token。
 
       - feature_id: workspace_resources

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: logic_map
 owner: bricks
-last_updated: 2026-04-22
+last_updated: 2026-04-23
 purpose: >
   为人类测试员、AI 测试员与 AI 工程师提供“功能 -> 代码/文档/关键词”映射，
   用于影响面分析、回归测试设计与遗留逻辑清理。
@@ -167,7 +167,7 @@ index:
       - 安装说明模板字段缺失或格式错误会导致 OpenClaw 配置失败。
 
   - feature_id: node_settings
-    capability: 节点管理（创建/重命名）与节点级 Token 签发
+    capability: 节点管理（创建/重命名）、节点级 Token 签发与 OpenClaw 命令复制
     code_index:
       - apps/mobile_chat_app/lib/features/settings/settings_screen.dart
       - apps/mobile_chat_app/lib/features/settings/node_settings_screen.dart
@@ -189,6 +189,8 @@ index:
       - node
       - platform token
       - pluginId
+      - openclaw config set
+      - clipboard commands
       - settings
       - create
       - rename
@@ -198,6 +200,8 @@ index:
       - 节点默认名称或唯一键策略不稳定时，可能出现重复节点或命名冲突。
       - token 签发若未强制 nodeId/pluginId 绑定，可能导致跨节点消息隔离失效。
       - 平台写回未注入 node metadata 时，聊天 UI 仍会回退显示 ask，导致归属不清晰。
+      - 复制命令若未使用 shell-safe quoting，base URL、plugin id 或 token 中的特殊字符可能导致用户粘贴执行失败。
+      - 若命令错误使用全局 `openclaw configure`，用户可能被迫修改与 Bricks 插件无关的 OpenClaw 配置。
 
   - feature_id: workspace_resources
     capability: Workspace / Projects / Skills / Resources 导航

--- a/docs/plans/2026-04-23-11-27-WIB-node-token-copy-openclaw-commands.md
+++ b/docs/plans/2026-04-23-11-27-WIB-node-token-copy-openclaw-commands.md
@@ -1,0 +1,68 @@
+# Node token copy OpenClaw commands
+
+## Background
+
+The Nodes settings screen can create node-scoped platform tokens for OpenClaw
+plugin installations. Its current copy text is a human-readable summary with
+Node, Plugin ID, Base URL, Scopes, and Token fields. Users still need to
+manually translate that summary into OpenClaw CLI commands before configuring
+the plugin.
+
+OpenClaw 2026.4.15 supports targeted non-interactive configuration through
+`openclaw config set`, which lets users configure only the Bricks channel
+without running the broad `openclaw configure` flow.
+
+## Goals
+
+- Make the Nodes token copy action produce commands that can be pasted directly
+  into a shell.
+- Configure only `channels.dev-askman-bricks`.
+- Preserve the generated token, plugin id, and base URL from the backend token
+  bundle.
+- Keep the copy flow simple and user-observable.
+
+## Implementation Plan (phased)
+
+### Phase 1: Command generation
+
+- Replace the Nodes screen install summary with a shell command block.
+- Use:
+  - `openclaw config set channels.dev-askman-bricks.BRICKS_BASE_URL ...`
+  - `openclaw config set channels.dev-askman-bricks.BRICKS_PLUGIN_ID ...`
+  - `openclaw config set channels.dev-askman-bricks.BRICKS_PLATFORM_TOKEN ...`
+  - `openclaw config validate`
+  - `openclaw gateway restart`
+  - `openclaw plugins inspect dev-askman-bricks`
+- Quote shell values safely for pasted command execution.
+
+### Phase 2: UI copy text
+
+- Keep the generated command block visible after token generation.
+- Change the copy button label and success message to reflect that commands are
+  copied, not generic install information.
+
+### Phase 3: Tests and validation
+
+- Update the Nodes settings widget test so token generation shows OpenClaw
+  commands.
+- Add clipboard assertion that the copied text contains executable
+  `openclaw config set` commands with the generated token bundle values.
+
+Validation commands:
+
+```bash
+./tools/init_dev_env.sh
+cd apps/mobile_chat_app
+flutter test test/node_settings_screen_test.dart
+flutter analyze
+```
+
+## Acceptance Criteria
+
+- After generating a node token, the Nodes screen shows paste-ready OpenClaw
+  commands.
+- Copying the generated instructions writes those commands to the clipboard.
+- The commands configure only `channels.dev-askman-bricks`.
+- The copied commands include the generated base URL, plugin id, and platform
+  token.
+- The targeted widget test passes.


### PR DESCRIPTION
## Summary
- Generate paste-ready OpenClaw config commands after node-scoped token creation
- Copy commands that only write channels.dev-askman-bricks, then validate/restart/inspect
- Update node settings coverage and code maps

## Validation
- Not run per request after moving to the new worktree
- Earlier before the worktree move: flutter test test/node_settings_screen_test.dart, flutter analyze, code map YAML parse