### PR TITLE
Mount Docusaurus at /docs and include its build in Vercel Flutter output

### DIFF
--- a/apps/docs_site/docusaurus.config.ts
+++ b/apps/docs_site/docusaurus.config.ts
@@ -5,9 +5,12 @@ const config: Config = {
   title: 'Bricks Docs',
   tagline: 'Documentation for Bricks',
 
-  // Production: DOCS_URL=https://bricks.askman.dev
+  // Production: DOCS_URL=https://bricks.askman.dev (origin only, no trailing slash).
+  // On Vercel preview deployments VERCEL_URL (e.g. bricks-git-branch.vercel.app) is used
+  // as a safe fallback so sitemaps/canonical links are never silently wrong.
   // Do not include /docs here. /docs belongs to baseUrl.
-  url: process.env.DOCS_URL ?? 'http://localhost',
+  url: process.env.DOCS_URL
+    ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost'),
   // Mount the whole Docusaurus site under /docs/.
   baseUrl: process.env.DOCS_BASE_URL ?? '/docs/',
 

--- a/apps/docs_site/docusaurus.config.ts
+++ b/apps/docs_site/docusaurus.config.ts
@@ -1,18 +1,39 @@
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
+// Resolve the site origin (scheme + host, no trailing slash) used for
+// absolute URLs in sitemaps, canonical tags, and Open Graph metadata.
+//
+// Resolution order:
+//   1. DOCS_URL — optional explicit override (e.g. https://bricks.askman.dev)
+//   2. VERCEL_PROJECT_PRODUCTION_URL — injected by Vercel on production deployments
+//   3. VERCEL_URL — injected by Vercel on preview deployments
+//   4. Fail fast — no silent localhost fallback that would corrupt prod metadata
+function resolveDocsUrl(): string {
+  if (process.env.DOCS_URL) {
+    return process.env.DOCS_URL;
+  }
+  if (process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  throw new Error(
+    'Cannot determine docs site URL. ' +
+    'Set DOCS_URL explicitly, or deploy via Vercel where ' +
+    'VERCEL_PROJECT_PRODUCTION_URL / VERCEL_URL are injected automatically.',
+  );
+}
+
 const config: Config = {
   title: 'Bricks Docs',
   tagline: 'Documentation for Bricks',
 
-  // Production: DOCS_URL=https://bricks.askman.dev (origin only, no trailing slash).
-  // On Vercel preview deployments VERCEL_URL (e.g. bricks-git-branch.vercel.app) is used
-  // as a safe fallback so sitemaps/canonical links are never silently wrong.
-  // Do not include /docs here. /docs belongs to baseUrl.
-  url: process.env.DOCS_URL
-    ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost'),
-  // Mount the whole Docusaurus site under /docs/.
-  baseUrl: process.env.DOCS_BASE_URL ?? '/docs/',
+  // Origin resolved at build time — no manual env var configuration required on Vercel.
+  url: resolveDocsUrl(),
+  // Docs are always mounted at /docs/. No env var needed.
+  baseUrl: '/docs/',
 
   organizationName: 'bricks',
   projectName: 'bricks-docs',

--- a/apps/docs_site/docusaurus.config.ts
+++ b/apps/docs_site/docusaurus.config.ts
@@ -5,14 +5,17 @@ const config: Config = {
   title: 'Bricks Docs',
   tagline: 'Documentation for Bricks',
 
+  // Production: DOCS_URL=https://bricks.askman.dev
+  // Do not include /docs here. /docs belongs to baseUrl.
   url: process.env.DOCS_URL ?? 'http://localhost',
-  baseUrl: '/',
+  // Mount the whole Docusaurus site under /docs/.
+  baseUrl: process.env.DOCS_BASE_URL ?? '/docs/',
 
   organizationName: 'bricks',
   projectName: 'bricks-docs',
 
   future: {
-    experimental_faster: {
+    faster: {
       rspackBundler: true,
     },
   },

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -223,3 +223,30 @@ products:
           - 插件启动时可通过 `openclaw agents list --json` 抓取 OpenClaw agents 并上报到 Bricks platform。
           - 插件 ACK body 仅包含 `cursor` 与 `ackedEventIds` 且可推进本地 cursor。
           - 收到 `message.created` 事件后可执行 create + patch 消息回写。
+
+  - product_id: docs_site
+    name: Docusaurus Docs Site
+    platform:
+      - nodejs
+      - docusaurus
+      - vercel-static
+    entry_points:
+      - path: apps/docs_site/docusaurus.config.ts
+        route: /docs/
+      - path: vercel.json
+        route: rewrite /docs/*
+      - path: tools/vercel-build.sh
+        route: build/web/docs artifact assembly
+    features:
+      - feature_id: docs_site_hosting
+        name: Docusaurus 文档子路径挂载
+        user_value: 用户可通过 `/docs/` 访问文档站点，并与 Flutter Web 主站共用同一域名部署。
+        entry_paths:
+          - route: /docs/
+            route_hint: apps/docs_site/docusaurus.config.ts
+          - route: /docs/:path*
+            route_hint: vercel.json
+        smoke_checks:
+          - 执行 `DOCS_URL=http://localhost:3000 DOCS_BASE_URL=/docs/ npm run build` 后，docs 输出可被 `/docs/` 前缀访问。
+          - 执行 `bash ./tools/vercel-build.sh` 后，`apps/mobile_chat_app/build/web/docs/index.html` 存在。
+          - 本地静态服务访问 `/docs/` 呈现 Docusaurus 页面，访问 `/` 仍呈现 Flutter Web 首页。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -374,6 +374,32 @@ index:
       - 上游接口字段变化可能导致回写消息失败。
       - '`openclaw agents list --json` 输出结构变化时，插件可能无法抓取或上报完整 Agent 列表。'
 
+  - feature_id: docs_site_hosting
+    capability: Docusaurus docs site 挂载到 /docs 并与 Flutter Web 同域部署
+    code_index:
+      - apps/docs_site/docusaurus.config.ts
+      - tools/vercel-build.sh
+      - vercel.json
+    doc_index:
+      - docs/intro.md
+      - docs/get-started/quickstart.md
+      - docs/product/overview.md
+      - docs/plans/2026-04-26-12-19-docs-subpath-vercel-integration.md
+    test_index:
+      - tools/vercel-build.sh
+    keywords:
+      - docs
+      - docusaurus
+      - baseUrl
+      - routeBasePath
+      - vercel rewrites
+      - subpath deployment
+      - flutter web output
+    change_risks:
+      - DOCS_URL 若误含 `/docs` 会导致静态资源 URL 双重前缀并产生 404。
+      - rewrites 顺序若把 Flutter fallback 放在 `/docs` 之前，会让 docs 路由错误落入 SPA。
+      - 若先复制 docs 再执行 Flutter build，`build/web/docs` 可能被 Flutter 构建流程覆盖。
+
 maintenance_rules:
   update_required_when:
     - 新增、删除或重命名用户可见功能入口。

--- a/docs/plans/2026-04-26-12-19-docs-subpath-vercel-integration.md
+++ b/docs/plans/2026-04-26-12-19-docs-subpath-vercel-integration.md
@@ -10,9 +10,9 @@ The repository currently deploys Flutter Web from `apps/mobile_chat_app/build/we
 # Implementation Plan (phased)
 ## Phase 1: Docs site config
 - Update `apps/docs_site/docusaurus.config.ts`:
-  - Set `baseUrl` to `process.env.DOCS_BASE_URL ?? '/docs/'`.
+  - Hardcode `baseUrl: '/docs/'` — no env var needed.
   - Keep `routeBasePath: '/'` to preserve docs-only mode semantics.
-  - Add clarifying comments to avoid setting `/docs` in `DOCS_URL`.
+  - Resolve `url` from `DOCS_URL` (optional override) → `VERCEL_PROJECT_PRODUCTION_URL` → `VERCEL_URL` → fail-fast error. No manual configuration required on Vercel.
 
 ## Phase 2: Build pipeline integration
 - Update `tools/vercel-build.sh`:
@@ -31,7 +31,7 @@ The repository currently deploys Flutter Web from `apps/mobile_chat_app/build/we
 - Review and update `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` if docs entry/routing capabilities are impacted.
 
 # Acceptance Criteria
-1. Running Docusaurus build with `DOCS_BASE_URL=/docs/` generates docs site paths under `/docs/`.
+1. Running Docusaurus build generates docs site paths under `/docs/` (baseUrl is hardcoded; no env var required).
 2. Running `bash ./tools/vercel-build.sh` produces `apps/mobile_chat_app/build/web/docs/index.html`.
 3. `vercel.json` rewrites route `/docs` and `/docs/*` to docs index before Flutter fallback.
 4. Existing `/api/*` and Flutter fallback routing remain present and ordered correctly.

--- a/docs/plans/2026-04-26-12-19-docs-subpath-vercel-integration.md
+++ b/docs/plans/2026-04-26-12-19-docs-subpath-vercel-integration.md
@@ -1,0 +1,37 @@
+# Background
+The repository currently deploys Flutter Web from `apps/mobile_chat_app/build/web` on Vercel, while the Docusaurus docs site is configured at root (`baseUrl: '/'`). We need to mount docs at `/docs/` without breaking existing Flutter SPA routing or API rewrites.
+
+# Goals
+1. Configure Docusaurus so generated links and assets are rooted at `/docs/`.
+2. Update Vercel build flow to package docs output under Flutter Web output at `build/web/docs`.
+3. Update Vercel rewrites so `/docs` and `/docs/*` are served by Docusaurus, while all other app routes continue to Flutter SPA.
+4. Keep API routing (`/api/*`) unchanged.
+
+# Implementation Plan (phased)
+## Phase 1: Docs site config
+- Update `apps/docs_site/docusaurus.config.ts`:
+  - Set `baseUrl` to `process.env.DOCS_BASE_URL ?? '/docs/'`.
+  - Keep `routeBasePath: '/'` to preserve docs-only mode semantics.
+  - Add clarifying comments to avoid setting `/docs` in `DOCS_URL`.
+
+## Phase 2: Build pipeline integration
+- Update `tools/vercel-build.sh`:
+  - Add `install_docs_site` and `build_docs_site` helpers.
+  - Run docs dependency install in `--install-only` mode.
+  - After Flutter web release build, build docs and copy to `apps/mobile_chat_app/build/web/docs`.
+  - Ensure copy happens after Flutter build to avoid output overwrite.
+
+## Phase 3: Vercel route dispatch
+- Update `vercel.json` rewrites:
+  - Keep `/api/:path* -> /api/index` first.
+  - Add `/docs -> /docs/index.html` and `/docs/:path* -> /docs/index.html` before Flutter fallback.
+  - Keep catch-all fallback to `/index.html` last.
+
+## Phase 4: Regression metadata
+- Review and update `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` if docs entry/routing capabilities are impacted.
+
+# Acceptance Criteria
+1. Running Docusaurus build with `DOCS_BASE_URL=/docs/` generates docs site paths under `/docs/`.
+2. Running `bash ./tools/vercel-build.sh` produces `apps/mobile_chat_app/build/web/docs/index.html`.
+3. `vercel.json` rewrites route `/docs` and `/docs/*` to docs index before Flutter fallback.
+4. Existing `/api/*` and Flutter fallback routing remain present and ordered correctly.

--- a/tools/vercel-build.sh
+++ b/tools/vercel-build.sh
@@ -27,6 +27,10 @@ ensure_flutter() {
 }
 
 install_docs_site() {
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "Error: 'npm' is required to install docs site dependencies but was not found in PATH." >&2
+    exit 1
+  fi
   echo "Installing docs site dependencies..."
   (
     cd apps/docs_site

--- a/tools/vercel-build.sh
+++ b/tools/vercel-build.sh
@@ -26,17 +26,39 @@ ensure_flutter() {
   echo "Using Flutter from ${flutter_root}"
 }
 
+install_docs_site() {
+  echo "Installing docs site dependencies..."
+  (
+    cd apps/docs_site
+    npm ci
+  )
+}
+
+build_docs_site() {
+  echo "Building docs site..."
+  (
+    cd apps/docs_site
+    npm run build
+  )
+
+  echo "Copying docs site into Flutter web output..."
+  rm -rf apps/mobile_chat_app/build/web/docs
+  mkdir -p apps/mobile_chat_app/build/web/docs
+  cp -R apps/docs_site/build/. apps/mobile_chat_app/build/web/docs/
+}
+
 ensure_flutter
 flutter config --enable-web >/dev/null
 
 if [ "${INSTALL_ONLY}" = "--install-only" ]; then
-  echo "Running install-only setup (pub get and web precache)..."
+  echo "Running install-only setup..."
   flutter --version
   (
     cd apps/mobile_chat_app
     flutter pub get
   )
   flutter precache --web 2>&1 || echo "Warning: flutter precache --web failed; build may be slower." >&2
+  install_docs_site
   echo "Install-only step finished."
   exit 0
 fi
@@ -47,3 +69,10 @@ flutter --version
   flutter pub get
   flutter build web --release
 )
+
+# Useful for local runs where --install-only was not executed first.
+if [ ! -d apps/docs_site/node_modules ]; then
+  install_docs_site
+fi
+
+build_docs_site

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,14 @@
       "destination": "/api/index"
     },
     {
+      "source": "/docs",
+      "destination": "/docs/index.html"
+    },
+    {
+      "source": "/docs/:path*",
+      "destination": "/docs/index.html"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
### Motivation
- Serve the Docusaurus docs site at the `/docs/` subpath on the same domain as the Flutter Web app without changing `routeBasePath`. 
- Ensure the docs static output is included in the Flutter web output directory so Vercel can serve both the SPA and docs from a single `outputDirectory`.
- Add build-time wiring so docs are built and copied after the Flutter build to avoid Flutter overwriting docs artifacts.
- Make the docs configuration explicit about `DOCS_URL` (origin-only) and ensure compatibility with the installed Docusaurus version.

### Description
- Updated `apps/docs_site/docusaurus.config.ts` to set `baseUrl: process.env.DOCS_BASE_URL ?? '/docs/'`, keep `routeBasePath: '/'`, add a comment clarifying `DOCS_URL` usage, and change `future.experimental_faster` to `future.faster` for Docusaurus 3.10 compatibility. 
- Extended `tools/vercel-build.sh` with `install_docs_site` and `build_docs_site` helpers, installed docs deps in `--install-only` mode, and added a post-Flutter-build step that copies `apps/docs_site/build` into `apps/mobile_chat_app/build/web/docs`. 
- Modified `vercel.json` rewrites to add `/docs` and `/docs/:path*` rules before the Flutter SPA fallback while keeping the `/api/:path*` rule first. 
- Added an implementation plan at `docs/plans/2026-04-26-12-19-docs-subpath-vercel-integration.md`. 
- Updated code maps `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` to add a `docs_site_hosting` entry documenting the new hosting/mounting behavior and associated smoke checks and risks.

### Testing
- Ran environment bootstrap with `./tools/init_dev_env.sh` which completed successfully. 
- Installed docs dependencies with `cd apps/docs_site && npm ci`, which succeeded (audit warnings reported but install completed). 
- Attempted `cd apps/docs_site && DOCS_URL=http://localhost:3000 DOCS_BASE_URL=/docs/ npm run build`, encountered a Docusaurus config validation error, then updated the config (`future.experimental_faster` → `future.faster`) and re-ran the build which succeeded and generated `build/`. 
- Executed full build orchestration via `DOCS_URL=http://localhost:3000 DOCS_BASE_URL=/docs/ bash ./tools/vercel-build.sh`, which performed the Flutter web `build` then built Docusaurus and copied docs into `apps/mobile_chat_app/build/web/docs`, and the presence of `apps/mobile_chat_app/build/web/docs/index.html` was verified. 
- Validated YAMLs and JSON: `npx js-yaml docs/code_maps/feature_map.yaml && npx js-yaml docs/code_maps/logic_map.yaml` succeeded, `bash -n tools/vercel-build.sh` passed, and `python3 -m json.tool vercel.json` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee02d11db4832db78bcd57d8282ed9)