### PR TITLE
Fix composer input focus loss after sending

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
@@ -157,7 +157,7 @@ class _ComposerBarState extends State<ComposerBar>
                   TextField(
                     controller: _controller,
                     focusNode: _focusNode,
-                    enabled: !isSending && !widget.isStreaming,
+                    enabled: !widget.isStreaming,
                     maxLines: 5,
                     minLines: 1,
                     textInputAction: TextInputAction.send,

--- a/apps/mobile_chat_app/test/composer_bar_test.dart
+++ b/apps/mobile_chat_app/test/composer_bar_test.dart
@@ -275,6 +275,54 @@ void main() {
       expect(textField.enabled, isTrue);
     });
 
+    testWidgets(
+        'text field retains focus when onSend toggles to null after sending',
+        (tester) async {
+      void Function(String)? sendCallback = (_) {};
+      late StateSetter outerSetState;
+
+      await tester.pumpWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            outerSetState = setState;
+            return MaterialApp(
+              home: Scaffold(
+                body: ComposerBar(
+                  agents: const [],
+                  onSend: sendCallback,
+                ),
+              ),
+            );
+          },
+        ),
+      );
+      await tester.pump();
+
+      // Enter a message and submit.
+      await tester.enterText(find.byType(TextField), 'hello');
+      await tester.pump();
+
+      // Tap Send to submit the message.
+      await tester.tap(find.byTooltip('Send'));
+      await tester.pump(_settle);
+
+      // Simulate the parent removing onSend while processing the sent message
+      // (the original regression: setting onSend = null also disabled the
+      // TextField, which caused the composer to lose focus).
+      outerSetState(() => sendCallback = null);
+      await tester.pump();
+
+      // TextField must remain enabled – this is the core regression guard.
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.enabled, isTrue);
+
+      // Verify the input can still receive and hold keyboard focus when onSend is null.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      final focusedField = tester.widget<TextField>(find.byType(TextField));
+      expect(focusedField.focusNode?.hasFocus, isTrue);
+    });
+
     testWidgets('send button is present when not streaming', (tester) async {
       await tester.pumpWidget(_buildBar());
       await tester.pump();

--- a/apps/mobile_chat_app/test/composer_bar_test.dart
+++ b/apps/mobile_chat_app/test/composer_bar_test.dart
@@ -265,6 +265,16 @@ void main() {
   });
 
   group('ComposerBar – send / stop controls', () {
+
+    testWidgets('text field stays enabled when send callback is unavailable',
+        (tester) async {
+      await tester.pumpWidget(_buildBar());
+      await tester.pump();
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.enabled, isTrue);
+    });
+
     testWidgets('send button is present when not streaming', (tester) async {
       await tester.pumpWidget(_buildBar());
       await tester.pump();

--- a/docs/plans/2026-05-08-08-43-UTC-composer-focus-keep.md
+++ b/docs/plans/2026-05-08-08-43-UTC-composer-focus-keep.md
@@ -1,0 +1,22 @@
+# Background
+用户反馈聊天输入框在发送消息（点击发送按钮或按回车）后会丢失焦点，导致无法连续输入下一条消息，影响高频对话体验。
+
+# Goals
+- 修复发送后输入框失焦问题。
+- 保持现有发送逻辑与流式状态控制不被破坏。
+- 增加回归测试，覆盖“不可发送但可继续输入”的行为。
+
+# Implementation Plan (phased)
+1. 检查 `ComposerBar` 的输入框可用性与提交后状态切换逻辑，定位导致失焦的条件。
+2. 调整输入框 `enabled` 条件，确保发送动作触发后在非流式阶段仍可保持可输入状态。
+3. 新增/更新 widget test，验证在 `onSend == null`（发送不可用）但非流式时输入框仍可编辑。
+4. 运行相关测试命令并记录结果。
+
+# Acceptance Criteria
+- 点击发送按钮或按回车发送后，输入框仍可保持焦点并继续输入。
+- 在 `isStreaming == false` 时，即便 `onSend == null`，输入框仍可输入文本。
+- 现有 `composer_bar_test` 全部通过。
+
+# Validation Commands
+- `./tools/init_dev_env.sh`
+- `cd apps/mobile_chat_app && flutter test test/composer_bar_test.dart`


### PR DESCRIPTION
### Motivation
- Users observed that the chat composer loses focus after sending a message, preventing continuous typing; the intent is to keep the input editable after send when the app is not streaming.
- The change aims to avoid disabling the `TextField` solely because the `onSend` callback is temporarily `null`, while preserving streaming-related disabling.

### Description
- Change the composer `TextField` `enabled` logic from `!isSending && !widget.isStreaming` to `!widget.isStreaming` so the input stays enabled when not streaming regardless of `onSend` availability.
- Add a widget test `text field stays enabled when send callback is unavailable` to verify the `TextField` remains enabled when `onSend == null` and `isStreaming == false`.
- Add an implementation plan document at `docs/plans/2026-05-08-08-43-UTC-composer-focus-keep.md` describing background, goals, and validation commands.
- No code maps were updated because this is a small interaction change that does not alter feature entry points or logic indexing.

### Testing
- Bootstrapped the environment with `./tools/init_dev_env.sh`, which completed successfully.
- Ran the targeted widget tests with `cd apps/mobile_chat_app && flutter test test/composer_bar_test.dart` and all tests passed.
- The added widget test asserting `TextField.enabled` succeeded as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda2056c24832dadd61d72c30edab8)