### PR TITLE
Disable navigation tab swipe and close drawer on left swipe

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
@@ -99,6 +99,8 @@ class ChatNavigationPage extends StatefulWidget {
 
 class _ChatNavigationPageState extends State<ChatNavigationPage>
     with SingleTickerProviderStateMixin {
+  static const double _closeSwipeVelocityThreshold = -300;
+
   late final TabController _tabController;
 
   @override
@@ -124,6 +126,13 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
   void _selectAction(BuildContext context, ChatNavigationAction action) {
     _closeNavigation(context);
     widget.onActionSelected(action);
+  }
+
+  void _handleHorizontalDragEnd(DragEndDetails details) {
+    final velocity = details.primaryVelocity ?? 0;
+    if (velocity < _closeSwipeVelocityThreshold) {
+      _closeNavigation(context);
+    }
   }
 
   Future<void> _showChannelMenu(ChatChannelItem channel) async {
@@ -175,8 +184,11 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
         ? widget.selectedChannelId
         : (channels.isNotEmpty ? channels.first.id : null);
 
-    return Column(
-      children: [
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onHorizontalDragEnd: _handleHorizontalDragEnd,
+      child: Column(
+        children: [
         // Header row
         SizedBox(
           height: kToolbarHeight,
@@ -221,6 +233,7 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
         Expanded(
           child: TabBarView(
             controller: _tabController,
+            physics: const NeverScrollableScrollPhysics(),
             children: [
               // Channels tab
               ListView(
@@ -303,7 +316,8 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
             ],
           ),
         ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
@@ -99,7 +99,7 @@ class ChatNavigationPage extends StatefulWidget {
 
 class _ChatNavigationPageState extends State<ChatNavigationPage>
     with SingleTickerProviderStateMixin {
-  static const double _closeSwipeVelocityThreshold = -300;
+  static const double _closeSwipeVelocityThreshold = 300;
 
   late final TabController _tabController;
 
@@ -130,7 +130,11 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
 
   void _handleHorizontalDragEnd(DragEndDetails details) {
     final velocity = details.primaryVelocity ?? 0;
-    if (velocity < _closeSwipeVelocityThreshold) {
+    final isRtl = Directionality.of(context) == TextDirection.rtl;
+    final shouldClose = isRtl
+        ? velocity > _closeSwipeVelocityThreshold
+        : velocity < -_closeSwipeVelocityThreshold;
+    if (shouldClose) {
       _closeNavigation(context);
     }
   }
@@ -314,8 +318,8 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
                 ],
               ),
             ],
+            ),
           ),
-        ),
         ],
       ),
     );

--- a/apps/mobile_chat_app/test/chat_navigation_page_test.dart
+++ b/apps/mobile_chat_app/test/chat_navigation_page_test.dart
@@ -10,22 +10,26 @@ Widget _buildPage({
   VoidCallback? onRequestClose,
   bool closeOnChannelSelected = true,
   List<ChatNodeItem> nodes = const [],
+  TextDirection textDirection = TextDirection.ltr,
 }) =>
     MaterialApp(
-      home: Scaffold(
-        body: ChatNavigationPage(
-          onActionSelected: onActionSelected ?? (_) {},
-          channels: const [
-            ChatChannelItem(id: 'default', name: '默认频道', isDefault: true),
-            ChatChannelItem(id: 'project', name: '项目频道'),
-          ],
-          selectedChannelId: 'default',
-          nodes: nodes,
-          onChannelSelected: onChannelSelected,
-          onChannelRename: onChannelRename,
-          onChannelArchive: onChannelArchive,
-          onRequestClose: onRequestClose,
-          closeOnChannelSelected: closeOnChannelSelected,
+      home: Directionality(
+        textDirection: textDirection,
+        child: Scaffold(
+          body: ChatNavigationPage(
+            onActionSelected: onActionSelected ?? (_) {},
+            channels: const [
+              ChatChannelItem(id: 'default', name: '默认频道', isDefault: true),
+              ChatChannelItem(id: 'project', name: '项目频道'),
+            ],
+            selectedChannelId: 'default',
+            nodes: nodes,
+            onChannelSelected: onChannelSelected,
+            onChannelRename: onChannelRename,
+            onChannelArchive: onChannelArchive,
+            onRequestClose: onRequestClose,
+            closeOnChannelSelected: closeOnChannelSelected,
+          ),
         ),
       ),
     );
@@ -63,25 +67,51 @@ void main() {
       expect(find.text('Nodes'), findsOneWidget);
     });
 
-
     testWidgets('horizontal swipe does not switch tabs', (tester) async {
-      await tester.pumpWidget(_buildPage());
+      var closeCount = 0;
+
+      await tester.pumpWidget(_buildPage(onRequestClose: () => closeCount++));
       await tester.pumpAndSettle();
 
-      await tester.fling(find.byType(ChatNavigationPage), const Offset(-400, 0), 1000);
+      await tester.drag(
+        find.byType(ChatNavigationPage),
+        const Offset(-200, 0),
+      );
       await tester.pumpAndSettle();
 
+      expect(closeCount, 0);
       expect(find.text('新建频道'), findsOneWidget);
       expect(find.text('No nodes'), findsNothing);
     });
 
-    testWidgets('right-to-left swipe requests close', (tester) async {
+    testWidgets('LTR right-to-left swipe requests close', (tester) async {
       var closeCount = 0;
 
       await tester.pumpWidget(_buildPage(onRequestClose: () => closeCount++));
       await tester.pumpAndSettle();
 
       await tester.fling(find.byType(ChatNavigationPage), const Offset(-400, 0), 1000);
+      await tester.pumpAndSettle();
+
+      expect(closeCount, 1);
+    });
+
+    testWidgets('RTL left-to-right swipe requests close', (tester) async {
+      var closeCount = 0;
+
+      await tester.pumpWidget(
+        _buildPage(
+          onRequestClose: () => closeCount++,
+          textDirection: TextDirection.rtl,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byType(ChatNavigationPage),
+        const Offset(400, 0),
+        1000,
+      );
       await tester.pumpAndSettle();
 
       expect(closeCount, 1);

--- a/apps/mobile_chat_app/test/chat_navigation_page_test.dart
+++ b/apps/mobile_chat_app/test/chat_navigation_page_test.dart
@@ -63,6 +63,30 @@ void main() {
       expect(find.text('Nodes'), findsOneWidget);
     });
 
+
+    testWidgets('horizontal swipe does not switch tabs', (tester) async {
+      await tester.pumpWidget(_buildPage());
+      await tester.pumpAndSettle();
+
+      await tester.fling(find.byType(ChatNavigationPage), const Offset(-400, 0), 1000);
+      await tester.pumpAndSettle();
+
+      expect(find.text('新建频道'), findsOneWidget);
+      expect(find.text('No nodes'), findsNothing);
+    });
+
+    testWidgets('right-to-left swipe requests close', (tester) async {
+      var closeCount = 0;
+
+      await tester.pumpWidget(_buildPage(onRequestClose: () => closeCount++));
+      await tester.pumpAndSettle();
+
+      await tester.fling(find.byType(ChatNavigationPage), const Offset(-400, 0), 1000);
+      await tester.pumpAndSettle();
+
+      expect(closeCount, 1);
+    });
+
     testWidgets('Current Chat is not present', (tester) async {
       await tester.pumpWidget(_buildPage());
       await tester.pumpAndSettle();

--- a/docs/plans/2026-05-08-13-46-UTC-disable-navigation-tab-swipe.md
+++ b/docs/plans/2026-05-08-13-46-UTC-disable-navigation-tab-swipe.md
@@ -1,0 +1,26 @@
+# Background
+The chat navigation panel currently contains two tabs (Channels and Nodes). A horizontal swipe inside the panel switches tabs by default via `TabBarView`, which conflicts with the desired UX for drawer-like navigation.
+
+# Goals
+- Prevent horizontal swipe from switching tabs inside chat navigation.
+- Make a right-to-left swipe in the navigation trigger close behavior.
+- Preserve existing tab switching via tab taps.
+- Add/adjust tests for the new gesture behavior.
+
+# Implementation Plan (phased)
+1. Update `ChatNavigationPage` gesture handling:
+   - Disable tab paging gestures in `TabBarView`.
+   - Add a horizontal drag-end handler that closes navigation on right-to-left swipe.
+2. Add widget tests:
+   - Verify horizontal swipe no longer switches tabs.
+   - Verify right-to-left swipe requests close.
+3. Run targeted Flutter tests for `chat_navigation_page_test.dart`.
+
+# Acceptance Criteria
+- Swiping horizontally inside navigation no longer changes active tab.
+- Right-to-left swipe on navigation triggers close callback.
+- Existing interactions (tab taps, back button, channel tap logic) continue to work.
+
+# Validation Commands
+- `./tools/init_dev_env.sh`
+- `cd apps/mobile_chat_app && flutter test test/chat_navigation_page_test.dart`

--- a/docs/plans/2026-05-09-06-10-UTC-chat-navigation-swipe-follow-up.md
+++ b/docs/plans/2026-05-09-06-10-UTC-chat-navigation-swipe-follow-up.md
@@ -1,0 +1,21 @@
+# Background
+The initial drawer swipe update disabled `TabBarView` paging and added swipe-to-close behavior, but review feedback identified two follow-ups: the close direction should respect RTL layouts, and the non-tab-switch test should avoid accidentally proving the drawer-close path instead.
+
+# Goals
+- Make swipe-to-close respect `Directionality`.
+- Keep the “no tab switch on swipe” test focused on tab behavior without triggering close.
+- Preserve existing drawer close behavior for LTR navigation.
+
+# Implementation Plan (phased)
+1. Update `ChatNavigationPage` drag-end handling to choose the close swipe direction from the current text direction.
+2. Refine widget tests to use a non-fling drag for the tab-stability case and assert no close request occurs.
+3. Add RTL widget coverage for swipe-to-close.
+
+# Acceptance Criteria
+- In LTR, a right-to-left fling closes navigation.
+- In RTL, a left-to-right fling closes navigation.
+- A horizontal drag no longer changes tabs and does not request close.
+
+# Validation Commands
+- `./tools/init_dev_env.sh`
+- `cd apps/mobile_chat_app && flutter test test/chat_navigation_page_test.dart`


### PR DESCRIPTION
### Motivation
- The navigation panel currently allows horizontal swipes to switch tabs via `TabBarView`, which conflicts with a drawer-like navigation UX. 
- A right-to-left swipe should instead close the navigation panel rather than change tabs.

### Description
- Disabled horizontal paging on the tabs by setting `physics: const NeverScrollableScrollPhysics()` on `TabBarView` in `apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart`.
- Wrapped the navigation column in a `GestureDetector` and added `_handleHorizontalDragEnd` with a velocity threshold constant `static const double _closeSwipeVelocityThreshold = -300` to close navigation on a right-to-left swipe.
- Added two widget tests in `apps/mobile_chat_app/test/chat_navigation_page_test.dart` to verify that swiping does not change tabs and that a right-to-left swipe requests close. 
- Added a plan document at `docs/plans/2026-05-08-13-46-UTC-disable-navigation-tab-swipe.md` describing goals, implementation plan, acceptance criteria, and validation commands.

### Testing
- Bootstrapped the environment with `./tools/init_dev_env.sh` which completed successfully. 
- Ran the targeted widget tests with `cd apps/mobile_chat_app && flutter test test/chat_navigation_page_test.dart` and all tests passed. 
- Test output included known `file_picker` plugin warnings but they did not affect test success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde92a1d2c832db4f5dbcd15441f2f)