### PR TITLE
Persist channel name on creation to survive page refresh

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -803,6 +803,20 @@ class _ChatScreenState extends State<ChatScreen> {
           _lastSyncedSeq = 0;
         });
         _configureActiveScopeSync();
+        final token = _authToken;
+        if (token != null && token.isNotEmpty) {
+          unawaited(
+            _chatHistoryApiService
+                .saveChannelName(
+              token: token,
+              channelId: id,
+              displayName: name,
+            )
+                .catchError((Object error, StackTrace stackTrace) {
+              debugPrint('Failed to save channel name "$id": $error');
+            }),
+          );
+        }
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(SnackBar(content: Text('已创建频道：${channel.name}')));

--- a/docs/plans/2026-05-08-09-44-UTC-fix-channel-name-refresh-loss.md
+++ b/docs/plans/2026-05-08-09-44-UTC-fix-channel-name-refresh-loss.md
@@ -1,0 +1,18 @@
+# Background
+Users reported that when creating a channel and entering a custom channel name, refreshing the page causes that channel name to be lost.
+
+# Goals
+- Persist the channel display name at channel creation time so a page refresh restores the custom name.
+- Keep behavior consistent with channel rename persistence.
+
+# Implementation Plan (phased)
+1. Inspect channel creation flow in `chat_screen.dart` and confirm whether `saveChannelName` is called when creating channels.
+2. Update channel creation logic to persist the newly entered name through `ChatHistoryApiService.saveChannelName` when an auth token is available.
+3. Run focused static checks/tests relevant to the modified file.
+
+# Acceptance Criteria
+- Creating a channel with a custom name triggers persistence of that name via the chat history API when authenticated.
+- After refresh/reload, the channel retains the user-provided name rather than reverting.
+
+# Validation Commands
+- `cd apps/mobile_chat_app && flutter test test/chat_navigation_page_test.dart`


### PR DESCRIPTION
### Motivation
- Creating a channel previously only updated local state so a page refresh could lose the user-provided display name, so the creation flow needs to persist the name like renames/archives do.

### Description
- Call `ChatHistoryApiService.saveChannelName` after channel creation in `_createChannel` when an auth token is available to persist the `displayName` (change made in `apps/mobile_chat_app/lib/features/chat/chat_screen.dart`).
- Add a repository plan file at `docs/plans/2026-05-08-09-44-UTC-fix-channel-name-refresh-loss.md` describing background, goals, implementation plan, acceptance criteria, and validation commands to satisfy repo plan persistence rules.
- No code-map updates were performed because this is a persistence fix within an existing channel creation path and does not change feature entry points or topology.

### Testing
- Bootstrapped the dev environment with `./tools/init_dev_env.sh` and the command completed successfully. (✅)
- Ran the focused widget tests with `cd apps/mobile_chat_app && flutter test test/chat_navigation_page_test.dart` and the test suite passed. (All tests passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb04e86f4832d8864a12202c7ec47)