### PR TITLE
Only show jump-to-latest after 2 viewports and animate to latest-content anchor

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -21,7 +21,7 @@ class MessageList extends StatefulWidget {
 
 class _MessageListState extends State<MessageList> {
   final ScrollController _scrollController = ScrollController();
-  static const double _kJumpButtonShowDistance = 120;
+  static const double _kJumpButtonShowScreens = 2;
   bool _showJumpToLatestButton = false;
 
   // A single key attached only to the focused (latest user) item so that
@@ -92,8 +92,9 @@ class _MessageListState extends State<MessageList> {
   void _handleScrollChanged() {
     if (!_scrollController.hasClients) return;
     final position = _scrollController.position;
-    final distanceToBottom = position.maxScrollExtent - position.pixels;
-    final shouldShow = distanceToBottom > _kJumpButtonShowDistance;
+    final distanceToLatestAnchor = _distanceToLatestContentAnchor(position);
+    final shouldShow = distanceToLatestAnchor >
+        position.viewportDimension * _kJumpButtonShowScreens;
     if (shouldShow != _showJumpToLatestButton) {
       setState(() {
         _showJumpToLatestButton = shouldShow;
@@ -133,13 +134,30 @@ class _MessageListState extends State<MessageList> {
     });
   }
 
+  double _latestContentAnchorOffset(ScrollPosition position) {
+    final bottomPadding = position.viewportDimension * _kBottomPaddingRatio;
+    return (position.maxScrollExtent - bottomPadding)
+        .clamp(position.minScrollExtent, position.maxScrollExtent)
+        .toDouble();
+  }
+
+  double _distanceToLatestContentAnchor(ScrollPosition position) {
+    final anchorOffset = _latestContentAnchorOffset(position);
+    return (anchorOffset - position.pixels)
+        .clamp(0.0, double.infinity)
+        .toDouble();
+  }
+
   void _scrollToLatestMessage() {
     if (!_scrollController.hasClients) return;
     final position = _scrollController.position;
+    final targetOffset = _latestContentAnchorOffset(position);
+    final distance = (targetOffset - position.pixels).abs();
+    final durationMs = (180 + distance * 0.18).clamp(220, 560).round();
     _scrollController.animateTo(
-      position.maxScrollExtent,
-      duration: const Duration(milliseconds: 220),
-      curve: Curves.easeOut,
+      targetOffset,
+      duration: Duration(milliseconds: durationMs),
+      curve: Curves.easeOutCubic,
     );
   }
 

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -23,6 +23,7 @@ class _MessageListState extends State<MessageList> {
   final ScrollController _scrollController = ScrollController();
   static const double _kJumpButtonShowScreens = 2;
   bool _showJumpToLatestButton = false;
+  double _listBottomPadding = 0;
 
   // A single key attached only to the focused (latest user) item so that
   // Scrollable.ensureVisible can locate it without creating a GlobalKey for
@@ -135,8 +136,7 @@ class _MessageListState extends State<MessageList> {
   }
 
   double _latestContentAnchorOffset(ScrollPosition position) {
-    final bottomPadding = position.viewportDimension * _kBottomPaddingRatio;
-    return (position.maxScrollExtent - bottomPadding)
+    return (position.maxScrollExtent - _listBottomPadding)
         .clamp(position.minScrollExtent, position.maxScrollExtent)
         .toDouble();
   }
@@ -278,6 +278,9 @@ class _MessageListState extends State<MessageList> {
       );
     }
 
+    _listBottomPadding = BricksSpacing.md +
+        MediaQuery.sizeOf(context).height * _kBottomPaddingRatio;
+
     return Stack(
       children: [
         SelectionArea(
@@ -287,8 +290,7 @@ class _MessageListState extends State<MessageList> {
               BricksSpacing.md,
               BricksSpacing.md,
               BricksSpacing.md,
-              BricksSpacing.md +
-                  MediaQuery.of(context).size.height * _kBottomPaddingRatio,
+              _listBottomPadding,
             ),
             itemCount: messages.length,
             itemBuilder: (context, index) {

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -4,6 +4,19 @@ import 'package:design_system/design_system.dart';
 import 'package:mobile_chat_app/features/chat/chat_message.dart';
 import 'package:mobile_chat_app/features/chat/widgets/message_list.dart';
 
+// Must match _kBottomPaddingRatio in message_list.dart
+const double _kTestBottomPaddingRatio = 0.35;
+
+/// Computes the expected latest-content anchor offset using the same formula
+/// as MessageList._latestContentAnchorOffset.
+double _latestAnchorOffset(WidgetTester tester, ScrollPosition position) {
+  final screenHeight =
+      tester.view.physicalSize.height / tester.view.devicePixelRatio;
+  return (position.maxScrollExtent -
+          (BricksSpacing.md + screenHeight * _kTestBottomPaddingRatio))
+      .clamp(position.minScrollExtent, position.maxScrollExtent);
+}
+
 List<ChatMessage> _messages(String prefix, int count) {
   final start = DateTime.utc(2026, 1, 1);
   return List<ChatMessage>.generate(
@@ -100,15 +113,9 @@ void main() {
       final jumpButton = find.byTooltip('Jump to latest');
       expect(jumpButton, findsOneWidget);
 
-      // Compute the expected anchor BEFORE tapping, using the same formula as
-      // production: maxScrollExtent - (BricksSpacing.md + screenHeight * _kBottomPaddingRatio)
-      const kBottomPaddingRatio = 0.35;
-      final screenHeight =
-          tester.view.physicalSize.height / tester.view.devicePixelRatio;
-      final expectedAnchor = (scrollable.position.maxScrollExtent -
-              (BricksSpacing.md + screenHeight * kBottomPaddingRatio))
-          .clamp(scrollable.position.minScrollExtent,
-              scrollable.position.maxScrollExtent);
+      // Compute the expected anchor BEFORE tapping so it uses the same
+      // maxScrollExtent the production code will see when the button is pressed.
+      final expectedAnchor = _latestAnchorOffset(tester, scrollable.position);
 
       await tester.tap(jumpButton);
       await tester.pumpAndSettle();
@@ -123,11 +130,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final scrollable = tester.state<ScrollableState>(find.byType(Scrollable));
-      const kBottomPaddingRatio = 0.35;
-      final screenHeight =
-          tester.view.physicalSize.height / tester.view.devicePixelRatio;
-      final nearAnchor = scrollable.position.maxScrollExtent -
-          (BricksSpacing.md + screenHeight * kBottomPaddingRatio);
+      final nearAnchor = _latestAnchorOffset(tester, scrollable.position);
       final almostNearEnough =
           nearAnchor - scrollable.position.viewportDimension * 1.9;
       scrollable.position.jumpTo(almostNearEnough.clamp(

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -87,7 +87,8 @@ void main() {
       expect(scrollable.position.pixels, greaterThan(0));
     });
 
-    testWidgets('shows jump-to-latest button and scrolls to bottom when tapped',
+    testWidgets(
+        'shows jump-to-latest button when over two screens away and scrolls to latest anchor on tap',
         (tester) async {
       await tester.pumpWidget(_build(_messages('jump', 60)));
       await tester.pumpAndSettle();
@@ -102,10 +103,36 @@ void main() {
       await tester.tap(jumpButton);
       await tester.pumpAndSettle();
 
+      final distanceToBottom =
+          scrollable.position.maxScrollExtent - scrollable.position.pixels;
+      expect(distanceToBottom, greaterThan(0));
       expect(
-        scrollable.position.pixels,
-        closeTo(scrollable.position.maxScrollExtent, 1.0),
+        distanceToBottom,
+        lessThan(scrollable.position.viewportDimension * 0.5),
       );
+    });
+
+    testWidgets(
+        'keeps jump-to-latest button hidden when under two screens away',
+        (tester) async {
+      await tester.pumpWidget(_build(_messages('near', 60)));
+      await tester.pumpAndSettle();
+
+      final scrollable = tester.state<ScrollableState>(find.byType(Scrollable));
+      final nearAnchor = scrollable.position.maxScrollExtent -
+          scrollable.position.viewportDimension * 0.35;
+      final almostNearEnough =
+          nearAnchor - scrollable.position.viewportDimension * 1.9;
+      scrollable.position.jumpTo(almostNearEnough.clamp(
+        scrollable.position.minScrollExtent,
+        scrollable.position.maxScrollExtent,
+      ));
+      await tester.pump();
+
+      final beforeTap = scrollable.position.pixels;
+      await tester.tap(find.byTooltip('Jump to latest'), warnIfMissed: false);
+      await tester.pumpAndSettle();
+      expect(scrollable.position.pixels, closeTo(beforeTap, 0.1));
     });
   });
 
@@ -367,7 +394,9 @@ void main() {
         find.descendant(of: row, matching: find.byIcon(Icons.check)),
         findsOneWidget,
       );
-      expect(find.descendant(of: row, matching: find.byIcon(Icons.hub_outlined)), findsNothing);
+      expect(
+          find.descendant(of: row, matching: find.byIcon(Icons.hub_outlined)),
+          findsNothing);
     });
 
     testWidgets('shows check + completed check when default router has replied',

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -100,16 +100,20 @@ void main() {
       final jumpButton = find.byTooltip('Jump to latest');
       expect(jumpButton, findsOneWidget);
 
+      // Compute the expected anchor BEFORE tapping, using the same formula as
+      // production: maxScrollExtent - (BricksSpacing.md + screenHeight * _kBottomPaddingRatio)
+      const kBottomPaddingRatio = 0.35;
+      final screenHeight =
+          tester.view.physicalSize.height / tester.view.devicePixelRatio;
+      final expectedAnchor = (scrollable.position.maxScrollExtent -
+              (BricksSpacing.md + screenHeight * kBottomPaddingRatio))
+          .clamp(scrollable.position.minScrollExtent,
+              scrollable.position.maxScrollExtent);
+
       await tester.tap(jumpButton);
       await tester.pumpAndSettle();
 
-      final distanceToBottom =
-          scrollable.position.maxScrollExtent - scrollable.position.pixels;
-      expect(distanceToBottom, greaterThan(0));
-      expect(
-        distanceToBottom,
-        lessThan(scrollable.position.viewportDimension * 0.5),
-      );
+      expect(scrollable.position.pixels, closeTo(expectedAnchor, 1.0));
     });
 
     testWidgets(
@@ -119,8 +123,11 @@ void main() {
       await tester.pumpAndSettle();
 
       final scrollable = tester.state<ScrollableState>(find.byType(Scrollable));
+      const kBottomPaddingRatio = 0.35;
+      final screenHeight =
+          tester.view.physicalSize.height / tester.view.devicePixelRatio;
       final nearAnchor = scrollable.position.maxScrollExtent -
-          scrollable.position.viewportDimension * 0.35;
+          (BricksSpacing.md + screenHeight * kBottomPaddingRatio);
       final almostNearEnough =
           nearAnchor - scrollable.position.viewportDimension * 1.9;
       scrollable.position.jumpTo(almostNearEnough.clamp(

--- a/docs/plans/2026-04-26-11-08-UTC-jump-button-threshold-and-scroll-target.md
+++ b/docs/plans/2026-04-26-11-08-UTC-jump-button-threshold-and-scroll-target.md
@@ -1,0 +1,25 @@
+# Background
+The chat message list currently shows the "Jump to latest" button when the user is only a short distance from the latest content, and tapping the button animates to the list max extent. With extra list bottom padding, this can feel too eager and can visually overshoot/rebound when far away.
+
+# Goals
+- Show the jump button only when the user is significantly far from the latest content.
+- Update jump animation target so it lands directly at the intended latest-content position without rebound-like behavior.
+- Keep or improve existing widget test coverage.
+
+# Implementation Plan (phased)
+1. Update `MessageList` scroll-distance logic:
+   - Replace fixed reveal threshold with a dynamic threshold based on viewport height (2 screens).
+   - Compute distance from current offset to the latest-content anchor (max extent minus reserved bottom padding).
+2. Update jump action behavior:
+   - Animate to the latest-content anchor offset instead of absolute max extent.
+   - Use a duration scaled by distance to keep motion stable over long jumps.
+3. Update tests:
+   - Adjust jump-to-latest assertion to anchor offset behavior.
+   - Add coverage that button stays hidden when far distance is below the 2-screen threshold.
+4. Validate:
+   - Run repository bootstrap and targeted Flutter widget tests.
+
+# Acceptance Criteria
+- Jump button appears only when distance to latest-content anchor exceeds two full viewport heights.
+- Tapping jump button animates directly to the latest-content anchor position (not absolute bottom padding extent).
+- Message list widget tests pass, including updated jump behavior checks.


### PR DESCRIPTION
### Motivation
- The jump-to-latest button appeared too eagerly and could feel jarring when the list bottom was far off-screen.  
- Long-distance jumps would visually overshoot and then rebound because the scroll target was the absolute `maxScrollExtent` instead of the logical latest-content anchor.  
- The intent is to show the button only when the user is meaningfully far from the latest content and to scroll directly to the correct anchor without a bounce.

### Description
- Replace the fixed pixel threshold with a dynamic threshold of `2` viewports by introducing `_kJumpButtonShowScreens` and using the distance to a computed latest-content anchor for visibility checks (`apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart`).  
- Compute a latest-content anchor offset as `maxScrollExtent - bottomPadding` (where `bottomPadding` is `viewportDimension * _kBottomPaddingRatio`) and use that anchor for visibility and scroll target calculations.  
- Change the jump action to animate to the anchor offset with a duration scaled by distance and use `Curves.easeOutCubic` to make long jumps feel stable and avoid rebound behavior.  
- Update and expand widget tests to assert the new threshold and scroll behavior and add a task plan under `docs/plans/` describing the change (`apps/mobile_chat_app/test/message_list_test.dart`, `docs/plans/2026-04-26-11-08-UTC-jump-button-threshold-and-scroll-target.md`).

### Testing
- Ran repository bootstrap with `./tools/init_dev_env.sh` successfully.  
- Ran formatting with `dart format` on the modified files successfully.  
- Ran the scoped widget tests with `cd apps/mobile_chat_app && flutter test test/message_list_test.dart` and they passed (the test run produced plugin platform warnings about `file_picker` but all assertions in `message_list_test.dart` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf2142410832d9b954a24d3e01190)