### PR TITLE
Reorganize repository docs into Docusaurus-friendly IA and add architecture/integration pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,138 +2,26 @@
 
 **The agent console for tinkerers.**
 
-Run agents side by side. Keep every thread in sight.
+Bricks is a native console for connecting external agent platforms, running multiple agent threads side by side, and keeping each run observable and controllable.
 
-Bricks is a native console for working with agent platforms like OpenClaw. It lets you connect agents, run them in parallel, switch between task threads, and keep every run visible and controllable.
+## Documentation
 
-Traditional chat tools are built for messages. Bricks is built for agents.
+The repository docs are now organized in a Docusaurus-friendly information architecture under `docs/`:
 
----
+- `docs/intro.md` — entry page
+- `docs/product/` — product overview and capabilities
+- `docs/get-started/` — quick setup and local run path
+- `docs/integrations/` — OpenClaw / platform integration guidance
+- `docs/architecture/` — system architecture and package layout
+- `docs/faq/` — common issues and troubleshooting pointers
 
-## Why Bricks?
-
-Most agent systems are powerful, but their interfaces are limited.
-
-When agents are connected to Telegram, Discord, or team chat tools, everything becomes a linear message stream. That works for simple Q&A, but breaks down when you want to run multiple agents, switch between tasks, inspect progress, recover from failures, or keep long-running work under control.
-
-Bricks is built for that gap.
-
-- It is not another code-generation workspace.
-- It is not a chat wrapper.
-- It is a console for people who actively work with agents.
-
-## What Bricks helps you do
-
-**Connect agent platforms.**
-Add OpenClaw or other agent platforms and make their agents available inside one native workspace.
-
-**Run agents side by side.**
-Start multiple agent threads, keep them visible, and switch between them without losing context.
-
-**Stay in control.**
-See which agents are running, waiting, completed, or failed. Stop, retry, continue, or inspect a thread when needed.
-
-**Use richer agent interfaces.**
-Agents should not be limited to plain text replies. Bricks is designed to support richer cards, controls, task views, and generative UI surfaces over time.
-
-## Who Bricks is for
-
-Bricks is for people who like to explore, combine, and control agent systems:
-
-- developers building with agent platforms
-- AI product builders testing agent workflows
-- tinkerers who run many agents at once
-- teams experimenting with OpenClaw-style agent systems
-
-If you only need a simple chatbot, Bricks may be more than you need.
-If you want to work with many agents without losing the thread, Bricks is for you.
-
-## Product direction
-
-Bricks focuses on three things:
-
-**Agent platforms** — Connect to external agent systems instead of locking users into one built-in agent.
-
-**Many threads** — Treat each agent task as a visible, recoverable thread rather than burying everything in one chat stream.
-
-**Control** — Make agent work observable and interruptible: state, progress, errors, retries, and handoffs should be clear.
-
-## Current status
-
-Bricks is in early development.
-
-The first goal is to make OpenClaw-style agent platforms feel usable inside a native agent console:
-
-- connect an agent platform
-- discover available agents
-- start agent threads
-- view running state
-- switch between tasks
-- control or recover failed runs
-
-## What Bricks is not
-
-Bricks is not trying to be GitHub Spark, v0, Bolt, or a general code-generation agent.
-
-Bricks may support generated interfaces and small app-like surfaces in the future, but its core purpose is different: Bricks is the console layer for agent platforms.
-
----
-
-## Getting Started
-
-### Quick Setup
-
-Initialize your development environment:
+## Quick setup
 
 ```bash
 ./tools/init_dev_env.sh
 ```
 
-### OpenSpec
+For complete local setup and validation commands, see:
 
-This repository is initialized for OpenSpec with checked-in tool integrations for GitHub Copilot, Codex, and Claude Code, plus project config under `openspec/`.
-
-Committed OpenSpec artifacts in this repository include:
-
-- `.github/` for GitHub Copilot prompts and skills
-- `.codex/` for Codex skills
-- `.claude/` for Claude Code commands and skills
-
-You do not need to install OpenSpec just to use these checked-in integrations in this repository.
-
-Install the CLI locally only if you want to refresh the setup or use the terminal workflow:
-
-```bash
-npm install -g @fission-ai/openspec@latest
-openspec init --tools github-copilot,codex,claude
-```
-
-Then start a spec-driven change by creating a new OpenSpec proposal with:
-
-```text
-/opsx:propose "your idea"
-```
-
-### Build / Test / Analyze
-
-For build prerequisites and detailed command workflows, see [BUILD.md](BUILD.md).
-
-For quick automation, use:
-
-```bash
-./build.sh
-```
-
----
-
-## Architecture
-
-See [`docs/architecture.md`](docs/architecture.md) for the full architecture design.
-
-### Product architecture highlights
-
-1. **Multi-thread agent console** – one workspace hosts multiple agent threads running in parallel, each visible and independently controllable.
-2. **Agent platform integration** – Bricks connects to external agent platforms (such as OpenClaw) via plugin interfaces rather than embedding a single built-in agent.
-3. **Multi-partition thread system** – each thread is partitioned by context boundary (task/agent/environment) to keep state, memory, and outputs isolated and auditable.
-4. **Multi-OpenClaw instance control** – the orchestration layer supports controlling multiple OpenClaw instances so work can be routed by capability, environment, or workload.
-5. **Agent Core is a separate module** – the console depends on stable `agent_sdk_contract` interfaces, not on `agent_core` internals.
+- `docs/get-started/quickstart.md`
+- `BUILD.md`

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -12,7 +12,8 @@ Bricks uses a modular architecture with clear package boundaries between UI, con
 ## Package graph summary
 
 - `apps/mobile_chat_app`
-  - depends on `agent_sdk_contract`, `workspace_fs`, `project_system`, `chat_domain`, `platform_bridge`, `design_system`
+  - depends on `agent_core`, `agent_sdk_contract`, `workspace_fs`, `project_system`, `chat_domain`, `platform_bridge`, `design_system`
+  - UI integration is kept separate from core runtime concerns and primarily relies on `agent_sdk_contract` interfaces
 - `packages/agent_core`
   - depends on `agent_sdk_contract`
 - `packages/test_harness`

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -1,0 +1,27 @@
+# System Overview
+
+Bricks uses a modular architecture with clear package boundaries between UI, contracts, runtime, and platform integration.
+
+## Core principles (current)
+
+- Agent threads are the primary unit of work.
+- `agent_core` is kept separate from the UI package.
+- Workspaces map to local filesystem directories.
+- External agent platforms are integrated through plugin contracts.
+
+## Package graph summary
+
+- `apps/mobile_chat_app`
+  - depends on `agent_sdk_contract`, `workspace_fs`, `project_system`, `chat_domain`, `platform_bridge`, `design_system`
+- `packages/agent_core`
+  - depends on `agent_sdk_contract`
+- `packages/test_harness`
+  - supports fixtures and integration-style validation
+
+## Event flow summary
+
+User send action in chat UI -> contract session send -> runtime processing -> event stream -> UI render updates.
+
+## Full architecture reference
+
+See [`docs/architecture.md`](../architecture.md) for the complete architecture document.

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -20,6 +20,8 @@ index:
       - apps/mobile_chat_app/ios/Runner/Info.plist
       - apps/mobile_chat_app/ios/Runner/SceneDelegate.swift
     doc_index:
+      - docs/intro.md
+      - docs/get-started/quickstart.md
       - docs/architecture.md
       - BUILD.md
     test_index:
@@ -63,7 +65,10 @@ index:
       - apps/node_backend/src/services/chatAsyncTransportService.ts
       - apps/node_backend/src/llm/llm_service.ts
     doc_index:
+      - docs/intro.md
+      - docs/product/overview.md
       - docs/architecture.md
+      - docs/architecture/system-overview.md
       - openspec/changes/multi-agent-participation/design.md
       - docs/plans/2026-04-18-00-20-UTC-openclaw-message-routing-current-state.md
       - docs/plans/2026-04-23-17-13-WIB-openclaw-agents-capture-display.md
@@ -151,6 +156,7 @@ index:
       - config/models.yaml
       - config/app.defaults.yaml
     doc_index:
+      - docs/get-started/quickstart.md
       - docs/model_settings_plan.md
       - docs/architecture.md
       - docs/openclaw_pull_only_integration_dev_doc.md
@@ -183,6 +189,8 @@ index:
       - apps/node_backend/src/services/platformNodeService.ts
       - apps/node_backend/src/db/migrations/011_create_platform_nodes.sql
     doc_index:
+      - docs/product/overview.md
+      - docs/integrations/openclaw-plugin.md
       - docs/plans/2026-04-21-00-12-UTC-multi-node-plugin-implementation.md
     test_index:
       - apps/mobile_chat_app/test/node_settings_screen_test.dart
@@ -215,6 +223,8 @@ index:
       - apps/mobile_chat_app/lib/features/skills/skills_screen.dart
       - apps/mobile_chat_app/lib/features/resources/resources_screen.dart
     doc_index:
+      - docs/product/overview.md
+      - docs/faq/common-issues.md
       - docs/architecture.md
     test_index:
       - apps/mobile_chat_app/test/app_test.dart
@@ -239,6 +249,7 @@ index:
       - apps/node_backend/src/services/oauthStateService.ts
       - apps/mobile_chat_app/lib/features/auth/oauth_callback.dart
     doc_index:
+      - docs/integrations/openclaw-plugin.md
       - docs/architecture.md
     test_index:
       - apps/node_backend/src/routes/auth.test.ts
@@ -277,6 +288,7 @@ index:
       - apps/node_backend/src/llm/providers/anthropic_adapter.ts
       - apps/node_backend/src/llm/providers/google_ai_studio_adapter.ts
     doc_index:
+      - docs/integrations/openclaw-plugin.md
       - docs/architecture.md
       - docs/openclaw_pull_only_integration_dev_doc.md
       - docs/plans/2026-04-18-00-20-UTC-openclaw-message-routing-current-state.md
@@ -329,6 +341,8 @@ index:
       - apps/node_openclaw_plugin/src/stateStore.ts
       - apps/node_openclaw_plugin/src/types.ts
     doc_index:
+      - docs/integrations/openclaw-plugin.md
+      - docs/faq/common-issues.md
       - docs/openclaw_pull_only_integration_dev_doc.md
       - docs/plugin_development_architecture.md
       - docs/plans/2026-04-23-17-13-WIB-openclaw-agents-capture-display.md

--- a/docs/faq/common-issues.md
+++ b/docs/faq/common-issues.md
@@ -1,0 +1,30 @@
+# Common Issues
+
+## Environment bootstrap not run
+
+Symptom: dependency checks or Flutter commands fail unexpectedly.
+
+Action: run `./tools/init_dev_env.sh` from repository root first.
+
+## Flutter test command run from wrong path
+
+Symptom: mobile app tests fail to resolve package layout when invoked from monorepo root with package path.
+
+Action: run from package directory:
+
+```bash
+cd apps/mobile_chat_app
+flutter test
+```
+
+## Plugin authentication failures
+
+Symptom: platform API requests rejected.
+
+Action:
+
+- verify Bearer token is valid
+- ensure `X-Bricks-Plugin-Id` is set
+- validate JWT mode setup for OpenClaw plugin runtime
+
+For protocol details, read [`docs/plugin_development_architecture.md`](../plugin_development_architecture.md).

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -1,0 +1,39 @@
+# Quickstart
+
+## 1) Initialize environment
+
+From repository root:
+
+```bash
+./tools/init_dev_env.sh
+```
+
+## 2) Run automated checks
+
+```bash
+./build.sh
+```
+
+## 3) Common manual checks
+
+```bash
+melos bootstrap
+melos analyze
+melos test
+```
+
+For mobile app package-specific tests, run from the package directory:
+
+```bash
+cd apps/mobile_chat_app
+flutter test
+```
+
+## 4) Build web app
+
+```bash
+cd apps/mobile_chat_app
+flutter build web --release
+```
+
+For full build details, see [`BUILD.md`](../../BUILD.md).

--- a/docs/integrations/openclaw-plugin.md
+++ b/docs/integrations/openclaw-plugin.md
@@ -1,0 +1,28 @@
+# OpenClaw Integration
+
+This page summarizes the current OpenClaw integration surface implemented in this repository.
+
+## Integration model
+
+- Backend platform API prefix: `/api/v1/platform/*`
+- Plugin authentication: Bearer token + `X-Bricks-Plugin-Id`
+- Data model: reuses existing `chat_messages` storage
+- Token retrieval: app settings flow + backend token endpoint
+
+## API capabilities
+
+- `GET /api/v1/platform/events`
+- `POST /api/v1/platform/events/ack`
+- `POST /api/v1/platform/messages`
+- `PATCH /api/v1/platform/messages/:messageId`
+- `GET /api/v1/platform/conversations/resolve`
+
+## Auth mode
+
+Current reference implementation in `apps/node_openclaw_plugin` uses JWT-only startup flow.
+
+## Where to read implementation details
+
+- [`docs/plugin_development_architecture.md`](../plugin_development_architecture.md)
+- `apps/node_backend/src/routes/platform.ts`
+- `apps/node_openclaw_plugin/src/pluginRunner.ts`

--- a/docs/integrations/openclaw-plugin.md
+++ b/docs/integrations/openclaw-plugin.md
@@ -12,6 +12,7 @@ This page summarizes the current OpenClaw integration surface implemented in thi
 ## API capabilities
 
 - `GET /api/v1/platform/events`
+- `GET /api/v1/platform/events/stream?cursor=...` (SSE – used by plugin client for event consumption)
 - `POST /api/v1/platform/events/ack`
 - `POST /api/v1/platform/messages`
 - `PATCH /api/v1/platform/messages/:messageId`

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,15 @@
+# Bricks Documentation
+
+This documentation is organized for product understanding, local setup, integration, and architecture navigation.
+
+## Read in this order
+
+1. [Product Overview](product/overview.md)
+2. [Quickstart](get-started/quickstart.md)
+3. [OpenClaw Integration](integrations/openclaw-plugin.md)
+4. [Architecture Overview](architecture/system-overview.md)
+5. [FAQ](faq/common-issues.md)
+
+## Scope
+
+The content in this docs tree focuses on currently implemented capabilities and workflows in this repository.

--- a/docs/plans/2026-04-26-10-20-UTC-docusaurus-doc-ia-restructure.md
+++ b/docs/plans/2026-04-26-10-20-UTC-docusaurus-doc-ia-restructure.md
@@ -1,0 +1,32 @@
+# Background
+
+The repository documentation had strong technical content but weak information architecture for product-facing navigation. The task is to restructure docs into a Docusaurus-friendly layout based only on currently implemented capabilities.
+
+# Goals
+
+1. Reorganize documentation entry points into product-first sections.
+2. Keep all content grounded in currently implemented repository state.
+3. Avoid roadmap, pricing, or operations planning content.
+
+# Implementation Plan (phased)
+
+## Phase 1: Entry and navigation
+- Update `README.md` to point to a clear docs IA.
+- Add `docs/intro.md` as the documentation entry page.
+
+## Phase 2: Section pages
+- Add product overview page under `docs/product/`.
+- Add quickstart page under `docs/get-started/`.
+- Add OpenClaw integration summary under `docs/integrations/`.
+- Add architecture overview page under `docs/architecture/`.
+- Add FAQ page under `docs/faq/`.
+
+## Phase 3: Documentation index alignment
+- Update code map `doc_index` references where relevant so new docs are discoverable.
+
+# Acceptance Criteria
+
+1. Repository contains a Docusaurus-friendly docs folder structure with entry page and section pages.
+2. `README.md` links users to the new docs structure.
+3. New pages describe only currently implemented capabilities/workflows.
+4. Code map document indexes include newly introduced docs references where relevant.

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -1,0 +1,22 @@
+# Product Overview
+
+Bricks is an agent console centered on multi-thread task execution and control.
+
+## What Bricks does today
+
+- Connects to external agent platforms through plugin integration points.
+- Runs multiple task threads in one workspace.
+- Exposes run state and recovery controls for agent threads.
+- Supports route-aware conversation handling across default and OpenClaw paths.
+
+## Core product areas in this repository
+
+- `mobile_chat_app`: user-facing console for auth, chat session, model and node settings.
+- `node_backend`: API service for auth, chat, model config, and platform endpoints.
+- `node_openclaw_plugin`: pull-only OpenClaw plugin runtime for platform events and writeback.
+
+## Primary user value
+
+- Keep many agent tasks visible instead of collapsing all work into one linear chat stream.
+- Control task lifecycle (start/switch/inspect/recover) with explicit state.
+- Connect existing agent runtime ecosystems instead of replacing them.

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -11,9 +11,9 @@ Bricks is an agent console centered on multi-thread task execution and control.
 
 ## Core product areas in this repository
 
-- `mobile_chat_app`: user-facing console for auth, chat session, model and node settings.
-- `node_backend`: API service for auth, chat, model config, and platform endpoints.
-- `node_openclaw_plugin`: pull-only OpenClaw plugin runtime for platform events and writeback.
+- `apps/mobile_chat_app`: user-facing console for auth, chat session, model and node settings.
+- `apps/node_backend`: API service for auth, chat, model config, and platform endpoints.
+- `apps/node_openclaw_plugin`: pull-only OpenClaw plugin runtime for platform events and writeback.
 
 ## Primary user value
 


### PR DESCRIPTION
### Motivation

- Provide a product-first, Docusaurus-friendly documentation information architecture for Bricks focused on currently implemented capabilities. 
- Surface integration and operational guidance (OpenClaw, quickstart, FAQ) so contributors can bootstrap and validate local development quickly. 
- Keep documentation references discoverable in the existing code map to aid impact analysis and test mapping. 

### Description

- Replace the long monolithic `README.md` content with a concise intro and pointer to the new `docs/` tree and a trimmed quick setup section. 
- Add a docs IA under `docs/` including `intro.md`, `product/overview.md`, `get-started/quickstart.md`, `integrations/openclaw-plugin.md`, `architecture/system-overview.md`, `faq/common-issues.md`, and a planning note `docs/plans/2026-04-26-10-20-UTC-docusaurus-doc-ia-restructure.md`. 
- Update the code map `docs/code_maps/logic_map.yaml` to reference the new docs pages from relevant feature `doc_index` entries. 
- Provide quickstart commands and troubleshooting pointers aimed at developer onboarding, and add a short system overview and OpenClaw integration summary. 

### Testing

- No automated unit or integration tests were added or modified for this documentation-only change and no test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda0a4821c832d95b35ad672891081)