### PR TITLE
Model default router as a built-in node and unify routing metadata

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
@@ -197,6 +197,9 @@ class ChatHistoryApiService {
         router: chatRouterFromApi(item['router'] as String?),
         nodeId: item['nodeId'] as String?,
         instructions: item['instructions'] as String?,
+        resolvedTargetNodeId: item['resolvedTargetNodeId'] as String?,
+        resolvedTargetNodeName: item['resolvedTargetNodeName'] as String?,
+        resolvedTargetPluginId: item['resolvedTargetPluginId'] as String?,
         updatedAt: item['updatedAt'] is String
             ? DateTime.tryParse(item['updatedAt'] as String)
             : null,

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -545,7 +545,7 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   String _currentComposerModelLabel() {
-    if (_effectiveRouterForScope() == ChatRouter.openclaw) {
+    if (_effectiveRouterForScope() == ChatRouter.plugin) {
       return 'OpenClaw';
     }
     final selectedConfig = _activeLlmConfig;
@@ -1121,12 +1121,11 @@ class _ChatScreenState extends State<ChatScreen> {
 
   ChatRouter _effectiveChannelRouter({String? channelId}) {
     final resolvedChannelId = channelId ?? _activeChannelId;
-    final router =
-        _channelRouters[resolvedChannelId] ?? ChatRouter.defaultRoute;
-    if (router != ChatRouter.openclaw) return router;
+    final router = _channelRouters[resolvedChannelId] ?? ChatRouter.local;
+    if (router != ChatRouter.plugin) return router;
     return _isKnownPlatformNodeId(_channelNodeIds[resolvedChannelId])
-        ? ChatRouter.openclaw
-        : ChatRouter.defaultRoute;
+        ? ChatRouter.plugin
+        : ChatRouter.local;
   }
 
   ChatRouter? _effectiveExplicitThreadRouter({
@@ -1137,15 +1136,15 @@ class _ChatScreenState extends State<ChatScreen> {
       channelId: channelId,
       threadId: threadId,
     );
-    if (router != ChatRouter.openclaw) return router;
+    if (router != ChatRouter.plugin) return router;
     return _isKnownPlatformNodeId(
       _explicitThreadNodeId(
         channelId: channelId,
         threadId: threadId,
       ),
     )
-        ? ChatRouter.openclaw
-        : ChatRouter.defaultRoute;
+        ? ChatRouter.plugin
+        : ChatRouter.local;
   }
 
   ChatRouter _effectiveRouterForScope({String? channelId, String? threadId}) {
@@ -1172,14 +1171,14 @@ class _ChatScreenState extends State<ChatScreen> {
           channelId: resolvedChannelId,
           threadId: resolvedThreadId,
         ) !=
-        ChatRouter.openclaw) {
+        ChatRouter.plugin) {
       return null;
     }
     if (_effectiveExplicitThreadRouter(
           channelId: resolvedChannelId,
           threadId: resolvedThreadId,
         ) ==
-        ChatRouter.openclaw) {
+        ChatRouter.plugin) {
       return _normalizeNodeId(
         _explicitThreadNodeId(
           channelId: resolvedChannelId,
@@ -1215,9 +1214,9 @@ class _ChatScreenState extends State<ChatScreen> {
 
   String _routerLabel(ChatRouter router) {
     switch (router) {
-      case ChatRouter.defaultRoute:
+      case ChatRouter.local:
         return 'Bricks Default';
-      case ChatRouter.openclaw:
+      case ChatRouter.plugin:
         return 'OpenClaw';
     }
   }
@@ -1228,7 +1227,7 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   List<ComposerAtAction> _composerAtActions(ChatRouter router) {
-    if (router == ChatRouter.openclaw) {
+    if (router == ChatRouter.plugin) {
       final node = _activeOpenClawNode();
       if (node == null) {
         return const <ComposerAtAction>[
@@ -1259,7 +1258,7 @@ class _ChatScreenState extends State<ChatScreen> {
           )
           .toList();
     }
-    if (router == ChatRouter.defaultRoute) {
+    if (router == ChatRouter.local) {
       return _agents
           .map(
             (agent) => ComposerAtAction(
@@ -1273,7 +1272,7 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   void _handleComposerAtSelection(ChatRouter router, String value) {
-    if (router == ChatRouter.openclaw) {
+    if (router == ChatRouter.plugin) {
       if (!value.startsWith('openclaw:')) return;
       final node = _activeOpenClawNode();
       if (node == null) return;
@@ -1284,7 +1283,7 @@ class _ChatScreenState extends State<ChatScreen> {
       if (agents.every((agent) => agent.agentId != agentId)) return;
       return;
     }
-    if (router != ChatRouter.defaultRoute) return;
+    if (router != ChatRouter.local) return;
     final agent = _findAgent(value);
     if (agent == null) return;
     _selectAgent(agent);
@@ -1329,7 +1328,15 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   String? _sourceFromRespondRouter(String? router) {
-    if (router == null || router.isEmpty || router == 'default') return null;
+    if (router == null ||
+        router.isEmpty ||
+        router == 'default' ||
+        router == 'local') {
+      return null;
+    }
+    if (router == 'openclaw' || router == 'plugin') {
+      return 'backend.respond.openclaw';
+    }
     return 'backend.respond.$router';
   }
 
@@ -1347,11 +1354,11 @@ class _ChatScreenState extends State<ChatScreen> {
     final previousNodeId = _channelNodeIds[channelId];
     final normalizedNodeId = _normalizeNodeId(nodeId);
     final effectiveRouter =
-        router == ChatRouter.openclaw && normalizedNodeId == null
-            ? ChatRouter.defaultRoute
+        router == ChatRouter.plugin && normalizedNodeId == null
+            ? ChatRouter.local
             : router;
     setState(() {
-      if (effectiveRouter == ChatRouter.defaultRoute) {
+      if (effectiveRouter == ChatRouter.local) {
         _channelRouters.remove(channelId);
         _channelNodeIds.remove(channelId);
       } else {
@@ -1370,10 +1377,8 @@ class _ChatScreenState extends State<ChatScreen> {
         token: token,
         scopeType: ChatScopeType.channel,
         channelId: channelId,
-        router:
-            effectiveRouter == ChatRouter.defaultRoute ? null : effectiveRouter,
-        nodeId:
-            effectiveRouter == ChatRouter.openclaw ? normalizedNodeId : null,
+        router: effectiveRouter,
+        nodeId: effectiveRouter == ChatRouter.plugin ? normalizedNodeId : null,
       );
       if (!mounted) return;
     } catch (error) {
@@ -1413,8 +1418,8 @@ class _ChatScreenState extends State<ChatScreen> {
     final previousNodeId = _threadNodeIds[key];
     final normalizedNodeId = _normalizeNodeId(nodeId);
     final effectiveRouter =
-        router == ChatRouter.openclaw && normalizedNodeId == null
-            ? ChatRouter.defaultRoute
+        router == ChatRouter.plugin && normalizedNodeId == null
+            ? ChatRouter.local
             : router;
     setState(() {
       if (effectiveRouter == null) {
@@ -1438,8 +1443,7 @@ class _ChatScreenState extends State<ChatScreen> {
         channelId: channelId,
         threadId: threadId,
         router: effectiveRouter,
-        nodeId:
-            effectiveRouter == ChatRouter.openclaw ? normalizedNodeId : null,
+        nodeId: effectiveRouter == ChatRouter.plugin ? normalizedNodeId : null,
       );
       if (!mounted) return;
     } catch (error) {
@@ -1467,7 +1471,7 @@ class _ChatScreenState extends State<ChatScreen> {
     if (value.startsWith('channel:openclaw:')) {
       unawaited(
         _saveChannelRouter(
-          ChatRouter.openclaw,
+          ChatRouter.plugin,
           nodeId: value.substring('channel:openclaw:'.length),
         ),
       );
@@ -1477,7 +1481,7 @@ class _ChatScreenState extends State<ChatScreen> {
       if (!_isThreadConversation()) return;
       unawaited(
         _saveThreadRouter(
-          ChatRouter.openclaw,
+          ChatRouter.plugin,
           nodeId: value.substring('thread:openclaw:'.length),
         ),
       );
@@ -1485,7 +1489,7 @@ class _ChatScreenState extends State<ChatScreen> {
     }
     switch (value) {
       case 'channel:default':
-        unawaited(_saveChannelRouter(ChatRouter.defaultRoute));
+        unawaited(_saveChannelRouter(ChatRouter.local));
         return;
       case 'thread:inherit':
         if (!_isThreadConversation()) return;
@@ -1493,7 +1497,7 @@ class _ChatScreenState extends State<ChatScreen> {
         return;
       case 'thread:default':
         if (!_isThreadConversation()) return;
-        unawaited(_saveThreadRouter(ChatRouter.defaultRoute));
+        unawaited(_saveThreadRouter(ChatRouter.local));
         return;
     }
   }
@@ -1518,17 +1522,15 @@ class _ChatScreenState extends State<ChatScreen> {
       }
     });
 
-    final effectiveRouter =
-        _channelRouters[channelId] ?? ChatRouter.defaultRoute;
+    final effectiveRouter = _channelRouters[channelId] ?? ChatRouter.local;
 
     try {
       await _chatHistoryApiService.saveScopeSetting(
         token: token,
         scopeType: ChatScopeType.channel,
         channelId: channelId,
-        router:
-            effectiveRouter == ChatRouter.defaultRoute ? null : effectiveRouter,
-        nodeId: effectiveRouter == ChatRouter.openclaw
+        router: effectiveRouter,
+        nodeId: effectiveRouter == ChatRouter.plugin
             ? _channelNodeIds[channelId]
             : null,
         instructions: normalized?.isEmpty ?? true ? null : normalized,
@@ -1573,7 +1575,7 @@ class _ChatScreenState extends State<ChatScreen> {
       }
     });
 
-    final effectiveRouter = _threadRouters[key] ?? ChatRouter.defaultRoute;
+    final effectiveRouter = _threadRouters[key] ?? ChatRouter.local;
 
     try {
       await _chatHistoryApiService.saveScopeSetting(
@@ -1582,9 +1584,8 @@ class _ChatScreenState extends State<ChatScreen> {
         channelId: channelId,
         threadId: threadId,
         router: effectiveRouter,
-        nodeId: effectiveRouter == ChatRouter.openclaw
-            ? _threadNodeIds[key]
-            : null,
+        nodeId:
+            effectiveRouter == ChatRouter.plugin ? _threadNodeIds[key] : null,
         instructions: normalized?.isEmpty ?? true ? null : normalized,
       );
       if (!mounted) return;
@@ -1697,7 +1698,7 @@ class _ChatScreenState extends State<ChatScreen> {
   bool _shouldSyncActiveScope() {
     final token = _authToken;
     if (token == null || token.isEmpty) return false;
-    if (_effectiveRouterForScope() == ChatRouter.openclaw) return true;
+    if (_effectiveRouterForScope() == ChatRouter.plugin) return true;
     if (_isSending || _isStreaming) return true;
     return _hasPendingAssistantTasks() || _hasPendingUserTasks();
   }
@@ -2464,9 +2465,9 @@ class _ChatScreenState extends State<ChatScreen> {
           builder: (context) {
             final effectiveRouter = _effectiveRouterForScope();
             final showComposerConfigMenu =
-                effectiveRouter == ChatRouter.defaultRoute ||
-                    effectiveRouter == ChatRouter.openclaw;
-            final slashCommands = effectiveRouter == ChatRouter.openclaw
+                effectiveRouter == ChatRouter.local ||
+                    effectiveRouter == ChatRouter.plugin;
+            final slashCommands = effectiveRouter == ChatRouter.plugin
                 ? _openClawSlashCommands
                 : const <String>[];
             final atActions = _composerAtActions(effectiveRouter);
@@ -2484,7 +2485,7 @@ class _ChatScreenState extends State<ChatScreen> {
                     final channelRouter = _effectiveChannelRouter(
                       channelId: _activeChannelId,
                     );
-                    final channelNodeId = channelRouter == ChatRouter.openclaw
+                    final channelNodeId = channelRouter == ChatRouter.plugin
                         ? _normalizeNodeId(
                             _channelNodeIds[_activeChannelId],
                           )
@@ -2493,7 +2494,7 @@ class _ChatScreenState extends State<ChatScreen> {
                     final explicitThreadRouter =
                         _effectiveExplicitThreadRouter();
                     final explicitThreadNodeId =
-                        explicitThreadRouter == ChatRouter.openclaw
+                        explicitThreadRouter == ChatRouter.plugin
                             ? _normalizeNodeId(_explicitThreadNodeId())
                             : null;
                     return [
@@ -2507,7 +2508,7 @@ class _ChatScreenState extends State<ChatScreen> {
                           child: _buildRouterMenuOption(
                             context: context,
                             label: 'Bricks Default',
-                            selected: channelRouter == ChatRouter.defaultRoute,
+                            selected: channelRouter == ChatRouter.local,
                           ),
                         ),
                         ..._platformNodes.map(
@@ -2517,7 +2518,7 @@ class _ChatScreenState extends State<ChatScreen> {
                               context: context,
                               label: _platformNodeLabel(node),
                               sublabel: 'OpenClaw',
-                              selected: channelRouter == ChatRouter.openclaw &&
+                              selected: channelRouter == ChatRouter.plugin &&
                                   channelNodeId ==
                                       _normalizeNodeId(node.nodeId),
                             ),
@@ -2534,7 +2535,7 @@ class _ChatScreenState extends State<ChatScreen> {
                           child: _buildRouterMenuOption(
                             context: context,
                             label: 'Follow channel',
-                            sublabel: channelRouter == ChatRouter.openclaw
+                            sublabel: channelRouter == ChatRouter.plugin
                                 ? '${_nodeLabel(channelNodeId)} · $channelRouterLabel'
                                 : channelRouterLabel,
                             selected: explicitThreadRouter == null,
@@ -2545,8 +2546,7 @@ class _ChatScreenState extends State<ChatScreen> {
                           child: _buildRouterMenuOption(
                             context: context,
                             label: 'Bricks Default',
-                            selected:
-                                explicitThreadRouter == ChatRouter.defaultRoute,
+                            selected: explicitThreadRouter == ChatRouter.local,
                           ),
                         ),
                         ..._platformNodes.map(
@@ -2557,7 +2557,7 @@ class _ChatScreenState extends State<ChatScreen> {
                               label: _platformNodeLabel(node),
                               sublabel: 'OpenClaw',
                               selected:
-                                  explicitThreadRouter == ChatRouter.openclaw &&
+                                  explicitThreadRouter == ChatRouter.plugin &&
                                       explicitThreadNodeId ==
                                           _normalizeNodeId(node.nodeId),
                             ),
@@ -2569,7 +2569,7 @@ class _ChatScreenState extends State<ChatScreen> {
                   icon: SizedBox.square(
                     dimension: 24,
                     child: Center(
-                      child: _effectiveRouterForScope() == ChatRouter.openclaw
+                      child: _effectiveRouterForScope() == ChatRouter.plugin
                           ? const Icon(Icons.hub_outlined, size: 20)
                           : const Icon(Icons.alt_route, size: 20),
                     ),
@@ -2797,15 +2797,14 @@ class _ScopeConfigDialogState extends State<_ScopeConfigDialog>
       ),
       actions: [
         TextButton(
-          onPressed:
-              _isSaving ? null : () => Navigator.of(context).pop(),
+          onPressed: _isSaving ? null : () => Navigator.of(context).pop(),
           child: const Text('Cancel'),
         ),
         FilledButton(
-          onPressed: _isSaving ||
-                  (_tabController.index == 1 && !widget.isSubSection)
-              ? null
-              : _save,
+          onPressed:
+              _isSaving || (_tabController.index == 1 && !widget.isSubSection)
+                  ? null
+                  : _save,
           child: _isSaving
               ? const SizedBox.square(
                   dimension: 16,

--- a/apps/mobile_chat_app/lib/features/chat/chat_topology.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_topology.dart
@@ -1,14 +1,14 @@
-enum ChatRouter { defaultRoute, openclaw }
+enum ChatRouter { local, plugin }
 
 enum ChatScopeType { channel, thread }
 
 extension ChatRouterApi on ChatRouter {
   String get apiValue {
     switch (this) {
-      case ChatRouter.defaultRoute:
-        return 'default';
-      case ChatRouter.openclaw:
-        return 'openclaw';
+      case ChatRouter.local:
+        return 'local';
+      case ChatRouter.plugin:
+        return 'plugin';
     }
   }
 }
@@ -26,11 +26,13 @@ extension ChatScopeTypeApi on ChatScopeType {
 
 ChatRouter chatRouterFromApi(String? value) {
   switch (value) {
+    case 'plugin':
     case 'openclaw':
-      return ChatRouter.openclaw;
+      return ChatRouter.plugin;
+    case 'local':
     case 'default':
     default:
-      return ChatRouter.defaultRoute;
+      return ChatRouter.local;
   }
 }
 
@@ -102,6 +104,9 @@ class ChatScopeSetting {
     this.nodeId,
     this.threadId,
     this.instructions,
+    this.resolvedTargetNodeId,
+    this.resolvedTargetNodeName,
+    this.resolvedTargetPluginId,
     this.updatedAt,
   });
 
@@ -111,6 +116,9 @@ class ChatScopeSetting {
   final ChatRouter router;
   final String? nodeId;
   final String? instructions;
+  final String? resolvedTargetNodeId;
+  final String? resolvedTargetNodeName;
+  final String? resolvedTargetPluginId;
   final DateTime? updatedAt;
 }
 

--- a/apps/mobile_chat_app/test/chat_history_api_service_test.dart
+++ b/apps/mobile_chat_app/test/chat_history_api_service_test.dart
@@ -389,6 +389,9 @@ void main() {
                 'scopeType': 'channel',
                 'channelId': 'default',
                 'router': 'openclaw',
+                'resolvedTargetNodeId': 'node-default',
+                'resolvedTargetNodeName': 'openclaw 1',
+                'resolvedTargetPluginId': 'plugin-local-main',
                 'updatedAt': '2026-04-17T07:00:00.000Z',
               },
             ],
@@ -402,10 +405,10 @@ void main() {
       expect(decoded['scopeType'], equals('thread'));
       expect(decoded['channelId'], equals('default'));
       expect(decoded['threadId'], equals('main'));
-      expect(decoded['router'], equals('default'));
+      expect(decoded['router'], equals('local'));
       return http.Response(
         jsonEncode({
-          'setting': {'router': 'default'},
+          'setting': {'router': 'local'},
         }),
         200,
       );
@@ -418,12 +421,15 @@ void main() {
       scopeType: ChatScopeType.thread,
       channelId: 'default',
       threadId: 'main',
-      router: ChatRouter.defaultRoute,
+      router: ChatRouter.local,
     );
 
     expect(settings, hasLength(1));
     expect(settings.single.scopeType, ChatScopeType.channel);
-    expect(settings.single.router, ChatRouter.openclaw);
+    expect(settings.single.router, ChatRouter.plugin);
+    expect(settings.single.resolvedTargetNodeId, 'node-default');
+    expect(settings.single.resolvedTargetNodeName, 'openclaw 1');
+    expect(settings.single.resolvedTargetPluginId, 'plugin-local-main');
   });
 
   test('loads and saves channel name mappings', () async {
@@ -601,7 +607,8 @@ void main() {
       final decoded = jsonDecode(request.body) as Map<String, dynamic>;
       expect(decoded['scopeType'], equals('channel'));
       expect(decoded['channelId'], equals('ch-1'));
-      expect(decoded['instructions'], equals('channel-level instructions text'));
+      expect(
+          decoded['instructions'], equals('channel-level instructions text'));
       return http.Response(
         jsonEncode({'setting': {}}),
         200,
@@ -613,7 +620,7 @@ void main() {
       token: 'token-1',
       scopeType: ChatScopeType.channel,
       channelId: 'ch-1',
-      router: ChatRouter.defaultRoute,
+      router: ChatRouter.local,
       instructions: 'channel-level instructions text',
     );
   });

--- a/apps/mobile_chat_app/test/chat_topology_and_task_protocol_test.dart
+++ b/apps/mobile_chat_app/test/chat_topology_and_task_protocol_test.dart
@@ -19,11 +19,13 @@ void main() {
   });
 
   test('parses router and scope type api values', () {
-    expect(chatRouterFromApi('openclaw'), ChatRouter.openclaw);
-    expect(chatRouterFromApi('default'), ChatRouter.defaultRoute);
+    expect(chatRouterFromApi('plugin'), ChatRouter.plugin);
+    expect(chatRouterFromApi('openclaw'), ChatRouter.plugin);
+    expect(chatRouterFromApi('local'), ChatRouter.local);
+    expect(chatRouterFromApi('default'), ChatRouter.local);
     expect(chatScopeTypeFromApi('channel'), ChatScopeType.channel);
     expect(chatScopeTypeFromApi('thread'), ChatScopeType.thread);
-    expect(ChatRouter.openclaw.apiValue, 'openclaw');
+    expect(ChatRouter.plugin.apiValue, 'plugin');
     expect(ChatScopeType.thread.apiValue, 'thread');
   });
 
@@ -132,7 +134,9 @@ void main() {
       expect(sorted.map((c) => c.id), ['b', 'c', 'a']);
     });
 
-    test('channels with equal last-message time are ordered deterministically by id', () {
+    test(
+        'channels with equal last-message time are ordered deterministically by id',
+        () {
       final sorted = sortChannelsByLastMessageAt(
         [chC, chA, chB],
         {chA.id: t1, chB.id: t1, chC.id: t1},

--- a/apps/node_backend/src/db/migrations/009_create_chat_scope_settings.sql
+++ b/apps/node_backend/src/db/migrations/009_create_chat_scope_settings.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS chat_scope_settings (
   scope_type VARCHAR(16) NOT NULL CHECK (scope_type IN ('channel', 'thread')),
   channel_id VARCHAR(255) NOT NULL,
   thread_id VARCHAR(255) NOT NULL DEFAULT '',
-  router VARCHAR(32) NOT NULL CHECK (router IN ('default', 'openclaw')),
+  router VARCHAR(32) NOT NULL CHECK (router IN ('local', 'plugin')),
   created_at TIMESTAMP DEFAULT NOW(),
   updated_at TIMESTAMP DEFAULT NOW(),
   CHECK (

--- a/apps/node_backend/src/db/migrations/014_rename_chat_router_values.sql
+++ b/apps/node_backend/src/db/migrations/014_rename_chat_router_values.sql
@@ -1,0 +1,65 @@
+-- Migration: Rename chat router values to dispatch strategies
+-- Description: Normalize chat_scope_settings.router from platform-specific values to dispatch strategy values.
+
+CREATE TABLE chat_scope_settings_router_migration (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  scope_type VARCHAR(16) NOT NULL CHECK (scope_type IN ('channel', 'thread')),
+  channel_id VARCHAR(255) NOT NULL,
+  thread_id VARCHAR(255) NOT NULL DEFAULT '',
+  router VARCHAR(32) NOT NULL CHECK (router IN ('local', 'plugin')),
+  node_id VARCHAR(64),
+  instructions TEXT,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  CHECK (
+    (scope_type = 'channel' AND thread_id = '') OR
+    (scope_type = 'thread' AND thread_id <> '')
+  ),
+  UNIQUE (user_id, scope_type, channel_id, thread_id)
+);
+
+INSERT INTO chat_scope_settings_router_migration (
+  id,
+  user_id,
+  scope_type,
+  channel_id,
+  thread_id,
+  router,
+  node_id,
+  instructions,
+  created_at,
+  updated_at
+)
+SELECT
+  id,
+  user_id,
+  scope_type,
+  channel_id,
+  thread_id,
+  CASE
+    WHEN router = 'openclaw' THEN 'plugin'
+    WHEN router = 'plugin' THEN 'plugin'
+    ELSE 'local'
+  END,
+  node_id,
+  instructions,
+  created_at,
+  updated_at
+FROM chat_scope_settings;
+
+DROP TABLE chat_scope_settings;
+
+ALTER TABLE chat_scope_settings_router_migration
+  RENAME TO chat_scope_settings;
+
+CREATE INDEX IF NOT EXISTS idx_chat_scope_settings_user_scope
+  ON chat_scope_settings(user_id, channel_id, scope_type, thread_id);
+
+CREATE INDEX IF NOT EXISTS idx_chat_scope_settings_user_scope_node
+  ON chat_scope_settings(user_id, channel_id, scope_type, thread_id, node_id);
+
+CREATE TRIGGER update_chat_scope_settings_updated_at
+  BEFORE UPDATE ON chat_scope_settings
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();

--- a/apps/node_backend/src/routes/chat.test.ts
+++ b/apps/node_backend/src/routes/chat.test.ts
@@ -250,6 +250,8 @@ describe("chat routes", () => {
           targetNodeId: "node-default",
           targetNodeName: "openclaw 1",
           targetPluginId: "plugin_local_main",
+          targetSourcePlatform: "openclaw",
+          resolvedRouteKind: "platform_openclaw",
           pendingAssistantMessageId: "msg-assistant-1",
         }),
       }),

--- a/apps/node_backend/src/routes/chat.test.ts
+++ b/apps/node_backend/src/routes/chat.test.ts
@@ -17,6 +17,7 @@ const {
   listUserScopesMock,
   listChatScopeSettingsMock,
   resolveChatScopeRoutingMock,
+  resolveScopeInstructionsMock,
   upsertChatScopeSettingMock,
   deleteChatScopeSettingMock,
   listChatChannelNamesMock,
@@ -47,6 +48,10 @@ const {
       nodeId: null,
     }),
   ),
+  resolveScopeInstructionsMock: vi.fn(async () => ({
+    channelInstructions: null,
+    threadInstructions: null,
+  })),
   upsertChatScopeSettingMock: vi.fn(async () => ({
     scopeType: "channel",
     channelId: "default",
@@ -96,9 +101,15 @@ vi.mock("../services/chatAsyncTransportService.js", () => ({
 vi.mock("../services/chatRouterService.js", () => ({
   CHAT_ROUTER_DEFAULT: "default",
   CHAT_ROUTER_OPENCLAW: "openclaw",
+  builtinDefaultNodeRef: () => ({
+    nodeId: "node_builtin_default",
+    nodeName: "Bricks Default",
+    sourcePlatform: "builtin",
+  }),
   deleteChatScopeSetting: deleteChatScopeSettingMock,
   listChatScopeSettings: listChatScopeSettingsMock,
   resolveChatScopeRouting: resolveChatScopeRoutingMock,
+  resolveScopeInstructions: resolveScopeInstructionsMock,
   upsertChatScopeSetting: upsertChatScopeSettingMock,
 }));
 
@@ -177,6 +188,11 @@ describe("chat routes", () => {
       nodeId: null,
     });
     upsertChatScopeSettingMock.mockClear();
+    resolveScopeInstructionsMock.mockReset();
+    resolveScopeInstructionsMock.mockResolvedValue({
+      channelInstructions: null,
+      threadInstructions: null,
+    });
     deleteChatScopeSettingMock.mockClear();
     listChatChannelNamesMock.mockClear();
     upsertChatChannelNameMock.mockClear();
@@ -248,7 +264,7 @@ describe("chat routes", () => {
         taskState: "dispatched",
         content: "",
         metadata: expect.objectContaining({
-          agentName: "OpenClaw",
+          agentName: "openclaw 1",
           dispatchPlaceholder: true,
           source: "backend.respond.openclaw",
         }),
@@ -283,19 +299,13 @@ describe("chat routes", () => {
         messageId: "msg-user-fallback-1",
         metadata: expect.objectContaining({
           source: "backend.respond",
+          targetNodeId: "node_builtin_default",
+          targetNodeName: "Bricks Default",
+          targetSourcePlatform: "builtin",
+          resolvedRouteKind: "builtin_default",
         }),
       }),
     ]);
-    expect(upsertMessagesMock).not.toHaveBeenCalledWith(
-      "user-123",
-      expect.arrayContaining([
-        expect.objectContaining({
-          metadata: expect.objectContaining({
-            targetNodeId: expect.anything(),
-          }),
-        }),
-      ]),
-    );
 
     await new Promise<void>((resolve) => {
       setTimeout(() => resolve(), 0);
@@ -341,6 +351,10 @@ describe("chat routes", () => {
         taskState: "accepted",
         metadata: expect.objectContaining({
           source: "backend.respond",
+          targetNodeId: "node_builtin_default",
+          targetNodeName: "Bricks Default",
+          targetSourcePlatform: "builtin",
+          resolvedRouteKind: "builtin_default",
         }),
       }),
     ]);

--- a/apps/node_backend/src/routes/chat.test.ts
+++ b/apps/node_backend/src/routes/chat.test.ts
@@ -25,6 +25,7 @@ const {
   deleteChatChannelNameMock,
   streamWithUserConfigMock,
   getPlatformNodeByNodeIdMock,
+  listPlatformNodesMock,
 } = vi.hoisted(() => ({
   acceptTaskMock: vi.fn(async () => ({
     taskId: "task-1",
@@ -43,8 +44,8 @@ const {
   listUserScopesMock: vi.fn(async () => []),
   listChatScopeSettingsMock: vi.fn(async () => []),
   resolveChatScopeRoutingMock: vi.fn(
-    async (): Promise<{ router: "default" | "openclaw"; nodeId: string | null }> => ({
-      router: "default",
+    async (): Promise<{ router: "local" | "plugin"; nodeId: string | null }> => ({
+      router: "local",
       nodeId: null,
     }),
   ),
@@ -56,7 +57,7 @@ const {
     scopeType: "channel",
     channelId: "default",
     threadId: null,
-    router: "openclaw",
+    router: "plugin",
     nodeId: "node-default",
     createdAt: "2026-04-17T07:00:00.000Z",
     updatedAt: "2026-04-17T07:00:00.000Z",
@@ -88,6 +89,15 @@ const {
       pluginId: nodeId === "node-2" ? "plugin_node_2" : "plugin_local_main",
     }),
   ),
+  listPlatformNodesMock: vi.fn(async () => [
+    {
+      nodeId: "node-default",
+      displayName: "openclaw 1",
+      pluginId: "plugin_local_main",
+      createdAt: "2026-04-17T07:00:00.000Z",
+      updatedAt: "2026-04-17T07:00:00.000Z",
+    },
+  ]),
 }));
 
 vi.mock("../services/chatAsyncTransportService.js", () => ({
@@ -99,13 +109,17 @@ vi.mock("../services/chatAsyncTransportService.js", () => ({
 }));
 
 vi.mock("../services/chatRouterService.js", () => ({
-  CHAT_ROUTER_DEFAULT: "default",
-  CHAT_ROUTER_OPENCLAW: "openclaw",
+  CHAT_ROUTER_LOCAL: "local",
+  CHAT_ROUTER_PLUGIN: "plugin",
   builtinDefaultNodeRef: () => ({
     nodeId: "node_builtin_default",
     nodeName: "Bricks Default",
-    sourcePlatform: "builtin",
   }),
+  normalizeChatRouterValue: (value: string | null | undefined) => {
+    if (value === "local" || value === "default") return "local";
+    if (value === "plugin" || value === "openclaw") return "plugin";
+    return null;
+  },
   deleteChatScopeSetting: deleteChatScopeSettingMock,
   listChatScopeSettings: listChatScopeSettingsMock,
   resolveChatScopeRouting: resolveChatScopeRoutingMock,
@@ -115,6 +129,7 @@ vi.mock("../services/chatRouterService.js", () => ({
 
 vi.mock("../services/platformNodeService.js", () => ({
   getPlatformNodeByNodeId: getPlatformNodeByNodeIdMock,
+  listPlatformNodes: listPlatformNodesMock,
 }));
 
 vi.mock("../services/chatChannelNameService.js", () => ({
@@ -184,7 +199,7 @@ describe("chat routes", () => {
     listChatScopeSettingsMock.mockClear();
     resolveChatScopeRoutingMock.mockReset();
     resolveChatScopeRoutingMock.mockResolvedValue({
-      router: "default",
+      router: "local",
       nodeId: null,
     });
     upsertChatScopeSettingMock.mockClear();
@@ -206,11 +221,12 @@ describe("chat routes", () => {
         pluginId: nodeId === "node-2" ? "plugin_node_2" : "plugin_local_main",
       }),
     );
+    listPlatformNodesMock.mockClear();
   });
 
-  it("routes OpenClaw scopes to async pending dispatch", async () => {
+  it("routes plugin scopes to async pending dispatch", async () => {
     resolveChatScopeRoutingMock.mockResolvedValueOnce({
-      router: "openclaw",
+      router: "plugin",
       nodeId: "node-default",
     });
 
@@ -250,8 +266,6 @@ describe("chat routes", () => {
           targetNodeId: "node-default",
           targetNodeName: "openclaw 1",
           targetPluginId: "plugin_local_main",
-          targetSourcePlatform: "openclaw",
-          resolvedRouteKind: "platform_openclaw",
           pendingAssistantMessageId: "msg-assistant-1",
         }),
       }),
@@ -274,9 +288,9 @@ describe("chat routes", () => {
     ]);
   });
 
-  it("falls back to Bricks Default when a saved OpenClaw node no longer exists", async () => {
+  it("falls back to Bricks Default when a saved plugin node no longer exists", async () => {
     resolveChatScopeRoutingMock.mockResolvedValueOnce({
-      router: "openclaw",
+      router: "plugin",
       nodeId: "deleted-node",
     });
     getPlatformNodeByNodeIdMock.mockResolvedValueOnce(null);
@@ -303,8 +317,7 @@ describe("chat routes", () => {
           source: "backend.respond",
           targetNodeId: "node_builtin_default",
           targetNodeName: "Bricks Default",
-          targetSourcePlatform: "builtin",
-          resolvedRouteKind: "builtin_default",
+          targetPluginId: null,
         }),
       }),
     ]);
@@ -317,7 +330,7 @@ describe("chat routes", () => {
 
   it("routes default scopes to async accepted and generates reply in background", async () => {
     resolveChatScopeRoutingMock.mockResolvedValueOnce({
-      router: "default",
+      router: "local",
       nodeId: null,
     });
 
@@ -355,8 +368,7 @@ describe("chat routes", () => {
           source: "backend.respond",
           targetNodeId: "node_builtin_default",
           targetNodeName: "Bricks Default",
-          targetSourcePlatform: "builtin",
-          resolvedRouteKind: "builtin_default",
+          targetPluginId: null,
         }),
       }),
     ]);
@@ -394,7 +406,7 @@ describe("chat routes", () => {
 
   it("rejects respond payload when maxTokens exceeds upper bound", async () => {
     resolveChatScopeRoutingMock.mockResolvedValueOnce({
-      router: "default",
+      router: "local",
       nodeId: null,
     });
 
@@ -419,9 +431,9 @@ describe("chat routes", () => {
     expect(streamWithUserConfigMock).not.toHaveBeenCalled();
   });
 
-  it("prefers an explicitly requested OpenClaw node", async () => {
+  it("prefers an explicitly requested plugin node", async () => {
     resolveChatScopeRoutingMock.mockResolvedValueOnce({
-      router: "openclaw",
+      router: "plugin",
       nodeId: "node-default",
     });
     getPlatformNodeByNodeIdMock.mockResolvedValueOnce({
@@ -478,14 +490,62 @@ describe("chat routes", () => {
     });
   });
 
-  it("persists nodeId when saving an OpenClaw scope setting", async () => {
+  it("lists scope settings with resolved target metadata", async () => {
+    listChatScopeSettingsMock.mockResolvedValueOnce([
+      {
+        scopeType: "channel",
+        channelId: "default",
+        threadId: null,
+        router: "plugin",
+        nodeId: "node-default",
+        instructions: null,
+        createdAt: "2026-04-17T07:00:00.000Z",
+        updatedAt: "2026-04-17T07:00:00.000Z",
+      },
+      {
+        scopeType: "thread",
+        channelId: "default",
+        threadId: "main",
+        router: "local",
+        nodeId: null,
+        instructions: null,
+        createdAt: "2026-04-17T07:00:00.000Z",
+        updatedAt: "2026-04-17T07:00:00.000Z",
+      },
+    ]);
+
+    const response = await fetch(`${baseUrl}/api/chat/scope-settings`);
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      settings?: Array<Record<string, unknown>>;
+    };
+    expect(body.settings?.[0]).toEqual(
+      expect.objectContaining({
+        router: "plugin",
+        resolvedTargetNodeId: "node-default",
+        resolvedTargetNodeName: "openclaw 1",
+        resolvedTargetPluginId: "plugin_local_main",
+      }),
+    );
+    expect(body.settings?.[1]).toEqual(
+      expect.objectContaining({
+        router: "local",
+        resolvedTargetNodeId: "node_builtin_default",
+        resolvedTargetNodeName: "Bricks Default",
+        resolvedTargetPluginId: null,
+      }),
+    );
+  });
+
+  it("persists nodeId when saving a plugin scope setting", async () => {
     const response = await fetch(`${baseUrl}/api/chat/scope-settings`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         scopeType: "channel",
         channelId: "default",
-        router: "openclaw",
+        router: "plugin",
         nodeId: "node-2",
       }),
     });
@@ -496,19 +556,19 @@ describe("chat routes", () => {
       scopeType: "channel",
       channelId: "default",
       threadId: null,
-      router: "openclaw",
+      router: "plugin",
       nodeId: "node-2",
     });
   });
 
-  it("rejects saving an OpenClaw scope setting without nodeId", async () => {
+  it("rejects saving a plugin scope setting without nodeId", async () => {
     const response = await fetch(`${baseUrl}/api/chat/scope-settings`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         scopeType: "channel",
         channelId: "default",
-        router: "openclaw",
+        router: "plugin",
       }),
     });
 
@@ -597,7 +657,7 @@ describe("chat routes", () => {
 
   it("rate limits respond requests per user and session after 120 requests per minute", async () => {
     resolveChatScopeRoutingMock.mockResolvedValue({
-      router: "openclaw",
+      router: "plugin",
       nodeId: "node-default",
     });
 

--- a/apps/node_backend/src/routes/chat.ts
+++ b/apps/node_backend/src/routes/chat.ts
@@ -11,6 +11,7 @@ import {
   type MessageUpsertInput,
 } from "../services/chatAsyncTransportService.js";
 import {
+  builtinDefaultNodeRef,
   CHAT_ROUTER_DEFAULT,
   CHAT_ROUTER_OPENCLAW,
   deleteChatScopeSetting,
@@ -526,20 +527,19 @@ router.post(
       const acceptedTaskId = acceptedTask.taskId;
       const acceptedSessionId = acceptedTask.sessionId;
 
+      const defaultNode = builtinDefaultNodeRef();
+      const isOpenClawRoute = resolvedRouter === CHAT_ROUTER_OPENCLAW;
       const userMessageMetadata = {
         resolvedBotId: input.resolvedBotId,
         resolvedSkillId: input.resolvedSkillId,
-        source:
-          resolvedRouter === CHAT_ROUTER_OPENCLAW
-            ? "backend.respond.openclaw"
-            : "backend.respond",
-        targetNodeId: targetNode?.nodeId,
-        targetNodeName: targetNode?.displayName,
-        targetPluginId: targetNode?.pluginId,
+        source: isOpenClawRoute ? "backend.respond.openclaw" : "backend.respond",
+        targetNodeId: isOpenClawRoute ? targetNode?.nodeId : defaultNode.nodeId,
+        targetNodeName: isOpenClawRoute ? targetNode?.displayName : defaultNode.nodeName,
+        targetPluginId: isOpenClawRoute ? targetNode?.pluginId : null,
+        targetSourcePlatform: isOpenClawRoute ? "openclaw" : defaultNode.sourcePlatform,
+        resolvedRouteKind: isOpenClawRoute ? "platform_openclaw" : "builtin_default",
         pendingAssistantMessageId:
-          resolvedRouter === CHAT_ROUTER_OPENCLAW
-            ? assistantMessageId
-            : undefined,
+          isOpenClawRoute ? assistantMessageId : undefined,
       };
 
       if (resolvedRouter === CHAT_ROUTER_OPENCLAW) {

--- a/apps/node_backend/src/routes/chat.ts
+++ b/apps/node_backend/src/routes/chat.ts
@@ -536,7 +536,7 @@ router.post(
         targetNodeId: isOpenClawRoute ? targetNode?.nodeId : defaultNode.nodeId,
         targetNodeName: isOpenClawRoute ? targetNode?.displayName : defaultNode.nodeName,
         targetPluginId: isOpenClawRoute ? targetNode?.pluginId : null,
-        targetSourcePlatform: isOpenClawRoute ? "openclaw" : defaultNode.sourcePlatform,
+        targetSourcePlatform: isOpenClawRoute ? CHAT_ROUTER_OPENCLAW : defaultNode.sourcePlatform,
         resolvedRouteKind: isOpenClawRoute ? "platform_openclaw" : "builtin_default",
         pendingAssistantMessageId:
           isOpenClawRoute ? assistantMessageId : undefined,

--- a/apps/node_backend/src/routes/chat.ts
+++ b/apps/node_backend/src/routes/chat.ts
@@ -12,10 +12,11 @@ import {
 } from "../services/chatAsyncTransportService.js";
 import {
   builtinDefaultNodeRef,
-  CHAT_ROUTER_DEFAULT,
-  CHAT_ROUTER_OPENCLAW,
+  CHAT_ROUTER_LOCAL,
+  CHAT_ROUTER_PLUGIN,
   deleteChatScopeSetting,
   listChatScopeSettings,
+  normalizeChatRouterValue,
   resolveChatScopeRouting,
   resolveScopeInstructions,
   type ChatRouter,
@@ -29,6 +30,7 @@ import {
 } from "../services/chatChannelNameService.js";
 import {
   getPlatformNodeByNodeId,
+  listPlatformNodes,
 } from "../services/platformNodeService.js";
 import { streamWithUserConfig } from "../llm/llm_service.js";
 import type { LlmProvider } from "../llm/types.js";
@@ -145,10 +147,7 @@ function parseProvider(value: unknown): LlmProvider | undefined {
 }
 
 function parseChatRouter(value: unknown): ChatRouter | null {
-  if (value === CHAT_ROUTER_DEFAULT || value === CHAT_ROUTER_OPENCLAW) {
-    return value;
-  }
-  return null;
+  return typeof value === "string" ? normalizeChatRouterValue(value) : null;
 }
 
 function parseScopeType(value: unknown): ChatScopeType | null {
@@ -499,7 +498,7 @@ router.post(
       });
       let resolvedRouter = resolvedRouting.router;
       let targetNode = null;
-      if (resolvedRouter === CHAT_ROUTER_OPENCLAW) {
+      if (resolvedRouter === CHAT_ROUTER_PLUGIN) {
         if (requestedNodeId) {
           targetNode = await getPlatformNodeByNodeId(userId, requestedNodeId);
           if (!targetNode) {
@@ -511,13 +510,13 @@ router.post(
         } else if (resolvedRouting.nodeId) {
           targetNode = await getPlatformNodeByNodeId(userId, resolvedRouting.nodeId);
           if (!targetNode) {
-            resolvedRouter = CHAT_ROUTER_DEFAULT;
+            resolvedRouter = CHAT_ROUTER_LOCAL;
           }
         } else {
-          resolvedRouter = CHAT_ROUTER_DEFAULT;
+          resolvedRouter = CHAT_ROUTER_LOCAL;
         }
       }
-      if (resolvedRouter === CHAT_ROUTER_OPENCLAW && !targetNode) {
+      if (resolvedRouter === CHAT_ROUTER_PLUGIN && !targetNode) {
         res.status(400).json({
           error: "Invalid payload: nodeId must reference an existing platform node",
         });
@@ -528,21 +527,19 @@ router.post(
       const acceptedSessionId = acceptedTask.sessionId;
 
       const defaultNode = builtinDefaultNodeRef();
-      const isOpenClawRoute = resolvedRouter === CHAT_ROUTER_OPENCLAW;
+      const isPluginRoute = resolvedRouter === CHAT_ROUTER_PLUGIN;
       const userMessageMetadata = {
         resolvedBotId: input.resolvedBotId,
         resolvedSkillId: input.resolvedSkillId,
-        source: isOpenClawRoute ? "backend.respond.openclaw" : "backend.respond",
-        targetNodeId: isOpenClawRoute ? targetNode?.nodeId : defaultNode.nodeId,
-        targetNodeName: isOpenClawRoute ? targetNode?.displayName : defaultNode.nodeName,
-        targetPluginId: isOpenClawRoute ? targetNode?.pluginId : null,
-        targetSourcePlatform: isOpenClawRoute ? CHAT_ROUTER_OPENCLAW : defaultNode.sourcePlatform,
-        resolvedRouteKind: isOpenClawRoute ? "platform_openclaw" : "builtin_default",
+        source: isPluginRoute ? "backend.respond.openclaw" : "backend.respond",
+        targetNodeId: isPluginRoute ? targetNode?.nodeId : defaultNode.nodeId,
+        targetNodeName: isPluginRoute ? targetNode?.displayName : defaultNode.nodeName,
+        targetPluginId: isPluginRoute ? targetNode?.pluginId : null,
         pendingAssistantMessageId:
-          isOpenClawRoute ? assistantMessageId : undefined,
+          isPluginRoute ? assistantMessageId : undefined,
       };
 
-      if (resolvedRouter === CHAT_ROUTER_OPENCLAW) {
+      if (resolvedRouter === CHAT_ROUTER_PLUGIN) {
         const persisted = await upsertMessages(userId, [
           {
             messageId: userMessageId,
@@ -914,7 +911,22 @@ router.get("/scope-settings", async (req: AuthRequest, res: Response) => {
     }
 
     const settings = await listChatScopeSettings(userId);
-    res.json({ settings });
+    const platformNodes = await listPlatformNodes(userId);
+    const platformNodeById = new Map(platformNodes.map((node) => [node.nodeId, node]));
+    const defaultNode = builtinDefaultNodeRef();
+    const enrichedSettings = settings.map((setting) => {
+      const platformNode =
+        setting.router === CHAT_ROUTER_PLUGIN && setting.nodeId
+          ? platformNodeById.get(setting.nodeId) ?? null
+          : null;
+      return {
+        ...setting,
+        resolvedTargetNodeId: platformNode?.nodeId ?? defaultNode.nodeId,
+        resolvedTargetNodeName: platformNode?.displayName ?? defaultNode.nodeName,
+        resolvedTargetPluginId: platformNode?.pluginId ?? null,
+      };
+    });
+    res.json({ settings: enrichedSettings });
   } catch (error) {
     console.error("List chat scope settings error:", error);
     res.status(500).json({ error: "Internal server error" });
@@ -1024,15 +1036,15 @@ router.put("/scope-settings", async (req: AuthRequest, res: Response) => {
 
     if (body.router !== null && body.router !== undefined && !routerValue) {
       res.status(400).json({
-        error: 'Invalid payload: router must be "default", "openclaw", or null',
+        error: 'Invalid payload: router must be "local", "plugin", "default", "openclaw", or null',
       });
       return;
     }
 
-    if (routerValue === CHAT_ROUTER_OPENCLAW) {
+    if (routerValue === CHAT_ROUTER_PLUGIN) {
       if (!nodeId) {
         res.status(400).json({
-          error: "Invalid payload: nodeId is required for openclaw router",
+          error: "Invalid payload: nodeId is required for plugin router",
         });
         return;
       }
@@ -1060,7 +1072,7 @@ router.put("/scope-settings", async (req: AuthRequest, res: Response) => {
       channelId,
       threadId,
       router: routerValue,
-      nodeId: routerValue === CHAT_ROUTER_OPENCLAW ? nodeId : null,
+      nodeId: routerValue === CHAT_ROUTER_PLUGIN ? nodeId : null,
       instructions: instructionsRaw,
     });
     res.json({ setting });

--- a/apps/node_backend/src/routes/config.test.ts
+++ b/apps/node_backend/src/routes/config.test.ts
@@ -83,6 +83,13 @@ vi.mock('../services/platformNodeService.js', () => ({
   getPlatformNodeByPluginId: getPlatformNodeByPluginIdMock,
 }));
 
+vi.mock('../services/chatRouterService.js', () => ({
+  builtinDefaultNodeRef: () => ({
+    nodeId: 'node_builtin_default',
+    nodeName: 'Bricks Default',
+  }),
+}));
+
 vi.mock('../services/openclawAgentRuntimeService.js', () => ({
   listOpenClawRuntimeAgents: listOpenClawRuntimeAgentsMock,
 }));
@@ -133,8 +140,18 @@ describe('config node routes', () => {
   it('lists nodes', async () => {
     const response = await fetch(`${baseUrl}/api/config/nodes`);
     expect(response.status).toBe(200);
-    const body = (await response.json()) as { nodes?: Array<{ displayName: string }> };
+    const body = (await response.json()) as {
+      nodes?: Array<{ displayName: string }>;
+      builtinTargets?: Array<{ displayName: string; router: string; readOnly: boolean }>;
+    };
     expect(body.nodes?.[0]?.displayName).toBe('openclaw 1');
+    expect(body.builtinTargets?.[0]).toEqual(
+      expect.objectContaining({
+        displayName: 'Bricks Default',
+        router: 'local',
+        readOnly: true,
+      }),
+    );
   });
 
   it('creates nodes', async () => {

--- a/apps/node_backend/src/routes/config.ts
+++ b/apps/node_backend/src/routes/config.ts
@@ -17,6 +17,7 @@ import {
   listPlatformNodes,
   renamePlatformNode,
 } from '../services/platformNodeService.js';
+import { builtinDefaultNodeRef } from '../services/chatRouterService.js';
 import { listOpenClawRuntimeAgents } from '../services/openclawAgentRuntimeService.js';
 
 const router = express.Router();
@@ -247,7 +248,18 @@ router.get('/nodes', async (req: AuthRequest, res: Response) => {
     }
     await ensureDefaultPlatformNode(userId);
     const nodes = await listPlatformNodes(userId);
-    res.json({ nodes });
+    const builtinDefaultNode = builtinDefaultNodeRef();
+    res.json({
+      nodes,
+      builtinTargets: [
+        {
+          nodeId: builtinDefaultNode.nodeId,
+          displayName: builtinDefaultNode.nodeName,
+          router: 'local',
+          readOnly: true,
+        },
+      ],
+    });
   } catch (error) {
     console.error('List platform nodes error:', error);
     res.status(500).json({ error: 'Internal server error' });

--- a/apps/node_backend/src/services/chatRouterService.test.ts
+++ b/apps/node_backend/src/services/chatRouterService.test.ts
@@ -11,10 +11,11 @@ vi.mock('../db/index.js', () => ({
 }));
 
 import {
-  CHAT_ROUTER_DEFAULT,
+  CHAT_ROUTER_LOCAL,
   buildChatSessionId,
   deleteChatScopeSetting,
   listChatScopeSettings,
+  normalizeChatRouterValue,
   normalizeChatThreadId,
   resolveChatScopeRouting,
   resolveChatRouter,
@@ -32,6 +33,14 @@ describe('chatRouterService', () => {
     expect(normalizeChatThreadId('')).toBe('main');
     expect(buildChatSessionId('channel-a', null)).toBe('session:channel-a:main');
     expect(buildChatSessionId('channel-a', 'sub-1')).toBe('session:channel-a:sub-1');
+  });
+
+  it('normalizes legacy router values to dispatch strategy values', () => {
+    expect(normalizeChatRouterValue('default')).toBe('local');
+    expect(normalizeChatRouterValue('openclaw')).toBe('plugin');
+    expect(normalizeChatRouterValue('local')).toBe('local');
+    expect(normalizeChatRouterValue('plugin')).toBe('plugin');
+    expect(normalizeChatRouterValue('unknown')).toBeNull();
   });
 
   it('lists scope settings with nullable channel-level thread id', async () => {
@@ -58,7 +67,7 @@ describe('chatRouterService', () => {
         scopeType: 'channel',
         channelId: 'default',
         threadId: null,
-        router: 'openclaw',
+        router: 'plugin',
         nodeId: 'node_default',
         instructions: null,
         createdAt: '2026-04-17T07:00:00.000Z',
@@ -74,7 +83,7 @@ describe('chatRouterService', () => {
           scope_type: 'thread',
           channel_id: 'default',
           thread_id: 'main',
-          router: 'default',
+          router: 'local',
           node_id: 'node_default',
           instructions: null,
           created_at: '2026-04-17T07:00:00.000Z',
@@ -88,7 +97,7 @@ describe('chatRouterService', () => {
       scopeType: 'thread',
       channelId: 'default',
       threadId: null,
-      router: 'default',
+      router: 'local',
       nodeId: 'node_default',
     });
 
@@ -97,7 +106,7 @@ describe('chatRouterService', () => {
     expect(setting.instructions).toBeNull();
     expect(queryMock).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO chat_scope_settings'),
-      ['u-1', 'thread', 'default', 'main', 'default', 'node_default', null],
+      ['u-1', 'thread', 'default', 'main', 'local', 'node_default', null],
     );
   });
 
@@ -125,7 +134,7 @@ describe('chatRouterService', () => {
       threadId: 'main',
     });
 
-    expect(router).toBe(CHAT_ROUTER_DEFAULT);
+    expect(router).toBe(CHAT_ROUTER_LOCAL);
   });
 
   it('resolves router and node id together for scope routing', async () => {
@@ -140,7 +149,7 @@ describe('chatRouterService', () => {
     });
 
     expect(routing).toEqual({
-      router: 'openclaw',
+      router: 'plugin',
       nodeId: 'node_default',
     });
   });

--- a/apps/node_backend/src/services/chatRouterService.ts
+++ b/apps/node_backend/src/services/chatRouterService.ts
@@ -2,6 +2,9 @@ import pool from '../db/index.js';
 
 export const CHAT_ROUTER_DEFAULT = 'default';
 export const CHAT_ROUTER_OPENCLAW = 'openclaw';
+export const BUILTIN_DEFAULT_NODE_ID = 'node_builtin_default';
+export const BUILTIN_DEFAULT_NODE_NAME = 'Bricks Default';
+export const BUILTIN_DEFAULT_SOURCE_PLATFORM = 'builtin';
 
 export type ChatRouter = typeof CHAT_ROUTER_DEFAULT | typeof CHAT_ROUTER_OPENCLAW;
 export type ChatScopeType = 'channel' | 'thread';
@@ -43,6 +46,20 @@ export interface ChatScopeSettingInput extends ChatScopeSelector {
 export interface ResolvedChatScopeRouting {
   router: ChatRouter;
   nodeId: string | null;
+}
+
+export interface BuiltinDefaultNodeRef {
+  nodeId: string;
+  nodeName: string;
+  sourcePlatform: string;
+}
+
+export function builtinDefaultNodeRef(): BuiltinDefaultNodeRef {
+  return {
+    nodeId: BUILTIN_DEFAULT_NODE_ID,
+    nodeName: BUILTIN_DEFAULT_NODE_NAME,
+    sourcePlatform: BUILTIN_DEFAULT_SOURCE_PLATFORM,
+  };
 }
 
 export function normalizeChatThreadId(threadId: string | null | undefined): string {

--- a/apps/node_backend/src/services/chatRouterService.ts
+++ b/apps/node_backend/src/services/chatRouterService.ts
@@ -2,11 +2,12 @@ import pool from '../db/index.js';
 
 export const CHAT_ROUTER_DEFAULT = 'default';
 export const CHAT_ROUTER_OPENCLAW = 'openclaw';
+export const CHAT_ROUTER_LOCAL = 'local';
+export const CHAT_ROUTER_PLUGIN = 'plugin';
 export const BUILTIN_DEFAULT_NODE_ID = 'node_builtin_default';
 export const BUILTIN_DEFAULT_NODE_NAME = 'Bricks Default';
-export const BUILTIN_DEFAULT_SOURCE_PLATFORM = 'builtin';
 
-export type ChatRouter = typeof CHAT_ROUTER_DEFAULT | typeof CHAT_ROUTER_OPENCLAW;
+export type ChatRouter = typeof CHAT_ROUTER_LOCAL | typeof CHAT_ROUTER_PLUGIN;
 export type ChatScopeType = 'channel' | 'thread';
 
 interface ChatScopeSettingRow {
@@ -51,15 +52,26 @@ export interface ResolvedChatScopeRouting {
 export interface BuiltinDefaultNodeRef {
   nodeId: string;
   nodeName: string;
-  sourcePlatform: string;
 }
 
 export function builtinDefaultNodeRef(): BuiltinDefaultNodeRef {
   return {
     nodeId: BUILTIN_DEFAULT_NODE_ID,
     nodeName: BUILTIN_DEFAULT_NODE_NAME,
-    sourcePlatform: BUILTIN_DEFAULT_SOURCE_PLATFORM,
   };
+}
+
+export function normalizeChatRouterValue(value: string | null | undefined): ChatRouter | null {
+  switch (value) {
+    case CHAT_ROUTER_LOCAL:
+    case CHAT_ROUTER_DEFAULT:
+      return CHAT_ROUTER_LOCAL;
+    case CHAT_ROUTER_PLUGIN:
+    case CHAT_ROUTER_OPENCLAW:
+      return CHAT_ROUTER_PLUGIN;
+    default:
+      return null;
+  }
 }
 
 export function normalizeChatThreadId(threadId: string | null | undefined): string {
@@ -77,7 +89,7 @@ function toDto(row: ChatScopeSettingRow): ChatScopeSetting {
     scopeType: row.scope_type,
     channelId: row.channel_id,
     threadId: row.scope_type === 'thread' ? row.thread_id : null,
-    router: row.router,
+    router: normalizeChatRouterValue(row.router) ?? CHAT_ROUTER_LOCAL,
     nodeId: row.node_id,
     instructions: row.instructions ?? null,
     createdAt: row.created_at,
@@ -107,6 +119,7 @@ export async function upsertChatScopeSetting(
   const threadId = toStorageThreadId(input.scopeType, input.threadId);
   const nodeId = input.nodeId?.trim() || null;
   const instructions = input.instructions?.trim() || null;
+  const router = normalizeChatRouterValue(input.router) ?? CHAT_ROUTER_LOCAL;
   const result = await pool.query<ChatScopeSettingRow>(
     `INSERT INTO chat_scope_settings (
         user_id,
@@ -124,7 +137,7 @@ export async function upsertChatScopeSetting(
         instructions = EXCLUDED.instructions,
         updated_at = CURRENT_TIMESTAMP
       RETURNING scope_type, channel_id, thread_id, router, node_id, instructions, created_at, updated_at`,
-    [userId, input.scopeType, input.channelId, threadId, input.router, nodeId, instructions],
+    [userId, input.scopeType, input.channelId, threadId, router, nodeId, instructions],
   );
 
   return toDto(result.rows[0]);
@@ -176,7 +189,7 @@ export async function resolveChatScopeRouting(
   );
 
   return {
-    router: result.rows[0]?.router ?? CHAT_ROUTER_DEFAULT,
+    router: normalizeChatRouterValue(result.rows[0]?.router) ?? CHAT_ROUTER_LOCAL,
     nodeId: result.rows[0]?.node_id ?? null,
   };
 }

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: feature_map
 owner: bricks
-last_updated: 2026-05-01
+last_updated: 2026-05-06
 purpose: >
   为人类测试员和 AI 测试员提供产品功能清单与进入路径，作为回归测试与变更影响评估的入口索引。
 
@@ -39,18 +39,18 @@ products:
             route_hint: apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
         smoke_checks:
           - 发送一条消息后可以看到消息列表更新。
-          - 将路由切到 openclaw 后发送消息，在插件离线时应呈现“已发送但未完成（未读）”。
+          - 将路由切到 plugin/OpenClaw 节点后发送消息，在插件离线时应呈现“已发送但未完成（未读）”。
           - 启动并配置 openclaw 插件后再次发送，消息应完成并出现 assistant 回复。
           - 当用户拥有多个 OpenClaw 节点时，输入框左侧路由菜单应仅列出真实节点；菜单主标题显示节点名称，副标题显示 `OpenClaw`。
           - 当已保存的 OpenClaw `nodeId` 对应节点已被删除时，聊天页与发送行为应回退到 `Bricks Default`，而不是改投递到其他 OpenClaw 节点。
           - 在聊天页选择某个 OpenClaw 节点后发送消息时，仅所选节点应收到并回复；同用户其他节点不应重复消费同一条消息。
           - 从设置页新增或重命名节点后返回聊天页，路由菜单中的 OpenClaw 节点列表应刷新为最新状态。
-          - 在 openclaw 离线后切回默认路由继续发送时，历史消息应优先按服务端 seqId（不可变插入序）渲染，后到达更新不会打乱对话先后。
+          - 在 OpenClaw 插件离线后切回本地 Bricks Default 路由继续发送时，历史消息应优先按服务端 seqId（不可变插入序）渲染，后到达更新不会打乱对话先后。
           - 当多条消息 createdAt 相同（秒级碰撞）时，消息应按 seqId 稳定从旧到新渲染。
           - 当 writeSeq 因更新语义与原始对话顺序冲突时，列表仍应按 seqId 保持“先问后答”。
-          - default 与 openclaw 路由均通过 `/api/chat/respond` 先入库 user query 并返回 async accepted，再由后台异步写入 assistant 回复。
+          - local 与 plugin 路由均通过 `/api/chat/respond` 先入库 user query 并返回 async accepted，再由后台异步写入 assistant 回复。
           - 发送后 user query 仍先显示“已接受”状态；assistant 身份占位可在 SSE dispatch 占位到达时提前出现，但 assistant 正文气泡仍应等待真实内容开始到达。
-          - user query 气泡应显示两段状态：入库后先显示第一枚 ✓；AI 开始回复后显示第二枚状态，default/其他远端为第二枚 ✓，openclaw 为单色路由状态图标。
+          - user query 气泡应显示两段状态：入库后先显示第一枚 ✓；AI 开始回复后显示第二枚状态，local/其他远端为第二枚 ✓，OpenClaw plugin 为单色路由状态图标。
           - user query 的时间/线程与投递状态应显示在气泡内；长按气泡可弹出“复制/分叉（待开发）/重发（待开发）”菜单，并在底部显示 message id 与 task id。
           - 发送消息后，user query 由后端 /respond 端点统一持久化；前端不执行独立入库请求。
           - 发送消息后，最新 user 消息会定位在可见区域首条，assistant 回复显示在其后。
@@ -72,13 +72,13 @@ products:
           - 点击任一侧边栏 Agent 后应进入 Prompt 详情页，且底部应提供“修改配置”“发起对话”两个按钮。
           - 在 Prompt 详情页点击“修改配置”后，应进入 Agent 管理流程。
           - 在 Prompt 详情页点击“发起对话”后，应将该 Agent 设为当前会话 Agent。
-          - 输入框不再支持 `@agent` 文本补全；当路由为默认路由时，`@` 按钮显示在路由按钮右侧、配置按钮左侧，点击后下拉展示与侧边栏 Agents 分组一致的 Agent 列表。
+          - 输入框不再支持 `@agent` 文本补全；当路由为 local/Bricks Default 时，`@` 按钮显示在路由按钮右侧、配置按钮左侧，点击后下拉展示与侧边栏 Agents 分组一致的 Agent 列表。
           - 当路由为 OpenClaw 时，`@` 按钮同样可点击并弹出下拉菜单；菜单应展示匹配 OpenClaw node 上报的 agents，选择后将 `@agentId` 插入输入框。
           - 对话页顶部不再显示横向“参与者/Agent 概率”指示条。
           - 从输入框左下角菜单点击“信息”后可看到调试信息弹窗。
-          - 当路由为默认路由时，输入框左下角应显示配置按钮，且“模型”项副标题展示当前生效模型名。
+          - 当路由为 local/Bricks Default 时，输入框左下角应显示配置按钮，且“模型”项副标题展示当前生效模型名。
           - 当路由为 OpenClaw 时，输入框左下角应额外出现 `/` 斜杠命令按钮，选择命令后应自动填充到输入框。
-          - 未来新增的非默认且非 OpenClaw 路由在未适配前，默认不显示配置按钮。
+          - 未来新增的 plugin 平台（例如 Hermes）应复用 plugin 路由，平台差异留在 node/plugin 配置层。
           - 顶部频道名称应支持下拉切换频道，切换后分区标签与分区列表需同步刷新为目标频道的数据。
           - 频道名称右侧应内嵌分区下拉按钮（显示当前分区名+下箭头），且该菜单与频道标题左对齐，不再使用右上角三个点。
           - 分区菜单应先显示功能组（新建子区、分区改名未实现、分区存档未实现），再以分割线分隔后显示分区列表组（主区+已有子区）；菜单弹出动画应保持快速缩放+淡入。
@@ -90,7 +90,7 @@ products:
           - Markdown/code 内容块应保持 embedded/recessed surface 层级，而不是使用输入框的 elevated surface。
           - 输入框底部动作按钮默认应为白灰层级；发送按钮仅在输入非空时进入高亮激活态。
           - 输入框底部可点击且非禁用的动作按钮（路由、`/`、`@`、配置、发送）应使用一致的白色系 enabled 颜色，除非该状态刻意使用 accent。
-          - OpenClaw 路由与投递状态图标应使用单色图标，不使用彩色 emoji。
+          - OpenClaw plugin 路由与投递状态图标应使用单色图标，不使用彩色 emoji。
           - 用户消息与 assistant 消息正文应共享同一文本样式基线（字号一致）；时间/thread 等 meta 信息应统一为次级灰。
 
       - feature_id: scope_instructions_config
@@ -113,9 +113,9 @@ products:
           - Channel 标签中可编辑并保存频道指令；保存后刷新页面应恢复已保存值。
           - 在主区下打开 Section 标签，应显示"主区仅使用频道指令"的非编辑提示，且 Save 按钮在 Section 标签时应禁用。
           - 在子区下打开 Section 标签，可编辑并保存当前子区指令；保存后切换到该子区应恢复已保存值。
-          - 当频道和子区指令均已保存时，从该子区发送默认路由消息，后端应将 Agent 提示词 + 频道指令 + 子区指令合并为系统提示发送给模型。
+          - 当频道和子区指令均已保存时，从该子区发送 local/Bricks Default 路由消息，后端应将 Agent 提示词 + 频道指令 + 子区指令合并为系统提示发送给模型。
           - 清空指令后保存，刷新页面后该范围不应再贡献任何提示上下文。
-          - OpenClaw 路由下保存或发送消息，OpenClaw 路由行为不变。
+          - plugin/OpenClaw 路由下保存或发送消息，OpenClaw dispatch 行为不变。
 
       - feature_id: model_settings
         name: 模型与提供商配置
@@ -213,11 +213,12 @@ products:
           - 调用 chat 接口时返回结构化响应。
           - provider 配置缺失时给出明确错误。
           - '使用 API Key + X-Bricks-Plugin-Id 可访问 /api/v1/platform/events 并获取 nextCursor。'
-          - '使用 `/api/chat/scope-settings` 为 openclaw 路由保存 nodeId 后，再读取应返回同一 nodeId。'
+          - '使用 `/api/chat/scope-settings` 为 plugin 路由保存 nodeId 后，再读取应返回同一 nodeId；旧值 openclaw 仍应兼容解析。'
+          - '`/api/chat/scope-settings` GET 应返回 resolvedTargetNodeId/resolvedTargetNodeName/resolvedTargetPluginId，便于 UI 展示继承或回退后的有效目标。'
           - '同一用户存在多个 OpenClaw 节点时，`/api/chat/respond` 为消息写入目标节点 metadata 后，仅目标 plugin 可从 `/api/v1/platform/events` 读到该消息。'
           - '非目标 plugin 对其他 plugin 创建的 assistant message 执行 PATCH 时，应返回 403。'
           - '/api/v1/platform/events/ack 禁止 body 中传 pluginId，合法 ACK 可重复调用并返回成功。'
-          - '/api/config/nodes/:nodeId/agents?sourcePlatform=openclaw 在请求时即时执行 OpenClaw CLI 查询 agents，并用于 OpenClaw router 的 @ 下拉菜单。'
+          - '/api/config/nodes/:nodeId/agents?sourcePlatform=openclaw 在请求时即时执行 OpenClaw CLI 查询 agents，并用于 plugin 路由的 OpenClaw @ 下拉菜单。'
           - '调用 /api/chat/channel-names 可保存并读取每个用户的频道自定义名称。'
           - '使用 /api/config/nodes 创建多个节点后，不同节点的 token 应绑定不同 pluginId。'
           - '/api/v1/platform/messages 写入后，消息 metadata 应包含 nodeId/nodeName（当 pluginId 可映射到节点）。'

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: logic_map
 owner: bricks
-last_updated: 2026-05-01
+last_updated: 2026-05-06
 purpose: >
   为人类测试员、AI 测试员与 AI 工程师提供“功能 -> 代码/文档/关键词”映射，
   用于影响面分析、回归测试设计与遗留逻辑清理。
@@ -200,7 +200,7 @@ index:
       - 若 buildComposedSystemPrompt 未对空字符串做 trim/null 检查，发给模型的 system 消息可能含空段落噪音。
       - 若 _hydrateChannelInstructions/_hydrateThreadInstructions 在应用启动时未正确调用，保存值不会在刷新后恢复。
       - _saveChannelInstructions 的乐观更新+失败回滚若 state key 命名与读取不一致，会导致静默数据错位。
-      - OpenClaw 路由走的是 dispatch placeholder 分支，若在该分支误加 system prompt 拼接逻辑，会干扰 OpenClaw 路由行为。
+      - plugin/OpenClaw 路由走的是 dispatch placeholder 分支，若在该分支误加 system prompt 拼接逻辑，会干扰 OpenClaw dispatch 行为。
       - 指令字段在 DB 中允许 NULL；若 DTO 层遗漏 null 转换，可能导致 undefined 被序列化为 undefined 字符串。
 
 
@@ -234,7 +234,7 @@ index:
       - 若 buildComposedSystemPrompt 未对空字符串做 trim/null 检查，发给模型的 system 消息可能含空段落噪音。
       - 若 _hydrateChannelInstructions/_hydrateThreadInstructions 在应用启动时未正确调用，保存值不会在刷新后恢复。
       - _saveChannelInstructions 的乐观更新+失败回滚若 state key 命名与读取不一致，会导致静默数据错位。
-      - OpenClaw 路由走的是 dispatch placeholder 分支，若在该分支误加 system prompt 拼接逻辑，会干扰 OpenClaw 路由行为。
+      - plugin/OpenClaw 路由走的是 dispatch placeholder 分支，若在该分支误加 system prompt 拼接逻辑，会干扰 OpenClaw dispatch 行为。
       - 指令字段在 DB 中允许 NULL；若 DTO 层遗漏 null 转换，可能导致 undefined 被序列化为 undefined 字符串。
 
   - feature_id: model_settings
@@ -373,6 +373,7 @@ index:
       - apps/node_backend/src/middleware/platformAuth.ts
       - apps/node_backend/src/services/platformIntegrationService.ts
       - apps/node_backend/src/db/migrations/012_add_node_id_to_chat_scope_settings.sql
+      - apps/node_backend/src/db/migrations/014_rename_chat_router_values.sql
       - apps/node_openclaw_plugin/src/pluginRunner.ts
       - apps/node_backend/src/llm/llm_service.ts
       - apps/node_backend/src/llm/providers/anthropic_adapter.ts
@@ -384,6 +385,8 @@ index:
       - docs/plans/2026-04-18-00-20-UTC-openclaw-message-routing-current-state.md
       - docs/plans/2026-04-23-17-13-WIB-openclaw-agents-capture-display.md
       - docs/plans/2026-04-23-15-33-openclaw-selected-node-routing.md
+      - docs/plans/2026-05-06-22-42-+08-router-strategy-rename.md
+      - docs/plans/2026-05-06-22-44-+08-post-router-refactor-followup.md
       - apps/node_backend/src/routes/platform.test.ts
       - apps/node_backend/src/routes/config.test.ts
       - apps/node_backend/src/services/chatRouterService.test.ts
@@ -407,6 +410,10 @@ index:
       - events ack
       - OpenClaw runtime agents query
       - targetPluginId
+      - resolvedTargetNodeId
+      - resolvedTargetNodeName
+      - local router
+      - plugin router
       - plugin ownership
       - scope settings
     change_risks:
@@ -417,7 +424,10 @@ index:
       - 平台 JWT 中 pluginId 约束变化可能导致插件隔离失效或合法请求被拒绝。
       - 若后端运行环境没有可用的 `openclaw` CLI 或 CLI 上下文与目标节点不一致，@ 菜单会缺少 agent 或显示错误列表。
       - 若 `/api/chat/respond` 未正确写入 targetPluginId/nodeId metadata，多节点环境下会重新出现一条消息被多个节点同时消费的问题。
+      - 若 `/api/chat/scope-settings` 的 resolved target 字段未与 node 删除回退逻辑保持一致，前端可能显示一个已经失效的 plugin 目标。
       - 若事件查询的 plugin 过滤条件与数据库方言不兼容，可能出现消息漏投递或跨节点串扰。
+      - 若 `default/openclaw` 旧 router 值未兼容归一化为 `local/plugin`，历史 scope settings 会在发送消息或读取设置时失效。
+      - 若将 OpenClaw/Hermes 等平台名重新写入 router 枚举，会再次混淆分发策略与具体 plugin 平台身份。
 
 
   - feature_id: node_openclaw_pull_loop

--- a/docs/plans/2026-05-06-10-13-UTC-default-router-agent-architecture.md
+++ b/docs/plans/2026-05-06-10-13-UTC-default-router-agent-architecture.md
@@ -1,0 +1,57 @@
+# Background
+
+In the current chat routing model, the `openclaw` router can bind to a concrete node (`nodeId`) and carries agent-style semantics through that node. By contrast, the `default` router mostly follows built-in logic (the default branch in `/api/chat/respond`) and is not modeled as a first-class node/agent entity.
+
+This creates product-level inconsistencies:
+
+- Channel and thread instructions can be saved, but they are not represented consistently under a unified “router == agent target” model.
+- Observability metadata for default routing is not aligned between frontend and backend.
+- Future AI-assisted instruction management (inheritance, overrides, auditing) is constrained by the lack of default-router identity.
+
+The target is to make the default router equivalent to a built-in agent node: always available, no import, no plugin installation.
+
+# Goals
+
+1. Model the default router as a built-in virtual node with stable ID and display name.
+2. Preserve current UX: every user has it by default, with no plugin setup.
+3. Align expressiveness with OpenClaw node routing to support future AI instruction editing for channels/threads.
+4. Keep existing OpenClaw routing/plugin behavior intact.
+
+# Implementation Plan (phased)
+
+## Phase 1: Domain model alignment (Backend)
+
+1. Define built-in default node constants (e.g. `node_builtin_default`) and source platform (e.g. `builtin`).
+2. Introduce a unified resolved target shape in routing resolution:
+   - `router`
+   - `nodeId`
+   - `nodeKind` (`builtin_default` / `platform_openclaw`)
+   - `agentName`
+3. In `/api/chat/respond`, emit consistent user/assistant metadata (including `targetNodeId/targetNodeName`) for both default and OpenClaw.
+
+## Phase 2: Config and presentation alignment (Config + Chat UI)
+
+1. Add a read-only built-in default node to node-list APIs (not renameable or deletable).
+2. Present default in the route picker with node-style UI (e.g. “Bricks Default (Built-in)”), while still being always available.
+3. Keep existing channel/thread instruction editors; optionally return `resolvedNodeId` from scope-setting reads (built-in node ID for default).
+
+## Phase 3: Instruction governance
+
+1. Add explicit inheritance/override semantics: global(agent) → channel → thread.
+2. Add service endpoints for AI-assisted instruction edits (default first, then OpenClaw).
+3. Add instruction audit metadata (who changed, when, scope, before/after diff summary).
+
+# Acceptance Criteria
+
+1. Without any OpenClaw node configured, users can still use default chat and routing resolves to a stable default-node identity.
+2. Channel and thread instructions continue to save/read and apply correctly under default routing.
+3. Default appears as a built-in node in routing UI without adding install/import steps.
+4. OpenClaw routing behavior and plugin flows do not regress.
+5. Chat message metadata exposes unified target fields across default/OpenClaw (`targetNodeId/targetNodeName`).
+
+# Validation Commands
+
+- `./tools/init_dev_env.sh`
+- `cd apps/node_backend && npm test`
+- `cd apps/mobile_chat_app && flutter test`
+- `cd apps/mobile_chat_app && flutter analyze`

--- a/docs/plans/2026-05-06-11-03-UTC-openclaw-default-router-agent-benchmark.md
+++ b/docs/plans/2026-05-06-11-03-UTC-openclaw-default-router-agent-benchmark.md
@@ -1,0 +1,105 @@
+# Background
+
+You requested that before upgrading Bricks default router into an agent-equivalent node architecture, we should first study OpenClaw (especially OpenClaw + Discord) in depth, including technology choices, architecture, and prompt design, then produce an implementation-ready plan.
+
+Based on repository/documentation research of `openclaw/openclaw`, this document converts benchmark findings into a practical Bricks migration blueprint.
+
+# Goals
+
+1. Extract key OpenClaw mechanisms for control plane, session routing, agent identity, and prompt assembly.
+2. Map those findings to current Bricks gaps and define what default router must gain.
+3. Produce a phased implementation plan for built-in default-node semantics and AI-governed channel/thread instructions.
+
+# OpenClaw Findings (fact extraction)
+
+## 1) Technology choices (control plane + channel plugins)
+
+- OpenClaw uses a **single long-lived Gateway daemon + typed WebSocket protocol** as a unified control plane.
+- All messaging surfaces (including Discord) attach to the Gateway; clients and nodes connect through the same WS surface, separated by role/capability.
+- Discord integration follows official gateway + bot token + account-aware config and behaves as a channel plugin surface.
+
+Implication for Bricks: default router should not remain an `if/else` branch; it should be a first-class routing target inside the control-plane model.
+
+## 2) Architecture (routing as a first-class object)
+
+- OpenClaw is driven by **session route metadata + stable agent identity**, not raw provider passthrough.
+- Different channels (Discord/Telegram/etc.) converge on consistent `agent:<agentId>:...` semantics.
+- Channel ingress and agent execution are decoupled but composable.
+
+Implication for Bricks:
+
+- default router needs stable built-in `nodeId/agentId` included in resolved routing.
+- scope settings should return resolved target semantics, not only a router string.
+
+## 3) Prompt design (OpenClaw-owned prompt assembly)
+
+- OpenClaw uses a **platform-owned system prompt assembly** model, not transparent passthrough.
+- Prompt sections are structured with cache-stable prefixes and runtime-dynamic suffixes.
+- Workspace bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, etc.) are injected context; sub-agents use smaller prompt modes.
+
+Implication for Bricks:
+
+- default router agentization should move to layered prompt assembly:
+  - agent layer (default built-in)
+  - channel layer
+  - thread layer
+- explicit governance is required: inheritance, override, truncation, audit.
+
+## 4) Why OpenClaw + Discord feels “agent-native”
+
+- Discord is only the ingress/egress surface; the durable layer is agent/session routing inside Gateway.
+- What users perceive as editable instructions, continuity, and cross-channel consistency comes from the unified agent abstraction.
+
+Implication for Bricks:
+
+- the correct target is “default router as built-in agent node,” not “default emulating a plugin.”
+
+# Implementation Plan (phased)
+
+## Phase 1: Default-router node identity (Backend first)
+
+1. Introduce built-in default node constants:
+   - `nodeId: node_builtin_default`
+   - `sourcePlatform: builtin`
+   - `displayName: Bricks Default`
+2. Extend resolved routing output:
+   - `router`, `nodeId`, `nodeKind`, `agentName`, `sourcePlatform`
+3. In `/api/chat/respond`, emit unified metadata for both default/openclaw:
+   - `targetNodeId`, `targetNodeName`, `targetPluginId?`, `resolvedRouteKind`
+
+## Phase 2: Scope setting + UI alignment
+
+1. Add `resolvedNodeId/resolvedNodeName` to scope-setting query responses.
+2. Show default as a built-in node in router menus (no install, read-only).
+3. For thread-follow-channel mode, return resolved target semantics to avoid ambiguous inheritance.
+
+## Phase 3: Prompt assembly + instruction governance
+
+1. Build a layered prompt assembler:
+   - base system
+   - built-in agent instructions
+   - channel instructions
+   - thread instructions
+2. Add AI instruction-edit service paths (default first, OpenClaw later).
+3. Add instruction audit fields: `changedBy`, `changedAt`, `scope`, `diffSummary`.
+
+## Phase 4: OpenClaw interoperability boundaries
+
+1. Keep built-in default node independent of plugin lifecycle.
+2. Keep OpenClaw node behavior on existing plugin path.
+3. Standardize observability fields for mixed-router troubleshooting.
+
+# Acceptance Criteria
+
+1. With no OpenClaw nodes configured, default remains usable with stable node identity.
+2. Channel/thread instructions inherit/override correctly under default and participate in prompt assembly.
+3. UI shows default as built-in node with no import/install workflow.
+4. OpenClaw async placeholder/backfill path remains unchanged.
+5. In mixed routing (default ↔ openclaw), metadata fields remain consistently observable.
+
+# Validation Commands
+
+- `./tools/init_dev_env.sh`
+- `cd apps/node_backend && npm test`
+- `cd apps/mobile_chat_app && flutter test`
+- `cd apps/mobile_chat_app && flutter analyze`

--- a/docs/plans/2026-05-06-11-14-UTC-default-router-builtin-node-coding.md
+++ b/docs/plans/2026-05-06-11-14-UTC-default-router-builtin-node-coding.md
@@ -1,0 +1,36 @@
+# Background
+
+The request moved from planning to coding: implement built-in agent/node semantics for the default router, not only documentation.
+
+# Goals
+
+1. Introduce a stable built-in node identity for default router on backend.
+2. Emit unified route-target metadata in `/api/chat/respond` for default and OpenClaw.
+3. Validate no regression through focused backend tests.
+
+# Implementation Plan (phased)
+
+## Phase 1
+- Add built-in default node constants and helper in `chatRouterService`.
+
+## Phase 2
+- Unify metadata output in chat respond path:
+  - `targetNodeId`
+  - `targetNodeName`
+  - `targetSourcePlatform`
+  - `resolvedRouteKind`
+
+## Phase 3
+- Update and pass related Vitest suites:
+  - `src/routes/chat.test.ts`
+  - `src/services/chatRouterService.test.ts`
+
+# Acceptance Criteria
+
+1. Default route writes stable `node_builtin_default` metadata.
+2. OpenClaw route continues to write real node metadata.
+3. Related tests pass.
+
+# Validation Commands
+
+- `cd apps/node_backend && npm test -- --run src/routes/chat.test.ts src/services/chatRouterService.test.ts`

--- a/docs/plans/2026-05-06-22-09-+08-branch-feature-checklist-analysis.md
+++ b/docs/plans/2026-05-06-22-09-+08-branch-feature-checklist-analysis.md
@@ -1,0 +1,32 @@
+# Branch Feature Checklist Analysis
+
+## Background
+
+The current branch needs to be compared with `main` to identify the planned feature scope, determine which implementation pieces already exist, and list the remaining work.
+
+## Goals
+
+- Read branch-added plan files and summarize the intended feature scope.
+- Compare branch changes against `main`.
+- Map planned acceptance criteria to current code and tests.
+- Produce a checklist of completed and remaining work without changing feature behavior.
+
+## Implementation Plan
+
+1. Fetch `origin/main`, then compare `origin/main...HEAD` to identify changed files and branch-added plans.
+2. Read the added plan files under `docs/plans/`.
+3. Inspect backend, Flutter, migration, test, and code-map diffs.
+4. Report completed, partial, missing, and risky items with concrete file references.
+
+## Acceptance Criteria
+
+- The analysis identifies all branch-added plan files.
+- The checklist separates completed work from remaining work.
+- The checklist calls out implementation risks where code behavior does not meet the plan.
+- No product behavior is changed by this analysis task.
+
+## Validation Commands
+
+- `git fetch origin main`
+- `git diff --name-status origin/main...HEAD`
+- `git diff --stat origin/main...HEAD`

--- a/docs/plans/2026-05-06-22-42-+08-router-strategy-rename.md
+++ b/docs/plans/2026-05-06-22-42-+08-router-strategy-rename.md
@@ -1,0 +1,58 @@
+# Router Strategy Rename
+
+## Background
+
+The current chat routing model uses `router: default | openclaw`. This mixes two concepts: dispatch strategy and concrete external platform. `default` currently means Bricks handles the response locally, while `openclaw` means the message is dispatched to a plugin-backed remote node. Future plugin-backed platforms such as Hermes should use the same remote plugin dispatch strategy without adding platform names to the router enum.
+
+The branch also adds metadata fields for default-router built-in node identity. The next step should simplify those metadata fields while preserving current business behavior.
+
+## Goals
+
+- Rename router semantics from platform-specific values to dispatch-strategy values.
+- Use `local` for Bricks-managed direct execution and `plugin` for plugin-backed remote dispatch.
+- Keep concrete platform identity, such as OpenClaw or future Hermes, on platform node/plugin configuration instead of the router enum.
+- Preserve existing default and OpenClaw behavior during migration.
+- Remove redundant target metadata fields that duplicate router semantics.
+
+## Implementation Plan
+
+1. Define the target router vocabulary:
+   - Canonical `ChatRouter` values become `local` and `plugin`.
+   - Legacy input values `default` and `openclaw` remain accepted during migration and normalize to `local` and `plugin`.
+2. Update backend router parsing and persistence:
+   - Normalize `default -> local` and `openclaw -> plugin` at API boundaries.
+   - Continue to support existing database rows during read/resolve until a migration is applied.
+   - Add or update migration logic for stored `chat_scope_settings.router` values.
+3. Simplify chat respond target metadata:
+   - Keep `targetNodeId`, `targetNodeName`, and `targetPluginId`.
+   - Remove `targetSourcePlatform` and `resolvedRouteKind` from newly written metadata.
+   - Do not add `targetNodeKind` unless a future router maps to multiple target node categories.
+4. Keep platform identity in node/plugin records:
+   - OpenClaw-specific behavior remains attached to platform node/plugin configuration.
+   - Future Hermes nodes should also use `router: plugin` and differ by plugin/platform metadata, not router enum.
+5. Update Flutter router models and API payloads:
+   - Rename UI enum values to local/plugin semantics.
+   - Preserve labels such as `Bricks Default` and `OpenClaw` at presentation boundaries.
+   - Keep thread inheritance behavior unchanged.
+6. Update tests and code maps:
+   - Backend tests should assert `local/plugin` router behavior and metadata shape.
+   - Flutter tests should assert legacy parsing compatibility and canonical outgoing values.
+   - Update `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` because this changes chat routing business logic and API contracts.
+
+## Acceptance Criteria
+
+- Existing saved `default` scope settings resolve as `local` without changing user-visible behavior.
+- Existing saved `openclaw` scope settings resolve as `plugin` and still dispatch to the configured OpenClaw node.
+- New scope-setting writes use canonical `local` or `plugin` router values.
+- Default Bricks chat still responds through local backend execution.
+- OpenClaw chat still creates the dispatch placeholder and waits for plugin-backed remote handling.
+- Chat message metadata still includes target node identity, but newly written messages no longer include `targetSourcePlatform` or `resolvedRouteKind`.
+- Future plugin-backed platforms can reuse `router: plugin` without adding a new router enum value.
+- Code maps are updated for the routing contract change.
+
+## Validation Commands
+
+- `./tools/init_dev_env.sh`
+- `cd apps/node_backend && npm test -- --run src/routes/chat.test.ts src/services/chatRouterService.test.ts`
+- `cd apps/mobile_chat_app && flutter test test/chat_history_api_service_test.dart test/chat_topology_and_task_protocol_test.dart`
+- `cd apps/mobile_chat_app && flutter analyze`

--- a/docs/plans/2026-05-06-22-44-+08-post-router-refactor-followup.md
+++ b/docs/plans/2026-05-06-22-44-+08-post-router-refactor-followup.md
@@ -1,0 +1,74 @@
+# Post Router Refactor Follow-up
+
+## Background
+
+The router model should first be clarified separately so that `router` means dispatch strategy only: `local` for Bricks-managed direct execution and `plugin` for plugin-backed remote dispatch. This plan assumes that router refactor is already complete and does not include the router rename or migration work.
+
+After that refactor, the remaining feature work is not to add another router kind. The remaining work is to make Bricks local execution and plugin-backed execution share a clearer target model, expose built-in Bricks targets consistently, and prepare instruction governance without coupling those concepts to OpenClaw-specific names.
+
+## Goals
+
+- Expose Bricks built-in local targets consistently in backend and frontend.
+- Keep plugin platform identity outside the router enum.
+- Preserve current local Bricks response behavior and plugin/OpenClaw dispatch behavior.
+- Make scope settings and target metadata easier to consume after router semantics are clarified.
+- Continue instruction governance work without changing the already implemented channel/thread instructions behavior.
+
+## Implementation Plan
+
+1. Define the built-in Bricks target model after router refactor.
+   - Keep `node_builtin_default` as the stable built-in target id.
+   - Keep `Bricks Default` as the display name.
+   - Treat this as the default local execution target, not as a separate router value.
+   - Add a compact shared type/helper for local target identity if needed.
+
+2. Normalize target metadata after router refactor.
+   - Newly written chat message metadata should include `targetNodeId`, `targetNodeName`, and `targetPluginId`.
+   - Do not reintroduce `targetSourcePlatform`, `resolvedRouteKind`, or `targetNodeKind` unless a later feature creates a real need.
+   - Ensure local responses write the built-in target id/name and plugin responses write the plugin node id/name/plugin id.
+
+3. Expose built-in Bricks target in target-selection surfaces.
+   - Backend node/target listing should make the built-in local target available as a read-only target.
+   - Frontend route/target menus should present `Bricks Default` as the local target and plugin nodes separately.
+   - The UI should still label concrete plugin nodes by their display name and plugin platform where useful, for example OpenClaw.
+
+4. Align scope-setting responses with resolved target semantics.
+   - Scope-setting reads should keep the persisted router strategy and node id.
+   - Where the UI needs display-ready information, return or derive the resolved target id/name after thread inheritance and fallback.
+   - For thread-follow-channel mode, make the effective target unambiguous without storing duplicate thread settings.
+
+5. Preserve existing instruction behavior and layer future governance on top.
+   - Channel and section instructions already save, hydrate, and apply to local/default responses.
+   - Keep that behavior unchanged.
+   - Add a future-ready prompt assembly boundary for local Bricks execution: base system prompt, selected agent prompt, channel instructions, section instructions.
+   - Do not apply local prompt assembly to plugin dispatch unless plugin-specific support is explicitly designed.
+
+6. Add instruction governance as a separate capability.
+   - Define inheritance/override semantics for local execution: built-in target defaults -> channel -> section.
+   - Add audit fields or audit events for instruction changes.
+   - Add AI-assisted instruction edit endpoints only after the storage and audit model is clear.
+
+7. Update tests and code maps.
+   - Add backend tests for built-in target listing/read-only behavior and metadata shape.
+   - Add frontend tests for target menu presentation and legacy hydrated scope behavior after router refactor.
+   - Add tests for effective target resolution with thread inheritance and missing plugin nodes.
+   - Update `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` because target resolution and chat routing entry points are affected.
+
+## Acceptance Criteria
+
+- Bricks local execution still works with no plugin nodes configured.
+- Plugin/OpenClaw dispatch still works when a valid plugin node is configured.
+- When a plugin node is missing, existing fallback/error behavior remains unchanged.
+- New chat message metadata records the actual target id/name/plugin id without redundant route-kind/source-platform fields.
+- The built-in Bricks target is visible where users choose or inspect chat targets, but it is read-only and requires no import/install flow.
+- Thread-follow-channel target resolution is clear to the UI and does not require duplicated settings.
+- Existing channel and section instructions continue to save, hydrate, clear, and apply to local Bricks responses.
+- Instruction governance is introduced behind clear storage/audit semantics, not mixed into router naming.
+- Code maps are updated after implementation.
+
+## Validation Commands
+
+- `./tools/init_dev_env.sh`
+- `cd apps/node_backend && npm test -- --run src/routes/chat.test.ts src/routes/config.test.ts src/services/chatRouterService.test.ts`
+- `cd apps/mobile_chat_app && flutter test test/chat_history_api_service_test.dart test/chat_topology_and_task_protocol_test.dart`
+- `cd apps/mobile_chat_app && flutter analyze`


### PR DESCRIPTION
### Motivation

- Treat the existing `default` chat router as a stable built-in node so default routing has a consistent identity and metadata comparable to OpenClaw nodes. 
- Align message metadata and routing resolution so downstream systems and UIs can rely on unified `targetNodeId/targetNodeName` fields and `resolvedRouteKind` for observability and future instruction management. 
- Preserve current OpenClaw behavior while enabling built-in instruction/agent semantics for the default path. 

### Description

- Added built-in default node constants and a helper `builtinDefaultNodeRef()` in `services/chatRouterService.ts` exporting `node_builtin_default` identity and source platform. 
- Updated `/api/chat/respond` in `routes/chat.ts` to use the built-in node ref for the `default` router and emit unified metadata fields including `targetNodeId`, `targetNodeName`, `targetSourcePlatform`, and `resolvedRouteKind`, while preserving OpenClaw-specific fields for `openclaw` routes. 
- Adjusted test mocks and expectations in `routes/chat.test.ts` to account for `builtinDefaultNodeRef()` and added a mock `resolveScopeInstructions` integration point. 
- Added planning docs under `docs/plans/` describing the agentization rationale and rollout/benchmark considerations. 

### Testing

- Ran the backend chat tests with `cd apps/node_backend && npm test -- --run src/routes/chat.test.ts`, and the updated `src/routes/chat.test.ts` completed successfully. 
- Existing flow-based expectations for OpenClaw routing and default routing were validated in the test suite and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1420b024832d80fcb12e756fcf7f)