### PR TITLE
fix(ios): add NSPhotoLibraryUsageDescription to Runner Info.plist

### DIFF
--- a/apps/mobile_chat_app/ios/Runner/Info.plist
+++ b/apps/mobile_chat_app/ios/Runner/Info.plist
@@ -39,6 +39,8 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Bricks uses your photo library so you can select and share images in chat.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/docs/plans/2026-05-07-18-29-fix-ios-photo-library-usage-description.md
+++ b/docs/plans/2026-05-07-18-29-fix-ios-photo-library-usage-description.md
@@ -1,0 +1,15 @@
+# Background
+Apple rejected iOS build 1 (version 0.1.0) for missing `NSPhotoLibraryUsageDescription` in the Runner app Info.plist.
+
+# Goals
+- Add the required privacy usage string so App Store validation passes ITMS-90683.
+- Keep the change minimal and user-facing text clear.
+
+# Implementation Plan (phased)
+1. Inspect iOS Runner Info.plist for existing privacy keys.
+2. Add `NSPhotoLibraryUsageDescription` with a clear purpose string.
+3. Run a lightweight repo check (git diff) to verify only intended files changed.
+
+# Acceptance Criteria
+- `apps/mobile_chat_app/ios/Runner/Info.plist` contains `NSPhotoLibraryUsageDescription` with a non-empty, user-facing explanation.
+- Diff contains only the intended privacy key addition and task plan documentation.


### PR DESCRIPTION
### Motivation
- Resolve App Store rejection ITMS-90683 by adding the required `NSPhotoLibraryUsageDescription` user-facing purpose string so the app's plist declares why photo-library access may be requested.

### Description
- Add `NSPhotoLibraryUsageDescription` to `apps/mobile_chat_app/ios/Runner/Info.plist` with the string "Bricks uses your photo library so you can select and share images in chat.", and add a timestamped plan file at `docs/plans/2026-05-07-18-29-fix-ios-photo-library-usage-description.md` documenting the change.

### Testing
- Parsed the updated plist with Python `plistlib` (`python - <<'PY' ... plistlib.loads(...)`) which succeeded, ran `git status --short` to verify the working tree, and observed that `plutil -lint` in this environment printed usage/help and did not complete as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd8fed114832dbea5e3642a8f655e)