### PR TITLE
Refactor dark chat theme to semantic color tokens

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
@@ -39,54 +39,25 @@ class ComposerBar extends StatefulWidget {
     this.isStreaming = false,
   });
 
-  /// Available agents for @mention selection.
   final List<AgentDefinition> agents;
-
-  /// The agent currently selected for replies.
   final AgentDefinition? activeAgent;
-
-  /// Optional actions displayed before composer action buttons.
   final List<Widget> leadingActions;
-
-  /// Whether to show the composer configuration menu.
   final bool showComposerConfigMenu;
-
-  /// Display label for the currently active model.
   final String? activeModelLabel;
-
-  /// Optional slash commands to insert into the input.
   final List<String> slashCommands;
-
-  /// Optional @ actions shown next to route/slash controls.
   final List<ComposerAtAction> atActions;
-
-  /// Called when the user submits a message. Null while a send is in progress.
   final void Function(String text)? onSend;
 
-  /// Legacy callback for agent selection.
-  ///
-  /// The current @ menu dispatches selections via [onAtActionSelected].
-  /// Prefer [onAtActionSelected] for handling @ menu actions.
   @Deprecated(
     'ComposerBar no longer invokes onAgentSelected from the @ menu. '
     'Use onAtActionSelected instead.',
   )
   final void Function(AgentDefinition agent)? onAgentSelected;
 
-  /// Called when the user picks an item from the @ menu, including
-  /// agent-backed @ actions.
   final void Function(String value)? onAtActionSelected;
-
-  /// Opens runtime model selection UI.
   final VoidCallback? onOpenModelSelection;
-
-  /// Opens debug info dialog.
   final VoidCallback? onShowInfo;
-
-  /// Called when the user stops streaming output.
   final VoidCallback? onStop;
-
-  /// Whether AI is currently streaming output.
   final bool isStreaming;
 
   @override
@@ -96,6 +67,7 @@ class ComposerBar extends StatefulWidget {
 class _ComposerBarState extends State<ComposerBar>
     with SingleTickerProviderStateMixin {
   final _controller = TextEditingController();
+  final _focusNode = FocusNode();
   late AnimationController _spinController;
 
   @override
@@ -105,6 +77,7 @@ class _ComposerBarState extends State<ComposerBar>
       vsync: this,
       duration: const Duration(seconds: 1),
     )..repeat();
+    _focusNode.addListener(() => setState(() {}));
   }
 
   void _submit() {
@@ -142,12 +115,15 @@ class _ComposerBarState extends State<ComposerBar>
   void dispose() {
     _spinController.dispose();
     _controller.dispose();
+    _focusNode.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final isSending = widget.onSend == null;
+    final chatColors =
+        Theme.of(context).extension<ChatColors>() ?? ChatColors.light;
 
     return SafeArea(
       child: Padding(
@@ -160,24 +136,35 @@ class _ComposerBarState extends State<ComposerBar>
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(BricksRadius.lg),
                 border: Border.all(
-                  color: Theme.of(context).colorScheme.outline,
+                  color: _focusNode.hasFocus
+                      ? chatColors.composerBorderFocus
+                      : chatColors.composerBorder,
                 ),
-                color: Theme.of(context).colorScheme.surface,
+                color: chatColors.composerBackground,
               ),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   TextField(
                     controller: _controller,
+                    focusNode: _focusNode,
                     enabled: !isSending && !widget.isStreaming,
                     maxLines: 5,
                     minLines: 1,
                     textInputAction: TextInputAction.send,
                     onSubmitted: (_) => _submit(),
-                    decoration: const InputDecoration(
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyMedium
+                        ?.copyWith(color: chatColors.onMessageAssistant),
+                    decoration: InputDecoration(
                       hintText: 'Ask Bricks to create something…',
+                      hintStyle: Theme.of(context)
+                          .textTheme
+                          .bodyMedium
+                          ?.copyWith(color: chatColors.composerPlaceholder),
                       border: InputBorder.none,
-                      contentPadding: EdgeInsets.fromLTRB(
+                      contentPadding: const EdgeInsets.fromLTRB(
                         BricksSpacing.md,
                         BricksSpacing.sm,
                         BricksSpacing.md,
@@ -212,8 +199,8 @@ class _ComposerBarState extends State<ComposerBar>
                                   ),
                                 )
                                 .toList(),
-                            child: const Padding(
-                              padding: EdgeInsets.symmetric(
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
                                 horizontal: BricksSpacing.sm,
                                 vertical: BricksSpacing.xs,
                               ),
@@ -222,6 +209,7 @@ class _ComposerBarState extends State<ComposerBar>
                                 style: TextStyle(
                                   fontSize: 18,
                                   fontWeight: FontWeight.w600,
+                                  color: chatColors.agentAccent,
                                 ),
                               ),
                             ),
@@ -256,8 +244,8 @@ class _ComposerBarState extends State<ComposerBar>
                                   ),
                                 )
                                 .toList(),
-                            child: const Padding(
-                              padding: EdgeInsets.symmetric(
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
                                 horizontal: BricksSpacing.sm,
                                 vertical: BricksSpacing.xs,
                               ),
@@ -266,6 +254,7 @@ class _ComposerBarState extends State<ComposerBar>
                                 style: TextStyle(
                                   fontSize: 18,
                                   fontWeight: FontWeight.w600,
+                                  color: chatColors.agentAccent,
                                 ),
                               ),
                             ),
@@ -278,7 +267,10 @@ class _ComposerBarState extends State<ComposerBar>
                                 BricksTheme.menuPopupAnimationStyle,
                             tooltip: 'Composer actions',
                             enabled: !widget.isStreaming,
-                            icon: const Icon(Icons.tune),
+                            icon: Icon(
+                              Icons.tune,
+                              color: chatColors.metaText,
+                            ),
                             onSelected: (action) {
                               switch (action) {
                                 case ComposerMenuAction.model:
@@ -319,6 +311,10 @@ class _ComposerBarState extends State<ComposerBar>
                           RotationTransition(
                             turns: _spinController,
                             child: IconButton.filled(
+                              style: IconButton.styleFrom(
+                                backgroundColor: chatColors.agentAccent,
+                                foregroundColor: chatColors.onMessageUser,
+                              ),
                               onPressed: widget.onStop,
                               icon: Container(
                                 width: 24,
@@ -326,8 +322,7 @@ class _ComposerBarState extends State<ComposerBar>
                                 decoration: BoxDecoration(
                                   shape: BoxShape.circle,
                                   border: Border.all(
-                                    color:
-                                        Theme.of(context).colorScheme.onPrimary,
+                                    color: chatColors.onMessageUser,
                                     width: 2,
                                   ),
                                 ),
@@ -344,9 +339,13 @@ class _ComposerBarState extends State<ComposerBar>
                                     width: 20,
                                     height: 20,
                                     child: CircularProgressIndicator(
-                                        strokeWidth: 2),
+                                      strokeWidth: 2,
+                                    ),
                                   )
-                                : const Icon(Icons.send),
+                                : Icon(
+                                    Icons.send,
+                                    color: chatColors.agentAccent,
+                                  ),
                             tooltip: 'Send',
                           ),
                       ],

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -630,74 +630,95 @@ class _AssistantMarkdownText extends StatelessWidget {
       return Text(text, style: baseStyle);
     }
     final lines = text.split('\n');
+    final widgets = <Widget>[];
+    var inCodeBlock = false;
+    final codeLines = <String>[];
+
+    Widget _buildCodeBlock(List<String> codeContent) => Container(
+          width: double.infinity,
+          margin: const EdgeInsets.only(bottom: BricksSpacing.xs),
+          padding: const EdgeInsets.symmetric(
+            horizontal: BricksSpacing.sm,
+            vertical: BricksSpacing.xs,
+          ),
+          decoration: BoxDecoration(
+            color: codeBlockColor,
+            borderRadius: BorderRadius.circular(BricksRadius.sm),
+          ),
+          child: Text(
+            codeContent.join('\n'),
+            style: baseStyle.copyWith(fontFamily: 'monospace'),
+          ),
+        );
+
+    for (final line in lines) {
+      final trimmed = line.trimLeft();
+      if (trimmed.startsWith('```')) {
+        if (inCodeBlock) {
+          widgets.add(_buildCodeBlock(codeLines));
+          codeLines.clear();
+          inCodeBlock = false;
+        } else {
+          inCodeBlock = true;
+        }
+        continue;
+      }
+      if (inCodeBlock) {
+        codeLines.add(line);
+        continue;
+      }
+      if (trimmed.startsWith('>')) {
+        widgets.add(Container(
+          width: double.infinity,
+          margin: const EdgeInsets.only(bottom: BricksSpacing.xs),
+          padding: const EdgeInsets.symmetric(
+            horizontal: BricksSpacing.sm,
+            vertical: BricksSpacing.xs,
+          ),
+          decoration: BoxDecoration(
+            color: quoteBlockColor,
+            borderRadius: BorderRadius.circular(BricksRadius.sm),
+          ),
+          child: Text(trimmed.substring(1).trimLeft(), style: baseStyle),
+        ));
+        continue;
+      }
+      final block = _MarkdownBlock.tryParse(line);
+      final lineStyle = block.type == _MarkdownBlockType.heading
+          ? baseStyle.copyWith(fontWeight: FontWeight.w700)
+          : baseStyle;
+      final inlineSpans = _parseInlineMarkdown(
+        block.text,
+        baseStyle: lineStyle,
+        linkStyle: lineStyle.copyWith(color: linkColor),
+        headingLike: false,
+      );
+      if (block.type == _MarkdownBlockType.unorderedList ||
+          block.type == _MarkdownBlockType.orderedList) {
+        widgets.add(Padding(
+          padding: const EdgeInsets.only(left: BricksSpacing.md),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(block.marker, style: lineStyle),
+              const SizedBox(width: BricksSpacing.xs),
+              Expanded(child: Text.rich(TextSpan(children: inlineSpans))),
+            ],
+          ),
+        ));
+        continue;
+      }
+      widgets.add(Text.rich(TextSpan(children: inlineSpans)));
+    }
+
+    // Handle unclosed code block (e.g. during streaming).
+    if (inCodeBlock && codeLines.isNotEmpty) {
+      widgets.add(_buildCodeBlock(codeLines));
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: lines.map((line) {
-        final block = _MarkdownBlock.tryParse(line);
-        final lineStyle = block.type == _MarkdownBlockType.heading
-            ? baseStyle.copyWith(fontWeight: FontWeight.w700)
-            : baseStyle;
-        final trimmed = line.trimLeft();
-        if (trimmed.startsWith('```')) {
-          return Container(
-            width: double.infinity,
-            margin: const EdgeInsets.only(bottom: BricksSpacing.xs),
-            padding: const EdgeInsets.symmetric(
-              horizontal: BricksSpacing.sm,
-              vertical: BricksSpacing.xs,
-            ),
-            decoration: BoxDecoration(
-              color: codeBlockColor,
-              borderRadius: BorderRadius.circular(BricksRadius.sm),
-            ),
-            child: Text(
-              trimmed,
-              style: lineStyle.copyWith(fontFamily: 'monospace'),
-            ),
-          );
-        }
-        if (trimmed.startsWith('>')) {
-          return Container(
-            width: double.infinity,
-            margin: const EdgeInsets.only(bottom: BricksSpacing.xs),
-            padding: const EdgeInsets.symmetric(
-              horizontal: BricksSpacing.sm,
-              vertical: BricksSpacing.xs,
-            ),
-            decoration: BoxDecoration(
-              color: quoteBlockColor,
-              borderRadius: BorderRadius.circular(BricksRadius.sm),
-            ),
-            child: Text(trimmed.substring(1).trimLeft(), style: lineStyle),
-          );
-        }
-        final inlineSpans = _parseInlineMarkdown(
-          block.text,
-          baseStyle: lineStyle,
-          linkStyle: lineStyle.copyWith(color: linkColor),
-          headingLike: false,
-        );
-        if (block.type == _MarkdownBlockType.unorderedList ||
-            block.type == _MarkdownBlockType.orderedList) {
-          return Padding(
-            padding: const EdgeInsets.only(left: BricksSpacing.md),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  block.marker,
-                  style: lineStyle,
-                ),
-                const SizedBox(width: BricksSpacing.xs),
-                Expanded(child: Text.rich(TextSpan(children: inlineSpans))),
-              ],
-            ),
-          );
-        }
-
-        return Text.rich(TextSpan(children: inlineSpans));
-      }).toList(growable: false),
+      children: widgets,
     );
   }
 }

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -283,12 +283,10 @@ class _MessageListState extends State<MessageList> {
                         const SizedBox(width: BricksSpacing.xs),
                         Text(
                           msg.agentName ?? msg.model ?? '',
-                          style: Theme.of(context)
-                              .textTheme
-                              .labelSmall
-                              ?.copyWith(
-                                color: chatColors.agentName,
-                              ),
+                          style:
+                              Theme.of(context).textTheme.labelSmall?.copyWith(
+                                    color: chatColors.agentName,
+                                  ),
                         ),
                         if (msg.nodeType?.trim().isNotEmpty == true) ...[
                           const SizedBox(width: BricksSpacing.xs),
@@ -375,7 +373,7 @@ class _MessageListState extends State<MessageList> {
                           : null,
                       decoration: isUser
                           ? BoxDecoration(
-                              color: chatColors.userMessageContainer,
+                              color: chatColors.messageUserBackground,
                               borderRadius:
                                   BorderRadius.circular(BricksRadius.md),
                             )
@@ -389,12 +387,15 @@ class _MessageListState extends State<MessageList> {
                                 'expand-toggle-${msg.messageId ?? '${msg.timestamp}-$index'}',
                               ),
                               text: msg.content,
-                              textColor: chatColors.onUserMessageContainer,
+                              textColor: chatColors.onMessageUser,
                             )
                           else
                             _AssistantMarkdownText(
                               text: msg.content,
-                              textColor: chatColors.onAgentMessageContainer,
+                              textColor: chatColors.onMessageAssistant,
+                              linkColor: chatColors.linkText,
+                              codeBlockColor: chatColors.codeBlockBackground,
+                              quoteBlockColor: chatColors.quoteBackground,
                               textStyle: Theme.of(context).textTheme.bodyMedium,
                             ),
                           if (msg.isStreaming)
@@ -408,7 +409,7 @@ class _MessageListState extends State<MessageList> {
                                   strokeWidth: 2,
                                   valueColor: AlwaysStoppedAnimation<Color>(
                                     isUser
-                                        ? chatColors.onUserMessageContainer
+                                        ? chatColors.onMessageUser
                                         : chatColors.agentAccent,
                                   ),
                                 ),
@@ -427,7 +428,7 @@ class _MessageListState extends State<MessageList> {
                                     .labelSmall
                                     ?.copyWith(
                                       color: isUser
-                                          ? chatColors.onUserMessageContainer
+                                          ? chatColors.onMessageUser
                                           : chatColors.agentAccent,
                                     ),
                               ),
@@ -448,7 +449,7 @@ class _MessageListState extends State<MessageList> {
                                           .textTheme
                                           .labelSmall
                                           ?.copyWith(
-                                            color: chatColors.userMessageMeta,
+                                            color: chatColors.metaText,
                                           ),
                                     ),
                                   ),
@@ -457,8 +458,7 @@ class _MessageListState extends State<MessageList> {
                                     _UserMessageDeliveryStatus(
                                       indicator: deliveryIndicator,
                                       messageId: msg.messageId,
-                                      foregroundColor:
-                                          chatColors.onUserMessageContainer,
+                                      foregroundColor: chatColors.onMessageUser,
                                     ),
                                   ],
                                 ],
@@ -478,7 +478,7 @@ class _MessageListState extends State<MessageList> {
                     child: Text(
                       _messageMetaLine(msg),
                       style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                            color: chatColors.agentMessageMeta,
+                            color: chatColors.metaText,
                           ),
                     ),
                   ),
@@ -596,7 +596,7 @@ class _DeliveryStatusIcon extends StatelessWidget {
           color: foregroundColor != null
               ? foregroundColor!.withValues(alpha: icon.isCompleted ? 1.0 : 0.6)
               : icon.isCompleted
-                  ? Colors.green
+                  ? AppColors.success
                   : Theme.of(context).colorScheme.outline,
         ),
       ),
@@ -608,11 +608,17 @@ class _AssistantMarkdownText extends StatelessWidget {
   const _AssistantMarkdownText({
     required this.text,
     required this.textColor,
+    required this.linkColor,
+    required this.codeBlockColor,
+    required this.quoteBlockColor,
     required this.textStyle,
   });
 
   final String text;
   final Color textColor;
+  final Color linkColor;
+  final Color codeBlockColor;
+  final Color quoteBlockColor;
   final TextStyle? textStyle;
 
   @override
@@ -632,9 +638,44 @@ class _AssistantMarkdownText extends StatelessWidget {
         final lineStyle = block.type == _MarkdownBlockType.heading
             ? baseStyle.copyWith(fontWeight: FontWeight.w700)
             : baseStyle;
+        final trimmed = line.trimLeft();
+        if (trimmed.startsWith('```')) {
+          return Container(
+            width: double.infinity,
+            margin: const EdgeInsets.only(bottom: BricksSpacing.xs),
+            padding: const EdgeInsets.symmetric(
+              horizontal: BricksSpacing.sm,
+              vertical: BricksSpacing.xs,
+            ),
+            decoration: BoxDecoration(
+              color: codeBlockColor,
+              borderRadius: BorderRadius.circular(BricksRadius.sm),
+            ),
+            child: Text(
+              trimmed,
+              style: lineStyle.copyWith(fontFamily: 'monospace'),
+            ),
+          );
+        }
+        if (trimmed.startsWith('>')) {
+          return Container(
+            width: double.infinity,
+            margin: const EdgeInsets.only(bottom: BricksSpacing.xs),
+            padding: const EdgeInsets.symmetric(
+              horizontal: BricksSpacing.sm,
+              vertical: BricksSpacing.xs,
+            ),
+            decoration: BoxDecoration(
+              color: quoteBlockColor,
+              borderRadius: BorderRadius.circular(BricksRadius.sm),
+            ),
+            child: Text(trimmed.substring(1).trimLeft(), style: lineStyle),
+          );
+        }
         final inlineSpans = _parseInlineMarkdown(
           block.text,
           baseStyle: lineStyle,
+          linkStyle: lineStyle.copyWith(color: linkColor),
           headingLike: false,
         );
         if (block.type == _MarkdownBlockType.unorderedList ||
@@ -712,6 +753,7 @@ class _MarkdownBlock {
 List<InlineSpan> _parseInlineMarkdown(
   String source, {
   required TextStyle baseStyle,
+  required TextStyle linkStyle,
   required bool headingLike,
 }) {
   if (source.isEmpty) {
@@ -767,7 +809,50 @@ List<InlineSpan> _parseInlineMarkdown(
   }
 
   flush();
-  return spans;
+  return _injectLinkSpans(spans, baseStyle: baseStyle, linkStyle: linkStyle);
+}
+
+List<InlineSpan> _injectLinkSpans(
+  List<InlineSpan> spans, {
+  required TextStyle baseStyle,
+  required TextStyle linkStyle,
+}) {
+  final urlPattern = RegExp(r'https?://[^\s]+');
+  final expanded = <InlineSpan>[];
+  for (final span in spans) {
+    if (span is! TextSpan || (span.text ?? '').isEmpty) {
+      expanded.add(span);
+      continue;
+    }
+    final text = span.text!;
+    var cursor = 0;
+    for (final match in urlPattern.allMatches(text)) {
+      if (match.start > cursor) {
+        expanded.add(
+          TextSpan(
+            text: text.substring(cursor, match.start),
+            style: span.style ?? baseStyle,
+          ),
+        );
+      }
+      expanded.add(
+        TextSpan(
+          text: match.group(0),
+          style: (span.style ?? baseStyle).merge(linkStyle),
+        ),
+      );
+      cursor = match.end;
+    }
+    if (cursor < text.length) {
+      expanded.add(
+        TextSpan(
+          text: text.substring(cursor),
+          style: span.style ?? baseStyle,
+        ),
+      );
+    }
+  }
+  return expanded;
 }
 
 TextStyle _styleFor(

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -382,15 +382,14 @@ void main() {
       final icons = tester.widgetList<Icon>(
         find.descendant(of: row, matching: find.byIcon(Icons.check)),
       );
-      // Completed check inside user bubble uses the onUserMessageContainer
+      // Completed check inside user bubble uses the onMessageUser
       // token from ChatColors — verifies the widget reads the theme token,
       // not a hard-coded color value.
-      final chatColors =
-          Theme.of(tester.element(find.byKey(
-                const ValueKey<String>('user-delivery-u-default-completed'))))
+      final chatColors = Theme.of(tester.element(find.byKey(
+                  const ValueKey<String>('user-delivery-u-default-completed'))))
               .extension<ChatColors>() ??
           ChatColors.light;
-      expect(icons.last.color, chatColors.onUserMessageContainer);
+      expect(icons.last.color, chatColors.onMessageUser);
     });
 
     testWidgets('shows check + lobster when openclaw reply starts',

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: feature_map
 owner: bricks
-last_updated: 2026-04-23
+last_updated: 2026-04-26
 purpose: >
   为人类测试员和 AI 测试员提供产品功能清单与进入路径，作为回归测试与变更影响评估的入口索引。
 
@@ -80,6 +80,8 @@ products:
           - 打开右上角分区菜单与输入框配置菜单时，弹出动画应快速并呈现缩放+淡入效果。
           - 在主区（channel 对话）打开路由菜单时，不应显示 Thread router 分组；在子区（thread 对话）应显示 Follow channel / Bricks Default / OpenClaw 三项。
           - Openclaw 异步会话空闲时，客户端应通过 SSE（`/api/chat/events/:sessionId`）保持持久推送连接，服务端将在新消息到达后实时推送事件，无需客户端反复轮询。
+          - 深色主题下应采用纯黑背景与低亮度灰阶 surface；用户消息气泡不得使用品牌 primary 色。
+          - 链接、Agent 名称与发送按钮应统一使用同一 accent token，时间/thread 等 meta 信息应统一为次级灰。
 
       - feature_id: model_settings
         name: 模型与提供商配置

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: logic_map
 owner: bricks
-last_updated: 2026-04-24
+last_updated: 2026-04-26
 purpose: >
   为人类测试员、AI 测试员与 AI 工程师提供“功能 -> 代码/文档/关键词”映射，
   用于影响面分析、回归测试设计与遗留逻辑清理。
@@ -56,6 +56,8 @@ index:
       - apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
       - apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
       - packages/design_system/lib/src/bricks_theme.dart
+      - packages/design_system/lib/src/chat_colors.dart
+      - packages/design_system/lib/src/tokens.dart
       - apps/node_backend/src/routes/chat.ts
       - apps/node_backend/src/services/chatRouterService.ts
       - apps/node_backend/src/services/chatAsyncTransportService.ts
@@ -67,6 +69,7 @@ index:
       - docs/plans/2026-04-23-17-13-WIB-openclaw-agents-capture-display.md
       - docs/plans/2026-04-23-15-33-openclaw-selected-node-routing.md
       - docs/plans/2026-04-24-12-15-dispatch-avatar-placeholder.md
+      - docs/plans/2026-04-26-02-45-dark-theme-semantic-token-refactor.md
     test_index:
       - apps/mobile_chat_app/test/chat_arbitration_engine_test.dart
       - apps/mobile_chat_app/test/chat_topology_and_task_protocol_test.dart
@@ -137,6 +140,7 @@ index:
       - Agent 详情页“修改配置/发起对话”回调若未正确关闭抽屉与路由跳转，可能出现重复页面栈或会话 Agent 未更新。
       - OpenClaw `@` 菜单若使用错误 nodeId 查询 agents，会导致用户引用到其他节点的 Agent 或看到空列表。
       - 设置页返回后若未刷新节点列表，聊天页路由菜单可能继续显示过期节点名称或缺少新节点。
+      - 若组件直接写死颜色或误用 `primary` 作为普通气泡背景，会破坏暗色信息层级并导致关键行动不突出。
 
   - feature_id: model_settings
     capability: 模型配置读写

--- a/docs/plans/2026-04-26-02-45-dark-theme-semantic-token-refactor.md
+++ b/docs/plans/2026-04-26-02-45-dark-theme-semantic-token-refactor.md
@@ -1,0 +1,35 @@
+# Background
+The chat UI dark theme currently mixes direct `ColorScheme` fields and hard-coded color values, which causes inconsistent hierarchy across user bubbles, assistant text, composer UI, and metadata. The design direction requires an X-style dark palette with semantic token usage so product surfaces remain neutral while brand blue is reserved for actionable states.
+
+# Goals
+1. Introduce a semantic dark color token set aligned with the provided palette (pure black base, grayscale surfaces, single brand blue, isolated status colors).
+2. Ensure chat components consume semantic tokens instead of raw colors or misused `colorScheme.primary` for non-brand surfaces.
+3. Update key components (message list + composer) to reflect the new visual hierarchy in dark mode.
+4. Keep code-map docs synchronized for changed feature logic/index references.
+
+# Implementation Plan (phased)
+## Phase 1: Token foundation
+- Update `packages/design_system/lib/src/tokens.dart` with semantic palette constants (background/surface/border/text/accent/status).
+- Expand `packages/design_system/lib/src/chat_colors.dart` semantic fields to cover message/composer/meta/link/badge roles.
+- Update `packages/design_system/lib/src/bricks_theme.dart` dark `ColorScheme` to keep Material base semantics minimal and consistent with the new palette.
+
+## Phase 2: Chat UI migration
+- Refactor `apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart` to consume updated `ChatColors` semantics for:
+  - user bubble/background/text/meta
+  - assistant text/meta/accent
+  - badge/pill styling
+  - markdown inline link color and code/quote container styling
+- Refactor `apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart` to use semantic composer colors for container, border, placeholder, and send/stop actions.
+
+## Phase 3: Validation and docs
+- Run environment bootstrap and targeted Flutter checks.
+- Update `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` to reflect token/theme and chat widget mapping changes.
+- Verify YAML format and summarize regression-smoke focus.
+
+# Acceptance Criteria
+- Dark mode uses black background + grayscale surfaces + single accent blue for interactive emphasis.
+- User message bubble no longer uses Material `primary`; it uses semantic message container tokens.
+- Meta text (time/thread/handle-like info) uses a unified secondary token.
+- Composer default border is subtle, with stronger emphasis only on focus/action states.
+- Business widgets avoid raw hex colors and direct color misuse for chat hierarchy.
+- Validation commands complete successfully: `./tools/init_dev_env.sh`, `cd apps/mobile_chat_app && flutter analyze`, and `python3 -c "import yaml..."` for code maps.

--- a/docs/plans/2026-04-26-02-45-dark-theme-semantic-token-refactor.md
+++ b/docs/plans/2026-04-26-02-45-dark-theme-semantic-token-refactor.md
@@ -32,4 +32,4 @@ The chat UI dark theme currently mixes direct `ColorScheme` fields and hard-code
 - Meta text (time/thread/handle-like info) uses a unified secondary token.
 - Composer default border is subtle, with stronger emphasis only on focus/action states.
 - Business widgets avoid raw hex colors and direct color misuse for chat hierarchy.
-- Validation commands complete successfully: `./tools/init_dev_env.sh`, `cd apps/mobile_chat_app && flutter analyze`, and `python3 -c "import yaml..."` for code maps.
+- Validation commands complete successfully: `./tools/init_dev_env.sh`, `cd apps/mobile_chat_app && flutter analyze`, `npx js-yaml docs/code_maps/feature_map.yaml`, and `npx js-yaml docs/code_maps/logic_map.yaml`.

--- a/packages/design_system/lib/src/bricks_theme.dart
+++ b/packages/design_system/lib/src/bricks_theme.dart
@@ -21,21 +21,28 @@ class BricksTheme {
   static ThemeData dark() => ThemeData(
         useMaterial3: true,
         brightness: Brightness.dark,
-        scaffoldBackgroundColor: AppColors.background,
+        scaffoldBackgroundColor: AppColors.backgroundBase,
+        appBarTheme: const AppBarTheme(
+          backgroundColor: AppColors.backgroundChrome,
+          foregroundColor: AppColors.textPrimary,
+          surfaceTintColor: Colors.transparent,
+        ),
         colorScheme: const ColorScheme.dark(
-          primary: Color(0xFF4A90D9),
-          surface: AppColors.surface,
-          surfaceContainerHighest: AppColors.surface2,
+          primary: AppColors.accentPrimary,
+          onPrimary: AppColors.textPrimary,
+          surface: AppColors.surfaceDefault,
+          surfaceContainerHighest: AppColors.surfaceElevated,
           onSurface: AppColors.textPrimary,
           onSurfaceVariant: AppColors.textSecondary,
-          outline: AppColors.textTertiary,
+          outline: AppColors.borderSubtle,
+          error: AppColors.danger,
         ),
         extensions: const [ChatColors.dark],
       );
 
   static ThemeData _buildTheme(Brightness brightness) => ThemeData(
         useMaterial3: true,
-        colorSchemeSeed: const Color(0xFF4A90D9),
+        colorSchemeSeed: AppColors.accentPrimary,
         brightness: brightness,
         extensions: const [ChatColors.light],
       );

--- a/packages/design_system/lib/src/chat_colors.dart
+++ b/packages/design_system/lib/src/chat_colors.dart
@@ -4,129 +4,120 @@ import 'package:flutter/material.dart';
 import 'tokens.dart';
 
 /// Semantic color tokens for the chat module.
-///
-/// Business components read these tokens; they never hard-code a color value or
-/// branch on [Brightness]. The theme layer is responsible for providing the
-/// correct [ChatColors] instance via [ThemeExtension].
-///
-/// Usage:
-/// ```dart
-/// final chatColors = Theme.of(context).extension<ChatColors>() ?? ChatColors.light;
-/// ```
 class ChatColors extends ThemeExtension<ChatColors> {
   const ChatColors({
-    required this.userMessageContainer,
-    required this.onUserMessageContainer,
-    required this.userMessageMeta,
+    required this.messageUserBackground,
+    required this.messageAssistantBackground,
+    required this.onMessageUser,
+    required this.onMessageAssistant,
+    required this.metaText,
     required this.agentName,
     required this.agentBadgeContainer,
     required this.onAgentBadgeContainer,
     required this.agentAccent,
-    required this.onAgentMessageContainer,
-    required this.agentMessageMeta,
+    required this.linkText,
+    required this.composerBackground,
+    required this.composerBorder,
+    required this.composerBorderFocus,
+    required this.composerPlaceholder,
+    required this.codeBlockBackground,
+    required this.quoteBackground,
   });
 
-  // ---------------------------------------------------------------------------
-  // User message bubble
-  // ---------------------------------------------------------------------------
-
-  /// Background color of the user message bubble container.
-  final Color userMessageContainer;
-
-  /// Foreground color (text, icons) rendered inside the user message bubble.
-  final Color onUserMessageContainer;
-
-  /// Secondary / meta text color inside the user message bubble (timestamp,
-  /// thread id, delivery status).
-  final Color userMessageMeta;
-
-  // ---------------------------------------------------------------------------
-  // Agent (assistant) header & badge
-  // ---------------------------------------------------------------------------
-
-  /// Color of the agent name label shown above an assistant message.
+  final Color messageUserBackground;
+  final Color messageAssistantBackground;
+  final Color onMessageUser;
+  final Color onMessageAssistant;
+  final Color metaText;
   final Color agentName;
-
-  /// Background of the nodeType badge chip shown next to the agent name.
   final Color agentBadgeContainer;
-
-  /// Text color inside the nodeType badge chip.
   final Color onAgentBadgeContainer;
-
-  // ---------------------------------------------------------------------------
-  // Agent (assistant) message body
-  // ---------------------------------------------------------------------------
-
-  /// Accent color used for the thinking/streaming progress indicator and
-  /// arbitration routing labels in agent messages.
   final Color agentAccent;
+  final Color linkText;
+  final Color composerBackground;
+  final Color composerBorder;
+  final Color composerBorderFocus;
+  final Color composerPlaceholder;
+  final Color codeBlockBackground;
+  final Color quoteBackground;
 
-  /// Main text color of an agent message.
-  final Color onAgentMessageContainer;
-
-  /// Secondary / meta text color rendered below an agent message (timestamp,
-  /// model name, etc.).
-  final Color agentMessageMeta;
-
-  // ---------------------------------------------------------------------------
-  // Default instances (used as fallback when no ThemeExtension is registered)
-  // ---------------------------------------------------------------------------
-
-  /// Default light-mode chat colors.
   static const ChatColors light = ChatColors(
-    userMessageContainer: Color(0xFFF2F2F2),
-    onUserMessageContainer: Color(0xFF1C1C1E),
-    userMessageMeta: Color(0xFF3A3A3C),
-    agentName: Color(0xFF4A90D9),
-    agentBadgeContainer: Color(0xFFE5E5EA),
-    onAgentBadgeContainer: Color(0xFF636366),
-    agentAccent: Color(0xFF4A90D9),
-    onAgentMessageContainer: Color(0xFF1C1C1E),
-    agentMessageMeta: Color(0xFF8E8E93),
+    messageUserBackground: Color(0xFFE9EBEC),
+    messageAssistantBackground: Colors.transparent,
+    onMessageUser: Color(0xFF1F2328),
+    onMessageAssistant: Color(0xFF1F2328),
+    metaText: Color(0xFF657786),
+    agentName: Color(0xFF1D9BF0),
+    agentBadgeContainer: Color(0xFFE8EEF2),
+    onAgentBadgeContainer: Color(0xFF576470),
+    agentAccent: Color(0xFF1D9BF0),
+    linkText: Color(0xFF1D9BF0),
+    composerBackground: Color(0xFFF5F7F8),
+    composerBorder: Color(0xFFD0D5D9),
+    composerBorderFocus: Color(0xFF536471),
+    composerPlaceholder: Color(0xFF7A838A),
+    codeBlockBackground: Color(0xFFEFF3F4),
+    quoteBackground: Color(0xFFE8EEF2),
   );
 
-  /// Default dark-mode chat colors.
   static const ChatColors dark = ChatColors(
-    userMessageContainer: AppColors.surface2,
-    onUserMessageContainer: AppColors.textPrimary,
-    userMessageMeta: AppColors.textSecondary,
-    agentName: Color(0xFF4A90D9),
-    agentBadgeContainer: AppColors.surface3,
+    messageUserBackground: AppColors.surfaceDefault,
+    messageAssistantBackground: Colors.transparent,
+    onMessageUser: AppColors.textPrimary,
+    onMessageAssistant: AppColors.textPrimary,
+    metaText: AppColors.textSecondary,
+    agentName: AppColors.accentPrimary,
+    agentBadgeContainer: AppColors.surfaceSubtle,
     onAgentBadgeContainer: AppColors.textSecondary,
-    agentAccent: Color(0xFF4A90D9),
-    onAgentMessageContainer: AppColors.textPrimary,
-    agentMessageMeta: AppColors.textTertiary,
+    agentAccent: AppColors.accentPrimary,
+    linkText: AppColors.accentPrimary,
+    composerBackground: AppColors.surfaceElevated,
+    composerBorder: AppColors.borderSubtle,
+    composerBorderFocus: AppColors.borderFocus,
+    composerPlaceholder: AppColors.textTertiary,
+    codeBlockBackground: AppColors.surfaceElevated,
+    quoteBackground: AppColors.surfaceSubtle,
   );
-
-  // ---------------------------------------------------------------------------
-  // ThemeExtension overrides
-  // ---------------------------------------------------------------------------
 
   @override
   ChatColors copyWith({
-    Color? userMessageContainer,
-    Color? onUserMessageContainer,
-    Color? userMessageMeta,
+    Color? messageUserBackground,
+    Color? messageAssistantBackground,
+    Color? onMessageUser,
+    Color? onMessageAssistant,
+    Color? metaText,
     Color? agentName,
     Color? agentBadgeContainer,
     Color? onAgentBadgeContainer,
     Color? agentAccent,
-    Color? onAgentMessageContainer,
-    Color? agentMessageMeta,
+    Color? linkText,
+    Color? composerBackground,
+    Color? composerBorder,
+    Color? composerBorderFocus,
+    Color? composerPlaceholder,
+    Color? codeBlockBackground,
+    Color? quoteBackground,
   }) {
     return ChatColors(
-      userMessageContainer: userMessageContainer ?? this.userMessageContainer,
-      onUserMessageContainer:
-          onUserMessageContainer ?? this.onUserMessageContainer,
-      userMessageMeta: userMessageMeta ?? this.userMessageMeta,
+      messageUserBackground:
+          messageUserBackground ?? this.messageUserBackground,
+      messageAssistantBackground:
+          messageAssistantBackground ?? this.messageAssistantBackground,
+      onMessageUser: onMessageUser ?? this.onMessageUser,
+      onMessageAssistant: onMessageAssistant ?? this.onMessageAssistant,
+      metaText: metaText ?? this.metaText,
       agentName: agentName ?? this.agentName,
       agentBadgeContainer: agentBadgeContainer ?? this.agentBadgeContainer,
       onAgentBadgeContainer:
           onAgentBadgeContainer ?? this.onAgentBadgeContainer,
       agentAccent: agentAccent ?? this.agentAccent,
-      onAgentMessageContainer:
-          onAgentMessageContainer ?? this.onAgentMessageContainer,
-      agentMessageMeta: agentMessageMeta ?? this.agentMessageMeta,
+      linkText: linkText ?? this.linkText,
+      composerBackground: composerBackground ?? this.composerBackground,
+      composerBorder: composerBorder ?? this.composerBorder,
+      composerBorderFocus: composerBorderFocus ?? this.composerBorderFocus,
+      composerPlaceholder: composerPlaceholder ?? this.composerPlaceholder,
+      codeBlockBackground: codeBlockBackground ?? this.codeBlockBackground,
+      quoteBackground: quoteBackground ?? this.quoteBackground,
     );
   }
 
@@ -134,22 +125,34 @@ class ChatColors extends ThemeExtension<ChatColors> {
   ChatColors lerp(ChatColors? other, double t) {
     if (other == null) return this;
     return ChatColors(
-      userMessageContainer:
-          Color.lerp(userMessageContainer, other.userMessageContainer, t)!,
-      onUserMessageContainer:
-          Color.lerp(onUserMessageContainer, other.onUserMessageContainer, t)!,
-      userMessageMeta:
-          Color.lerp(userMessageMeta, other.userMessageMeta, t)!,
+      messageUserBackground:
+          Color.lerp(messageUserBackground, other.messageUserBackground, t)!,
+      messageAssistantBackground: Color.lerp(
+        messageAssistantBackground,
+        other.messageAssistantBackground,
+        t,
+      )!,
+      onMessageUser: Color.lerp(onMessageUser, other.onMessageUser, t)!,
+      onMessageAssistant:
+          Color.lerp(onMessageAssistant, other.onMessageAssistant, t)!,
+      metaText: Color.lerp(metaText, other.metaText, t)!,
       agentName: Color.lerp(agentName, other.agentName, t)!,
       agentBadgeContainer:
           Color.lerp(agentBadgeContainer, other.agentBadgeContainer, t)!,
       onAgentBadgeContainer:
           Color.lerp(onAgentBadgeContainer, other.onAgentBadgeContainer, t)!,
       agentAccent: Color.lerp(agentAccent, other.agentAccent, t)!,
-      onAgentMessageContainer:
-          Color.lerp(onAgentMessageContainer, other.onAgentMessageContainer, t)!,
-      agentMessageMeta:
-          Color.lerp(agentMessageMeta, other.agentMessageMeta, t)!,
+      linkText: Color.lerp(linkText, other.linkText, t)!,
+      composerBackground:
+          Color.lerp(composerBackground, other.composerBackground, t)!,
+      composerBorder: Color.lerp(composerBorder, other.composerBorder, t)!,
+      composerBorderFocus:
+          Color.lerp(composerBorderFocus, other.composerBorderFocus, t)!,
+      composerPlaceholder:
+          Color.lerp(composerPlaceholder, other.composerPlaceholder, t)!,
+      codeBlockBackground:
+          Color.lerp(codeBlockBackground, other.codeBlockBackground, t)!,
+      quoteBackground: Color.lerp(quoteBackground, other.quoteBackground, t)!,
     );
   }
 }

--- a/packages/design_system/lib/src/tokens.dart
+++ b/packages/design_system/lib/src/tokens.dart
@@ -12,27 +12,51 @@ class BricksSpacing {
   static const double xxl = 48.0;
 }
 
-/// A centralized color palette matching the design target.
+/// Centralized app color palette with semantic names.
+///
+/// The dark palette follows a pure-black foundation + grayscale surfaces +
+/// single brand blue accent strategy.
 class AppColors {
   const AppColors._();
 
-  static const background = Color(0xFF000000);
+  // Backgrounds
+  static const backgroundBase = Color(0xFF000000);
+  static const backgroundChrome = Color(0xFF000000);
 
-  static const surface = Color(0xFF111111);
-  static const surface2 = Color(0xFF1C1C1E);
-  static const surface3 = Color(0xFF232325);
+  // Surfaces
+  static const surfaceDefault = Color(0xFF16181C);
+  static const surfaceElevated = Color(0xFF1C1F23);
+  static const surfaceSubtle = Color(0xFF202327);
 
-  static const border = Color(0xFF2C2C2E);
-  static const divider = Color(0xFF3A3A3C);
+  // Borders
+  static const borderSubtle = Color(0xFF2F3336);
+  static const borderFocus = Color(0xFF536471);
 
-  static const textPrimary = Color(0xFFF5F5F7);
-  static const textSecondary = Color(0xFF9A9AA0);
-  static const textTertiary = Color(0xFF6C6C70);
+  // Typography
+  static const textPrimary = Color(0xFFE7E9EA);
+  static const textSecondary = Color(0xFF71767B);
+  static const textTertiary = Color(0xFF536471);
 
-  static const iconPrimary = Color(0xFFF5F5F7);
-  static const iconSecondary = Color(0xFFB0B0B5);
+  // Accent
+  static const accentPrimary = Color(0xFF1D9BF0);
+  static const accentMuted = Color(0xFF0A3A5C);
 
-  static const danger = Color(0xFF8B8B90);
+  // Status colors
+  static const danger = Color(0xFFF4212E);
+  static const warning = Color(0xFFFFD400);
+  static const success = Color(0xFF00BA7C);
+
+  // ------------------------------------------------------------------------
+  // Legacy aliases kept for compatibility with existing components.
+  // ------------------------------------------------------------------------
+  static const background = backgroundBase;
+  static const surface = surfaceDefault;
+  static const surface2 = surfaceElevated;
+  static const surface3 = surfaceSubtle;
+  static const border = borderSubtle;
+  static const divider = borderFocus;
+  static const iconPrimary = textPrimary;
+  static const iconSecondary = textSecondary;
 }
 
 /// Semantic color names used across the app.


### PR DESCRIPTION
### Motivation
- Unify dark-mode colors into a semantic token system (pure black base, X-style grayscale surfaces, single brand blue, isolated status colors) so component visuals follow design hierarchy instead of ad-hoc `Color` literals or misuse of `colorScheme.primary`.
- Ensure chat surfaces (user bubble, assistant text, meta, composer, badges, links, code/quote blocks) consume product-level semantic tokens instead of raw hex values or material primary semantics.
- Provide a clear migration path and documentation for testers by recording the plan and updating code maps so regression risks and smoke checks are discoverable.

### Description
- Introduced a semantic dark palette in `packages/design_system/lib/src/tokens.dart` with named tokens such as `backgroundBase`, `surfaceDefault`, `borderSubtle`, `textPrimary`, `accentPrimary`, and status colors, and preserved legacy aliases for compatibility.
- Expanded `ChatColors` (`packages/design_system/lib/src/chat_colors.dart`) to carry product-level semantic tokens (message/user/assistant surfaces, `metaText`, `linkText`, composer tokens, `codeBlockBackground`, `quoteBackground`) and added `ChatColors.dark` values mapped to the new palette.
- Updated dark `ThemeData` in `packages/design_system/lib/src/bricks_theme.dart` to keep `ColorScheme` focused on Material base semantics while injecting `ChatColors.dark` for chat components.
- Migrated chat UI to the new tokens: `apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart` now uses `chatColors.messageUserBackground`, `chatColors.metaText`, unified accent and link tokens, and renders code/quote blocks with semantic backgrounds; `apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart` now uses composer semantic tokens for background, border (subtle default / focused state), placeholder, and send/stop visuals.
- Adjusted tests and docs: updated `apps/mobile_chat_app/test/message_list_test.dart` expectations, added implementation plan `docs/plans/2026-04-26-02-45-dark-theme-semantic-token-refactor.md`, and updated `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` (feature `chat_session` impacted).

### Testing
- Bootstrapped the environment with `./tools/init_dev_env.sh` and the script completed successfully.
- Ran static analysis with `cd apps/mobile_chat_app && flutter analyze` which completed with no issues (some external plugin notices only) and reported success.
- Executed targeted unit/widget tests with `cd apps/mobile_chat_app && flutter test test/message_list_test.dart test/composer_bar_test.dart` and all tests passed.
- Validated YAML code maps with `npx js-yaml docs/code_maps/feature_map.yaml` and `npx js-yaml docs/code_maps/logic_map.yaml` which succeeded; a direct Python `yaml` check failed due to missing `PyYAML` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed7b3babbc832da05a206879d5b66a)