### PR TITLE
Light-mode color adjustments and jump-to-latest button theming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Before running Flutter/Dart workspace checks in this repository, run `./tools/init_dev_env.sh` from the repo root.
 - `tools/init_dev_env.sh` is the standard bootstrap entrypoint for both local and Codex/container environments.
 - Run mobile app Flutter tests from the package directory: `cd apps/mobile_chat_app && flutter test` (avoid `flutter test apps/mobile_chat_app` from repo root).
+- Never pass Markdown files (for example `*.md`) to `dart format` or other Dart source-only tooling commands; target only Dart files/directories.
 
 ## Plan persistence
 - For each feature or task, create and save a markdown plan file in `docs/plans/`.

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -567,7 +567,8 @@ class _MessageListState extends State<MessageList> {
                 child: Builder(
                   builder: (context) {
                     final chatColors =
-                        Theme.of(context).extension<ChatColors>()!;
+                        Theme.of(context).extension<ChatColors>() ??
+                            ChatColors.light;
                     return IconButton.filled(
                       onPressed: _scrollToLatestMessage,
                       tooltip: 'Jump to latest',

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -564,10 +564,20 @@ class _MessageListState extends State<MessageList> {
               opacity: _showJumpToLatestButton ? 1 : 0,
               duration: const Duration(milliseconds: 150),
               child: Center(
-                child: IconButton.filled(
-                  onPressed: _scrollToLatestMessage,
-                  tooltip: 'Jump to latest',
-                  icon: const Icon(Icons.arrow_downward),
+                child: Builder(
+                  builder: (context) {
+                    final chatColors =
+                        Theme.of(context).extension<ChatColors>()!;
+                    return IconButton.filled(
+                      onPressed: _scrollToLatestMessage,
+                      tooltip: 'Jump to latest',
+                      style: IconButton.styleFrom(
+                        backgroundColor: chatColors.jumpToLatestBackground,
+                        foregroundColor: chatColors.onJumpToLatest,
+                      ),
+                      icon: const Icon(Icons.arrow_downward),
+                    );
+                  },
                 ),
               ),
             ),

--- a/docs/plans/2026-04-27-13-47-UTC-light-mode-color-adjustments.md
+++ b/docs/plans/2026-04-27-13-47-UTC-light-mode-color-adjustments.md
@@ -12,10 +12,11 @@
 - 在 `ChatColors.light` 中调整 `messageUserBackground` 与 `onMessageUser`，实现亮色模式黑底白字气泡。
 - 在 `BricksTheme.light()` 明确设置亮色 `scaffoldBackgroundColor` 与 `appBarTheme`，去除由 `colorSchemeSeed` 带来的灰蓝背景倾向。
 
-## Phase 2: 定位按钮亮暗模式分流
-- 在消息列表中按 `Theme.brightness` 区分 jump-to-latest 按钮样式：
-  - Light: 白色系按钮（白底、深色箭头）。
-  - Dark: 保持现有蓝色主色填充按钮。
+## Phase 2: 定位按钮语义色调整
+- 通过 `ChatColors.jumpToLatestBackground` 与 `ChatColors.onJumpToLatest` 统一定义 jump-to-latest 按钮样式，不在消息列表组件内按 `Theme.brightness` 额外分支。
+- 在主题 token 层分别配置亮暗模式取值：
+  - Light: `jumpToLatestBackground` 为白色系，`onJumpToLatest` 为深色箭头/图标。
+  - Dark: 保持现有蓝色主色填充按钮及对应前景色。
 
 ## Phase 3: 校验
 - 运行格式化和 Flutter 分析命令，确保代码风格与静态检查通过。

--- a/docs/plans/2026-04-27-13-47-UTC-light-mode-color-adjustments.md
+++ b/docs/plans/2026-04-27-13-47-UTC-light-mode-color-adjustments.md
@@ -1,0 +1,27 @@
+# Background
+用户反馈亮色模式仍存在灰蓝倾向，且与目标视觉不一致。需要依据设计手册（`docs/kb/color-theme-architecture.md`）将亮色模式关键区域调整为中性白/黑体系：页面背景、用户消息气泡、以及“定位到最底部”圆形按钮。
+
+# Goals
+1. 亮色模式页面背景去蓝化，改为中性白系。
+2. 亮色模式用户气泡改为黑底白字，提升对比度并符合视觉要求。
+3. 亮色模式“定位到最新”圆形按钮改为白色系；暗色模式蓝色按钮保持不变。
+4. 不引入业务组件内硬编码色值，优先通过 design system token/主题层实现。
+
+# Implementation Plan (phased)
+## Phase 1: 主题与语义色调整
+- 在 `ChatColors.light` 中调整 `messageUserBackground` 与 `onMessageUser`，实现亮色模式黑底白字气泡。
+- 在 `BricksTheme.light()` 明确设置亮色 `scaffoldBackgroundColor` 与 `appBarTheme`，去除由 `colorSchemeSeed` 带来的灰蓝背景倾向。
+
+## Phase 2: 定位按钮亮暗模式分流
+- 在消息列表中按 `Theme.brightness` 区分 jump-to-latest 按钮样式：
+  - Light: 白色系按钮（白底、深色箭头）。
+  - Dark: 保持现有蓝色主色填充按钮。
+
+## Phase 3: 校验
+- 运行格式化和 Flutter 分析命令，确保代码风格与静态检查通过。
+
+# Acceptance Criteria
+1. 亮色模式聊天页面背景为中性白系，不再呈现灰蓝底感。
+2. 亮色模式右侧用户消息气泡呈现黑底白字，时间与状态图标在气泡上清晰可读。
+3. 亮色模式 jump-to-latest 按钮呈白色系；暗色模式该按钮继续为蓝色。
+4. `cd apps/mobile_chat_app && flutter analyze` 无错误。

--- a/packages/design_system/lib/src/bricks_theme.dart
+++ b/packages/design_system/lib/src/bricks_theme.dart
@@ -16,7 +16,23 @@ class BricksTheme {
     reverseCurve: Curves.easeInCubic,
   );
 
-  static ThemeData light() => _buildTheme(Brightness.light);
+  static ThemeData light() => ThemeData(
+        useMaterial3: true,
+        brightness: Brightness.light,
+        scaffoldBackgroundColor: const Color(0xFFFFFFFF),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Color(0xFFFFFFFF),
+          foregroundColor: Color(0xFF1F2328),
+          surfaceTintColor: Colors.transparent,
+        ),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppColors.accentPrimary,
+          brightness: Brightness.light,
+        ).copyWith(
+          surface: const Color(0xFFFFFFFF),
+        ),
+        extensions: const [ChatColors.light],
+      );
 
   static ThemeData dark() => ThemeData(
         useMaterial3: true,
@@ -38,12 +54,5 @@ class BricksTheme {
           error: AppColors.danger,
         ),
         extensions: const [ChatColors.dark],
-      );
-
-  static ThemeData _buildTheme(Brightness brightness) => ThemeData(
-        useMaterial3: true,
-        colorSchemeSeed: AppColors.accentPrimary,
-        brightness: brightness,
-        extensions: const [ChatColors.light],
       );
 }

--- a/packages/design_system/lib/src/chat_colors.dart
+++ b/packages/design_system/lib/src/chat_colors.dart
@@ -24,6 +24,8 @@ class ChatColors extends ThemeExtension<ChatColors> {
     required this.sendIdle,
     required this.sendActive,
     required this.agentIdentity,
+    required this.jumpToLatestBackground,
+    required this.onJumpToLatest,
   });
 
   final Color messageUserBackground;
@@ -44,10 +46,12 @@ class ChatColors extends ThemeExtension<ChatColors> {
   final Color sendIdle;
   final Color sendActive;
   final Color agentIdentity;
+  final Color jumpToLatestBackground;
+  final Color onJumpToLatest;
 
   static const ChatColors light = ChatColors(
-    messageUserBackground: Color(0xFFE9EBEC),
-    onMessageUser: Color(0xFF1F2328),
+    messageUserBackground: Color(0xFF111111),
+    onMessageUser: Color(0xFFFFFFFF),
     onMessageAssistant: Color(0xFF1F2328),
     metaText: Color(0xFF657786),
     agentName: Color(0xFF1D9BF0),
@@ -64,6 +68,8 @@ class ChatColors extends ThemeExtension<ChatColors> {
     sendIdle: Color(0xFF576470),
     sendActive: Color(0xFF1D9BF0),
     agentIdentity: Color(0xFF1F2328),
+    jumpToLatestBackground: Color(0xFFFFFFFF),
+    onJumpToLatest: Color(0xFF1F2328),
   );
 
   static const ChatColors dark = ChatColors(
@@ -85,6 +91,8 @@ class ChatColors extends ThemeExtension<ChatColors> {
     sendIdle: AppColors.textPrimary,
     sendActive: AppColors.textPrimary,
     agentIdentity: Color(0xFFDEE3E7),
+    jumpToLatestBackground: AppColors.accentPrimary,
+    onJumpToLatest: AppColors.textPrimary,
   );
 
   @override
@@ -107,6 +115,8 @@ class ChatColors extends ThemeExtension<ChatColors> {
     Color? sendIdle,
     Color? sendActive,
     Color? agentIdentity,
+    Color? jumpToLatestBackground,
+    Color? onJumpToLatest,
   }) {
     return ChatColors(
       messageUserBackground:
@@ -129,6 +139,9 @@ class ChatColors extends ThemeExtension<ChatColors> {
       sendIdle: sendIdle ?? this.sendIdle,
       sendActive: sendActive ?? this.sendActive,
       agentIdentity: agentIdentity ?? this.agentIdentity,
+      jumpToLatestBackground:
+          jumpToLatestBackground ?? this.jumpToLatestBackground,
+      onJumpToLatest: onJumpToLatest ?? this.onJumpToLatest,
     );
   }
 
@@ -162,6 +175,9 @@ class ChatColors extends ThemeExtension<ChatColors> {
       sendIdle: Color.lerp(sendIdle, other.sendIdle, t)!,
       sendActive: Color.lerp(sendActive, other.sendActive, t)!,
       agentIdentity: Color.lerp(agentIdentity, other.agentIdentity, t)!,
+      jumpToLatestBackground:
+          Color.lerp(jumpToLatestBackground, other.jumpToLatestBackground, t)!,
+      onJumpToLatest: Color.lerp(onJumpToLatest, other.onJumpToLatest, t)!,
     );
   }
 }


### PR DESCRIPTION
### Motivation
- Align the light theme with the design system by removing the gray-blue cast and switching key chat elements to a neutral white/black system. 
- Make the circular "jump to latest" button theme-aware so it appears white in light mode and preserves the blue style in dark mode. 
- Capture the change plan and local tooling guidance for future contributors.

### Description
- Replaced the previous light theme builder with an explicit `ThemeData.light()` configuration in `packages/design_system/lib/src/bricks_theme.dart` setting `scaffoldBackgroundColor` and `appBarTheme` to neutral white values. 
- Added two new semantic theme tokens `jumpToLatestBackground` and `onJumpToLatest` to `ChatColors` and wired light/dark values in `packages/design_system/lib/src/chat_colors.dart`. 
- Updated user message bubble colors in `ChatColors.light` to use a dark user-bubble (`messageUserBackground: 0xFF111111`) with white text (`onMessageUser: 0xFFFFFFFF`) to increase contrast. 
- Updated the message list widget `apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart` to use the new `ChatColors` tokens when rendering the `IconButton.filled` via a `Builder` so the jump button respects theme tokens for background and foreground. 
- Added a plan `docs/plans/2026-04-27-13-47-UTC-light-mode-color-adjustments.md` documenting goals, phased implementation, and acceptance criteria. 
- Added a small tooling note to `AGENTS.md` advising not to pass Markdown files to Dart-only formatting tools.

### Testing
- Ran `cd apps/mobile_chat_app && flutter analyze` to validate static analysis and it completed without errors. 
- Ran `cd apps/mobile_chat_app && flutter test` to exercise widget/unit tests and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef664a8158832dac344d2672ee7390)