### PR TITLE
feat(chat): render markdown tables in assistant messages

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -735,7 +735,8 @@ class _AssistantMarkdownText extends StatelessWidget {
           ),
         );
 
-    for (final line in lines) {
+    for (var lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+      final line = lines[lineIndex];
       final trimmed = line.trimLeft();
       if (trimmed.startsWith('```')) {
         if (inCodeBlock) {
@@ -765,6 +766,67 @@ class _AssistantMarkdownText extends StatelessWidget {
           ),
           child: Text(trimmed.substring(1).trimLeft(), style: baseStyle),
         ));
+        continue;
+      }
+      final table = _MarkdownTable.tryParseAt(lines, lineIndex);
+      if (table != null) {
+        final borderColor = textColor.withValues(alpha: 0.24);
+        widgets.add(
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Table(
+              border: TableBorder.all(color: borderColor),
+              defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+              children: [
+                TableRow(
+                  decoration: BoxDecoration(
+                    color: quoteBlockColor.withValues(alpha: 0.7),
+                  ),
+                  children: [
+                    for (final cell in table.headers)
+                      Padding(
+                        padding: const EdgeInsets.all(BricksSpacing.xs),
+                        child: Text.rich(
+                          TextSpan(
+                            children: _parseInlineMarkdown(
+                              cell,
+                              baseStyle: baseStyle.copyWith(
+                                  fontWeight: FontWeight.w700),
+                              linkStyle: baseStyle.copyWith(
+                                color: linkColor,
+                                fontWeight: FontWeight.w700,
+                              ),
+                              headingLike: false,
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                for (final row in table.rows)
+                  TableRow(
+                    children: [
+                      for (final cell in row)
+                        Padding(
+                          padding: const EdgeInsets.all(BricksSpacing.xs),
+                          child: Text.rich(
+                            TextSpan(
+                              children: _parseInlineMarkdown(
+                                cell,
+                                baseStyle: baseStyle,
+                                linkStyle: baseStyle.copyWith(color: linkColor),
+                                headingLike: false,
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+        );
+        lineIndex = table.lastLineIndex;
         continue;
       }
       final block = _MarkdownBlock.tryParse(line);
@@ -804,6 +866,82 @@ class _AssistantMarkdownText extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: widgets,
     );
+  }
+}
+
+class _MarkdownTable {
+  const _MarkdownTable({
+    required this.headers,
+    required this.rows,
+    required this.lastLineIndex,
+  });
+
+  final List<String> headers;
+  final List<List<String>> rows;
+  final int lastLineIndex;
+
+  static final RegExp _separatorPattern = RegExp(
+    r'^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$',
+  );
+
+  static _MarkdownTable? tryParseAt(List<String> lines, int startIndex) {
+    if (startIndex + 1 >= lines.length) return null;
+    final headerLine = lines[startIndex];
+    final separatorLine = lines[startIndex + 1];
+    if (!_looksLikeTableRow(headerLine) ||
+        !_separatorPattern.hasMatch(separatorLine)) {
+      return null;
+    }
+
+    final headers = _splitCells(headerLine);
+    if (headers.isEmpty) return null;
+
+    final rowLines = <List<String>>[];
+    var currentIndex = startIndex + 2;
+    while (currentIndex < lines.length) {
+      final candidate = lines[currentIndex];
+      if (!_looksLikeTableRow(candidate) || candidate.trim().isEmpty) {
+        break;
+      }
+      final cells = _splitCells(candidate);
+      if (cells.isEmpty) break;
+      rowLines.add(_normalizeCells(cells, headers.length));
+      currentIndex++;
+    }
+
+    return _MarkdownTable(
+      headers: _normalizeCells(headers, headers.length),
+      rows: rowLines,
+      lastLineIndex: currentIndex - 1,
+    );
+  }
+
+  static bool _looksLikeTableRow(String line) {
+    final trimmed = line.trim();
+    if (trimmed.isEmpty) return false;
+    return trimmed.startsWith('|') || trimmed.endsWith('|');
+  }
+
+  static List<String> _splitCells(String line) {
+    var normalized = line.trim();
+    if (normalized.startsWith('|')) {
+      normalized = normalized.substring(1);
+    }
+    if (normalized.endsWith('|')) {
+      normalized = normalized.substring(0, normalized.length - 1);
+    }
+    return normalized.split('|').map((cell) => cell.trim()).toList();
+  }
+
+  static List<String> _normalizeCells(List<String> cells, int targetLength) {
+    final normalized = List<String>.from(cells);
+    if (normalized.length < targetLength) {
+      normalized
+          .addAll(List<String>.filled(targetLength - normalized.length, ''));
+    } else if (normalized.length > targetLength) {
+      return normalized.sublist(0, targetLength);
+    }
+    return normalized;
   }
 }
 

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -414,6 +414,30 @@ void main() {
       );
       expect(padding.padding, const EdgeInsets.only(left: BricksSpacing.md));
     });
+
+    testWidgets('renders markdown tables as table widgets', (tester) async {
+      final assistant = ChatMessage(
+        messageId: 'assistant-markdown-table',
+        role: 'assistant',
+        content: '''
+| 参数 | 含义 |
+|---|---|
+| `flutter run` | Flutter 的开发运行命令 |
+| `-d chrome` | 指定 Chrome 设备 |
+''',
+        timestamp: DateTime.utc(2026, 1, 1),
+      );
+
+      await tester.pumpWidget(_build([assistant]));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Table), findsOneWidget);
+      expect(find.text('| 参数 | 含义 |'), findsNothing);
+      expect(find.text('参数'), findsOneWidget);
+      expect(find.text('含义'), findsOneWidget);
+      expect(find.text('Flutter 的开发运行命令'), findsOneWidget);
+      expect(find.text('指定 Chrome 设备'), findsOneWidget);
+    });
   });
 
   group('User delivery status', () {

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -81,6 +81,7 @@ index:
       - docs/plans/2026-04-26-23-24-+08-chat-dark-colors.md
       - docs/plans/2026-04-27-00-19-+08-design-system-token-alignment.md
       - docs/plans/2026-04-27-00-27-+08-design-system-skill.md
+      - docs/plans/2026-04-27-17-28-UTC-markdown-table-rendering.md
     test_index:
       - apps/mobile_chat_app/test/chat_arbitration_engine_test.dart
       - apps/mobile_chat_app/test/chat_topology_and_task_protocol_test.dart
@@ -112,6 +113,7 @@ index:
       - menu-animation
       - slash-commands
       - route-aware composer actions
+      - markdown-table
       - long-polling (deprecated, replaced by SSE)
       - SSE (Server-Sent Events)
       - built-in agents

--- a/docs/plans/2026-04-27-17-28-UTC-markdown-table-rendering.md
+++ b/docs/plans/2026-04-27-17-28-UTC-markdown-table-rendering.md
@@ -1,0 +1,26 @@
+# Background
+The mobile chat assistant currently supports a lightweight markdown subset (headings, lists, code fences, block quotes, inline styles/links) but does not render markdown table syntax. As a result, table source text is shown literally in messages, which harms readability for structured answers.
+
+# Goals
+- Render GitHub-style markdown tables (`|` row syntax + separator row) as visual table widgets in assistant messages.
+- Keep existing markdown features and styles intact.
+- Add regression coverage for table rendering in widget tests.
+
+# Implementation Plan (phased)
+## Phase 1: Parser and renderer extension
+- Extend `_AssistantMarkdownText` line-walking logic to detect table blocks before paragraph/list parsing.
+- Add a `_MarkdownTable` helper that parses a header row + separator row + data rows and normalizes column counts.
+- Render parsed tables with Flutter `Table` wrapped in horizontal scroll for narrow screens.
+
+## Phase 2: Validation and regression tests
+- Add widget test coverage to verify table syntax is transformed into a rendered `Table` and cell text appears as expected.
+- Ensure literal raw markdown table line text is no longer displayed for parsed table messages.
+
+## Phase 3: Verification commands
+- Initialize repo dev environment with `./tools/init_dev_env.sh`.
+- Run targeted mobile app tests from package directory: `cd apps/mobile_chat_app && flutter test test/message_list_test.dart`.
+
+# Acceptance Criteria
+- Assistant messages containing markdown tables render visually as table UI, not literal raw `|`-delimited text.
+- Existing markdown behaviors (headings/lists/code/quote) remain functional.
+- New widget tests for markdown table rendering pass.


### PR DESCRIPTION
### Motivation
- Assistant messages showed raw `|`-style markdown tables as plain text, reducing readability for structured answers and causing layout issues on narrow screens.
- Add first-class rendering for GitHub-style pipe tables while preserving existing markdown features (headings, lists, code fences, block quotes, inline styles).
- Keep repository metadata and traceability up to date by adding an implementation plan and updating code maps for the affected chat feature.

### Description
- Detect table blocks in the lightweight markdown walker inside `_AssistantMarkdownText` by iterating lines with an index and calling a new parser helper before falling back to paragraph/list parsing in `apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart`.
- Add a `_MarkdownTable` helper that validates the separator row, splits and normalizes columns, and returns parsed headers/rows with the last consumed line index.
- Render parsed tables as a horizontally scrollable Flutter `Table` with header styling and per-cell inline markdown parsing via the existing `_parseInlineMarkdown` pipeline to preserve bold/links/code formatting.
- Add a widget test `renders markdown tables as table widgets` to `apps/mobile_chat_app/test/message_list_test.dart` that asserts a `Table` is rendered and raw `|` source lines are not shown.
- Add an implementation plan document `docs/plans/2026-04-27-17-28-UTC-markdown-table-rendering.md` and update `docs/code_maps/logic_map.yaml` to include the new plan and a `markdown-table` keyword under the `chat_session` feature.

### Testing
- Ran repository bootstrap with `./tools/init_dev_env.sh`, which completed successfully.
- Ran the mobile widget tests with `cd apps/mobile_chat_app && flutter test test/message_list_test.dart` and observed all tests pass (including the new table rendering test).
- Validated updated code maps with `npx js-yaml docs/code_maps/feature_map.yaml` and `npx js-yaml docs/code_maps/logic_map.yaml`, which succeeded; a Python `yaml` import check failed in this environment due to missing `PyYAML` but is not required when `npx js-yaml` passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9c5c2d3c832db705adcff818258b)