### PR TITLE
Add OpenClaw publish metadata

### DIFF
--- a/apps/node_openclaw_plugin/.gitignore
+++ b/apps/node_openclaw_plugin/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+*.tgz
+*.zip

--- a/apps/node_openclaw_plugin/README.md
+++ b/apps/node_openclaw_plugin/README.md
@@ -62,6 +62,21 @@ openclaw gateway restart
 If you changed channel credentials or endpoint, re-run `openclaw configure` (or
 `openclaw config set ...`) and then restart gateway.
 
+## ClawHub packaging metadata
+
+ClawHub publish validation requires OpenClaw package metadata in
+`package.json` under the `openclaw.compat` and `openclaw.build` keys. This
+package now declares:
+
+- `openclaw.compat.pluginApi`
+- `openclaw.compat.minGatewayVersion`
+- `openclaw.build.openclawVersion`
+- `openclaw.build.pluginSdkVersion`
+
+If you rebuild a release archive after changing package metadata, regenerate the
+package artifact from the current plugin directory so the updated `package.json`
+is included.
+
 ## Runtime behavior summary
 
 When OpenClaw gateway starts/restarts, the plugin runner is host-managed:

--- a/apps/node_openclaw_plugin/package.json
+++ b/apps/node_openclaw_plugin/package.json
@@ -27,6 +27,14 @@
     "extensions": [
       "./dist/openclawExtension.js"
     ],
+    "compat": {
+      "pluginApi": ">=2026.4.15",
+      "minGatewayVersion": ">=2026.4.15"
+    },
+    "build": {
+      "openclawVersion": "2026.4.15",
+      "pluginSdkVersion": "2026.4.15"
+    },
     "setupEntry": "./dist/openclawSetupEntry.js",
     "channel": {
       "id": "dev-askman-bricks",

--- a/docs/plans/2026-04-23-14-42-openclaw-package-metadata.md
+++ b/docs/plans/2026-04-23-14-42-openclaw-package-metadata.md
@@ -1,0 +1,31 @@
+# Background
+
+The OpenClaw plugin package at `apps/node_openclaw_plugin/package.json` is missing ClawHub publish metadata under the `openclaw` field. ClawHub rejects the package upload when `openclaw.compat.pluginApi` and `openclaw.build.openclawVersion` are absent.
+
+# Goals
+
+1. Add the required OpenClaw publish metadata to the plugin package.
+2. Align the metadata with the plugin's current OpenClaw dependency version.
+3. Keep the package ready for external ClawHub publishing without changing runtime behavior.
+
+# Implementation Plan
+
+## Phase 1
+
+Inspect the existing plugin package metadata and confirm the ClawHub-required `openclaw.compat` and `openclaw.build` fields from the OpenClaw docs.
+
+## Phase 2
+
+Update `apps/node_openclaw_plugin/package.json` to add the missing compatibility and build metadata using the current OpenClaw package version as the baseline.
+
+## Phase 3
+
+Run the existing plugin validation commands to ensure the package still builds and its tests continue to pass after the metadata-only change.
+
+# Acceptance Criteria
+
+1. `apps/node_openclaw_plugin/package.json` includes `openclaw.compat.pluginApi`.
+2. `apps/node_openclaw_plugin/package.json` includes `openclaw.compat.minGatewayVersion`.
+3. `apps/node_openclaw_plugin/package.json` includes `openclaw.build.openclawVersion`.
+4. `apps/node_openclaw_plugin/package.json` includes `openclaw.build.pluginSdkVersion`.
+5. The plugin's existing test, type-check, and build commands still complete successfully.


### PR DESCRIPTION
## Summary
- add the ClawHub-required `openclaw.compat` and `openclaw.build` metadata to the OpenClaw plugin package
- document the required package metadata in the plugin README
- keep the generated upload zip out of git

## Testing
- cd apps/node_openclaw_plugin && npm test
- cd apps/node_openclaw_plugin && npm run type-check
- cd apps/node_openclaw_plugin && npm run build