### PR TITLE
Improve dark-mode user bubble clarity and message spacing

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -388,8 +388,10 @@ class _MessageListState extends State<MessageList> {
                           key: ValueKey<String>(
                             'message-${msg.messageId ?? '${msg.timestamp}-$index'}',
                           ),
-                          margin:
-                              const EdgeInsets.only(bottom: BricksSpacing.xs),
+                          margin: EdgeInsets.only(
+                            bottom:
+                                isUser ? BricksSpacing.md : BricksSpacing.xs,
+                          ),
                           padding: isUser
                               ? const EdgeInsets.symmetric(
                                   horizontal: BricksSpacing.md,
@@ -487,7 +489,12 @@ class _MessageListState extends State<MessageList> {
                                               .textTheme
                                               .labelSmall
                                               ?.copyWith(
-                                                color: chatColors.metaText,
+                                                color: isUser
+                                                    ? chatColors.onMessageUser
+                                                        .withValues(
+                                                        alpha: 0.68,
+                                                      )
+                                                    : chatColors.metaText,
                                               ),
                                         ),
                                       ),

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -388,10 +388,13 @@ class _MessageListState extends State<MessageList> {
                           key: ValueKey<String>(
                             'message-${msg.messageId ?? '${msg.timestamp}-$index'}',
                           ),
-                          margin: EdgeInsets.only(
-                            bottom:
-                                isUser ? BricksSpacing.md : BricksSpacing.xs,
-                          ),
+                          margin: isUser
+                              ? const EdgeInsets.only(
+                                  bottom: BricksSpacing.md,
+                                )
+                              : const EdgeInsets.only(
+                                  bottom: BricksSpacing.xs,
+                                ),
                           padding: isUser
                               ? const EdgeInsets.symmetric(
                                   horizontal: BricksSpacing.md,
@@ -489,12 +492,8 @@ class _MessageListState extends State<MessageList> {
                                               .textTheme
                                               .labelSmall
                                               ?.copyWith(
-                                                color: isUser
-                                                    ? chatColors.onMessageUser
-                                                        .withValues(
-                                                        alpha: 0.68,
-                                                      )
-                                                    : chatColors.metaText,
+                                                color: chatColors.onMessageUser
+                                                    .withValues(alpha: 0.68),
                                               ),
                                         ),
                                       ),

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -423,8 +423,9 @@ void main() {
         findsOneWidget,
       );
       expect(
-          find.descendant(of: row, matching: find.byIcon(Icons.hub_outlined)),
-          findsNothing);
+        find.descendant(of: row, matching: find.byIcon(Icons.hub_outlined)),
+        findsNothing,
+      );
     });
 
     testWidgets('shows check + completed check when default router has replied',

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -17,7 +17,12 @@ List<ChatMessage> _messages(String prefix, int count) {
   );
 }
 
-Widget _build(List<ChatMessage> messages) => MaterialApp(
+Widget _build(
+  List<ChatMessage> messages, {
+  ThemeData? theme,
+}) =>
+    MaterialApp(
+      theme: theme,
       home: Scaffold(
         body: SizedBox(height: 320, child: MessageList(messages: messages)),
       ),
@@ -240,6 +245,56 @@ void main() {
     });
   });
 
+  group('MessageList visual style', () {
+    testWidgets('uses high-contrast user bubble colors in dark mode',
+        (tester) async {
+      final user = ChatMessage(
+        messageId: 'u-dark',
+        role: 'user',
+        content: 'dark mode user message',
+        timestamp: DateTime.utc(2026, 1, 1),
+      );
+
+      await tester.pumpWidget(_build([user], theme: BricksTheme.dark()));
+      await tester.pumpAndSettle();
+
+      final userContainer = tester.widget<Container>(
+        find.byKey(const ValueKey<String>('message-u-dark')),
+      );
+      final decoration = userContainer.decoration! as BoxDecoration;
+      expect(decoration.color, const Color(0xFFE9EBEC));
+
+      final userText = tester.widget<Text>(find.text('dark mode user message'));
+      expect(userText.style?.color, const Color(0xFF1F2328));
+    });
+
+    testWidgets('adds larger gap after user bubbles', (tester) async {
+      final user = ChatMessage(
+        messageId: 'u-gap',
+        role: 'user',
+        content: 'first message',
+        timestamp: DateTime.utc(2026, 1, 1),
+      );
+      final assistant = ChatMessage(
+        messageId: 'a-gap',
+        role: 'assistant',
+        content: 'second message',
+        timestamp: DateTime.utc(2026, 1, 1, 0, 1),
+      );
+
+      await tester.pumpWidget(_build([user, assistant]));
+      await tester.pumpAndSettle();
+
+      final userContainer = tester.widget<Container>(
+        find.byKey(const ValueKey<String>('message-u-gap')),
+      );
+      expect(
+        userContainer.margin,
+        const EdgeInsets.only(bottom: BricksSpacing.md),
+      );
+    });
+  });
+
   group('Assistant markdown rendering', () {
     testWidgets(
         'renders markdown heading without heading marker and without size increase',
@@ -367,7 +422,9 @@ void main() {
         find.descendant(of: row, matching: find.byIcon(Icons.check)),
         findsOneWidget,
       );
-      expect(find.descendant(of: row, matching: find.byIcon(Icons.hub_outlined)), findsNothing);
+      expect(
+          find.descendant(of: row, matching: find.byIcon(Icons.hub_outlined)),
+          findsNothing);
     });
 
     testWidgets('shows check + completed check when default router has replied',

--- a/docs/plans/2026-04-26-12-03-UTC-chat-bubble-contrast-spacing.md
+++ b/docs/plans/2026-04-26-12-03-UTC-chat-bubble-contrast-spacing.md
@@ -1,0 +1,26 @@
+# Background
+The user requested two dark-mode chat UI adjustments in the mobile chat app: (1) make user message bubbles use a clear white-like color similar to a competitor screenshot, and (2) increase spacing between user and assistant messages. The user also asked why the current color feels visually "weak"/"hazy".
+
+# Goals
+1. Increase visual clarity of user bubbles in dark mode by using a higher-luminance bubble background and preserving text contrast.
+2. Increase perceived separation between user turns and assistant turns in the message list.
+3. Keep behavior stable and cover the style adjustments with widget tests where practical.
+
+# Implementation Plan (phased)
+## Phase 1: Inspect current tokens and message layout
+- Locate chat color tokens and message-list spacing logic in `packages/design_system` and `apps/mobile_chat_app`.
+
+## Phase 2: Apply visual updates
+- Update dark-mode user bubble token(s) to a light surface with strong text contrast.
+- Adjust message list spacing rules to increase the gap after user bubbles.
+- Tune user bubble metadata color so it remains legible on the lighter bubble.
+
+## Phase 3: Validate
+- Run environment bootstrap: `./tools/init_dev_env.sh`.
+- Run targeted widget tests from mobile package directory, focusing on `message_list_test.dart`.
+- If needed, update/add tests that assert bubble color and spacing behavior.
+
+# Acceptance Criteria
+- In dark theme, user bubbles render with a light, high-contrast background and readable dark text.
+- The vertical gap between a user message block and following assistant content is visibly larger than before.
+- Widget tests covering the modified message-list behavior pass (`cd apps/mobile_chat_app && flutter test test/message_list_test.dart`).

--- a/packages/design_system/lib/src/chat_colors.dart
+++ b/packages/design_system/lib/src/chat_colors.dart
@@ -79,9 +79,9 @@ class ChatColors extends ThemeExtension<ChatColors> {
   );
 
   static const ChatColors dark = ChatColors(
-    messageUserBackground: AppColors.surfaceDefault,
+    messageUserBackground: Color(0xFFE9EBEC),
     messageAssistantBackground: Colors.transparent,
-    onMessageUser: AppColors.textPrimary,
+    onMessageUser: Color(0xFF1F2328),
     onMessageAssistant: AppColors.textPrimary,
     metaText: AppColors.textSecondary,
     agentName: AppColors.accentPrimary,


### PR DESCRIPTION
### Motivation
- Users reported the dark-mode user bubbles appear "hazy" and indistinct compared to a bright white competitor bubble, and the vertical separation between user and assistant messages felt too tight.
- The intent is to increase visual clarity and perceived separation without changing behavior or message semantics.

### Description
- Change dark-mode user bubble token in `packages/design_system/lib/src/chat_colors.dart` from a dark surface to a light, high-luminance color `#E9EBEC` and pair it with a dark foreground `#1F2328` so user bubbles read as bright blocks in dark theme.
- Increase the bottom margin after user message containers in `apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart` from `BricksSpacing.xs` to `BricksSpacing.md` to enlarge the gap between user and assistant turns.
- Improve user meta text legibility inside the lighter bubble by using a derivation of the user foreground color (`chatColors.onMessageUser.withValues(alpha: 0.68)`) in `message_list.dart` so timestamps/metadata remain clear on the new background.
- Add widget tests in `apps/mobile_chat_app/test/message_list_test.dart` that validate the dark-mode user bubble color/foreground and the increased post-user spacing, and add a plan document at `docs/plans/2026-04-26-12-03-UTC-chat-bubble-contrast-spacing.md` describing the change.
- No code map updates were made because this change is purely UI style/spacing and does not alter feature entry points, business logic, test indexing, or documentation indexing.

### Testing
- Bootstrapped the environment with `./tools/init_dev_env.sh` which completed successfully.
- Ran the mobile widget tests with `cd apps/mobile_chat_app && flutter test test/message_list_test.dart` and the test suite passed (all tests green).
- Ran `dart format` on modified files to ensure formatting consistency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfeec4c88832da843d53bc05ac701)