### PR TITLE
Fix Turso tool errors and iOS chat setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@
 ## API debugging workflow
 - When debugging API/interface errors, try the `vercel-api-log-context` skill first to collect Vercel deployment log context before proposing fixes.
 
+## Turso / SQLite compatibility
+- Real issue encountered: `table_create` wrote a `tool_call_start` row, then `assetTableService.createTable` failed on Turso with `SQL_INPUT_ERROR: SQLite input error: no such function: NOW` because runtime SQL used PostgreSQL `NOW()`. Since the AI SDK `tool-error` event was not persisted, the UI stayed stuck on "正在调用 table_create".
+
 ## OpenClaw plugin refresh
 - When users ask how to apply newly pulled local code under `apps/node_openclaw_plugin` to their local OpenClaw install, use the `openclaw-plugin-refresh` skill first.
 - The repository skill lives at `.codex/skills/openclaw-plugin-refresh/SKILL.md` and covers rebuild, linked reinstall, gateway restart, and log verification.

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -128,15 +128,14 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Future<void> _loadAgents() async {
-    final repoFuture = createAgentsRepository();
+    final customDefinitionsFuture = _loadCustomAgentDefinitionsForStartup();
     final llmConfigsFuture = _llmConfigService.fetchConfigs();
     final tokenFuture = AuthService.getToken();
 
     try {
-      final repo = await repoFuture;
       final llmConfigs = await llmConfigsFuture;
       final authToken = await tokenFuture;
-      final customDefinitions = await _readAgentDefinitions(repo);
+      final customDefinitions = await customDefinitionsFuture;
       final mergedDefinitions = _mergeWithBuiltInAgents(customDefinitions);
       List<ChatPersistedScope> persistedScopes = const [];
       List<ChatScopeSetting> scopeSettings = const [];
@@ -291,6 +290,18 @@ class _ChatScreenState extends State<ChatScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Failed to load chat setup: $error')),
       );
+    }
+  }
+
+  Future<List<AgentDefinition>> _loadCustomAgentDefinitionsForStartup() async {
+    try {
+      final repo = await createAgentsRepository();
+      return _readAgentDefinitions(repo);
+    } catch (e) {
+      debugPrint(
+        'loadCustomAgents failed, continuing with built-in agents only: $e',
+      );
+      return const [];
     }
   }
 

--- a/apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
+++ b/apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
@@ -90,7 +90,9 @@ class LlmConfigService {
   static String resolveBaseUrl() {
     if (_apiBaseUrl.isNotEmpty) return _apiBaseUrl;
     if (kIsWeb) return Uri.base.origin;
-    if (kReleaseMode) return productionApiBaseUrl;
+    if (kReleaseMode || defaultTargetPlatform == TargetPlatform.iOS) {
+      return productionApiBaseUrl;
+    }
     return 'http://localhost:3000';
   }
 

--- a/apps/mobile_chat_app/test/llm_config_service_test.dart
+++ b/apps/mobile_chat_app/test/llm_config_service_test.dart
@@ -1,8 +1,13 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_chat_app/features/settings/llm_config_service.dart';
 
 void main() {
   group('LlmConfigService base URL', () {
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+    });
+
     test('documents the production native release default', () {
       expect(
         LlmConfigService.productionApiBaseUrl,
@@ -14,6 +19,15 @@ void main() {
       expect(
         LlmConfigService.resolveBaseUrl(),
         equals('http://localhost:3000'),
+      );
+    });
+
+    test('uses production API for iOS debug builds by default', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      expect(
+        LlmConfigService.resolveBaseUrl(),
+        equals(LlmConfigService.productionApiBaseUrl),
       );
     });
   });

--- a/apps/node_backend/src/llm/llm_service.ts
+++ b/apps/node_backend/src/llm/llm_service.ts
@@ -215,6 +215,13 @@ interface SdkToolResult {
   output: unknown;
 }
 
+interface SdkToolError {
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  error: unknown;
+}
+
 /**
  * Minimal subset of the AI SDK `OnStepFinishEvent` we consume.
  */
@@ -237,6 +244,7 @@ type SdkFullStreamEvent =
   | { type: 'text-delta'; text: string }
   | { type: 'reasoning-delta'; text: string }
   | { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown }
+  | { type: 'tool-error'; toolCallId: string; toolName: string; input: unknown; error: unknown }
   | { type: 'finish-step'; stepType: string }
   | { type: string };
 
@@ -295,6 +303,16 @@ export async function streamWithAgentToolsAndUserConfig(
     onToolCallStart?: (
       toolName: string,
       args: Record<string, unknown>,
+      stepIndex: number,
+      callIndex: number,
+    ) => Promise<void>;
+    /**
+     * Called when tool execution throws and the SDK emits a `tool-error` part.
+     */
+    onToolCallError?: (
+      toolName: string,
+      args: Record<string, unknown>,
+      error: unknown,
       stepIndex: number,
       callIndex: number,
     ) => Promise<void>;
@@ -399,6 +417,7 @@ export async function streamWithAgentToolsAndUserConfig(
     let stepHasToolCalls = false;
     let stepText = '';
     let reasoningBuffer = '';
+    const toolCallIndexes = new Map<string, { stepIndex: number; callIndex: number }>();
 
     // Fire a callback Promise without blocking the generator. The callback
     // name is included in error logs so failures are easy to diagnose.
@@ -428,19 +447,41 @@ export async function streamWithAgentToolsAndUserConfig(
         } else if (rawEvent.type === 'tool-call') {
           stepHasToolCalls = true;
           if (options.onToolCallStart) {
-            const tc = rawEvent as { type: 'tool-call'; toolName: string; input: unknown };
+            const tc = rawEvent as {
+              type: 'tool-call';
+              toolCallId: string;
+              toolName: string;
+              input: unknown;
+            };
             // Skip the callback if the SDK emits a tool-call with no name — an
             // empty tool name would produce meaningless DB records.
             if (tc.toolName) {
               const toolName = String(tc.toolName);
               // Guard against non-object args (e.g. SDK emits a primitive).
               const args = isRecordObject(tc.input) ? tc.input : {};
+              toolCallIndexes.set(tc.toolCallId, { stepIndex: streamStepIndex, callIndex });
               // Await the callback so that the :tc message is written before tool
               // execution begins, which guarantees correct write_seq ordering.
               await options.onToolCallStart(toolName, args, streamStepIndex, callIndex);
             }
           }
           callIndex++;
+        } else if (rawEvent.type === 'tool-error') {
+          if (options.onToolCallError) {
+            const te = rawEvent as SdkToolError & { type: 'tool-error' };
+            const indexed = toolCallIndexes.get(te.toolCallId) ?? {
+              stepIndex: streamStepIndex,
+              callIndex: Math.max(0, callIndex - 1),
+            };
+            const args = isRecordObject(te.input) ? te.input : {};
+            await options.onToolCallError(
+              String(te.toolName ?? ''),
+              args,
+              te.error,
+              indexed.stepIndex,
+              indexed.callIndex,
+            );
+          }
         } else if (rawEvent.type === 'finish-step') {
           if (stepHasToolCalls) {
             // Intermediate step: route text to the :pt:S record, not the main

--- a/apps/node_backend/src/routes/chat.test.ts
+++ b/apps/node_backend/src/routes/chat.test.ts
@@ -43,7 +43,9 @@ const {
   ),
   upsertMessagesMock: vi.fn(async () => ({ lastSeqId: 7 })),
   listUserScopesMock: vi.fn(async () => []),
-  listChatScopeSettingsMock: vi.fn(async () => []),
+  listChatScopeSettingsMock: vi.fn(
+    async (): Promise<Array<Record<string, unknown>>> => [],
+  ),
   resolveChatScopeRoutingMock: vi.fn(
     async (): Promise<{ router: "local" | "plugin"; nodeId: string | null }> => ({
       router: "local",
@@ -895,6 +897,120 @@ describe("chat routes", () => {
             stepIndex: 1,
             callIndex: 0,
             toolName: 'chat_channel_create',
+          }),
+        }),
+      }),
+    ]);
+  });
+
+  it('persists tool execution errors and completes the matching tool_call_start message', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const implToolError = async (...args: any[]) => {
+      const options = args[3] as {
+        onToolCallStart?: (
+          toolName: string,
+          args: Record<string, unknown>,
+          stepIndex: number,
+          callIndex: number,
+        ) => Promise<void>;
+        onToolCallError?: (
+          toolName: string,
+          args: Record<string, unknown>,
+          error: unknown,
+          stepIndex: number,
+          callIndex: number,
+        ) => Promise<void>;
+      };
+      if (options.onToolCallStart) {
+        await options.onToolCallStart(
+          'table_create',
+          { resourceId: 'sports-day-prep', title: 'Sports Day Preparation' },
+          2,
+          0,
+        );
+      }
+      if (options.onToolCallError) {
+        await options.onToolCallError(
+          'table_create',
+          { resourceId: 'sports-day-prep', title: 'Sports Day Preparation' },
+          new Error('SQL_INPUT_ERROR: SQLite input error: no such function: NOW'),
+          2,
+          0,
+        );
+      }
+      return {
+        textStream: (async function* () {
+          yield 'fallback table';
+        })(),
+        provider: 'anthropic',
+        modelId: 'claude-sonnet-4-5',
+      };
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    streamWithAgentToolsAndUserConfigMock.mockImplementationOnce(implToolError as any);
+
+    const response = await fetch(`${baseUrl}/api/chat/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        taskId: 'task-tool-error-1',
+        idempotencyKey: 'idem-tool-error-1',
+        channelId: 'default',
+        sessionId: 'session:default:main',
+        userMessageId: 'msg-u-tool-error-1',
+        assistantMessageId: 'msg-a-tool-error-1',
+        userMessage: 'show me a table',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(upsertMessagesMock).toHaveBeenCalledWith('user-123', [
+      expect.objectContaining({
+        messageId: 'msg-a-tool-error-1:ts:3',
+        role: 'assistant',
+        taskState: 'failed',
+        content: expect.stringContaining('no such function: NOW'),
+        metadata: expect.objectContaining({
+          agentLoop: expect.objectContaining({
+            phase: 'tool_call',
+            stepIndex: 3,
+            failedCalls: 1,
+          }),
+          toolCalls: [
+            expect.objectContaining({
+              toolName: 'table_create',
+              args: {
+                resourceId: 'sports-day-prep',
+                title: 'Sports Day Preparation',
+              },
+              result: expect.objectContaining({
+                ok: false,
+                error: expect.objectContaining({
+                  message: 'SQL_INPUT_ERROR: SQLite input error: no such function: NOW',
+                }),
+              }),
+            }),
+          ],
+        }),
+      }),
+    ]);
+    expect(upsertMessagesMock).toHaveBeenCalledWith('user-123', [
+      expect.objectContaining({
+        messageId: 'msg-a-tool-error-1:tc:3:0',
+        role: 'assistant',
+        content: '',
+        taskState: 'completed',
+        metadata: expect.objectContaining({
+          agentLoop: expect.objectContaining({
+            phase: 'tool_call_start',
+            stepIndex: 3,
+            callIndex: 0,
+            toolName: 'table_create',
+            error: expect.objectContaining({
+              message: 'SQL_INPUT_ERROR: SQLite input error: no such function: NOW',
+            }),
           }),
         }),
       }),

--- a/apps/node_backend/src/routes/chat.ts
+++ b/apps/node_backend/src/routes/chat.ts
@@ -75,6 +75,20 @@ function parseBoundedInt(
   return Math.max(defaults.min, Math.min(defaults.max, parsed));
 }
 
+function formatToolExecutionError(error: unknown): { code: string; message: string } {
+  if (error instanceof Error) {
+    return { code: error.name || "tool_execution_error", message: error.message };
+  }
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    return {
+      code: "tool_execution_error",
+      message: typeof message === "string" ? message : String(error),
+    };
+  }
+  return { code: "tool_execution_error", message: String(error) };
+}
+
 function dispatchPlaceholderMetadata(params: {
   resolvedBotId: string | null;
   resolvedSkillId: string | null;
@@ -479,6 +493,91 @@ async function runDefaultRouterRespondAsync(params: {
                     callIndex,
                     toolName,
                     args,
+                  },
+                },
+                createdAt: null,
+              },
+            ]);
+          },
+          onToolCallError: async (toolName, args, error, stepIndex, callIndex) => {
+            const oneBasedStepIndex = stepIndex + 1;
+            const toolError = formatToolExecutionError(error);
+            const failedResult = {
+              ok: false,
+              toolName,
+              data: null,
+              error: toolError,
+            };
+            const stepSuffix = `:ts:${oneBasedStepIndex}`;
+            const stepMessageId = `${assistantMessageId.slice(0, 255 - stepSuffix.length)}${stepSuffix}`;
+            const stepContent = `**Tool:** \`${toolName}\`\n\`\`\`json\n${JSON.stringify(failedResult, null, 2)}\n\`\`\``;
+
+            await upsertMessages(userId, [
+              {
+                messageId: stepMessageId,
+                taskId: acceptedTaskId,
+                channelId,
+                sessionId: acceptedSessionId,
+                threadId,
+                role: 'assistant',
+                content: stepContent,
+                taskState: 'failed',
+                checkpointCursor: null,
+                metadata: {
+                  ...dispatchPlaceholderMetadata({
+                    resolvedBotId,
+                    resolvedSkillId,
+                    source: 'backend.respond.agent_loop',
+                    model: typeof body.model === 'string' ? body.model : null,
+                  }),
+                  agentLoop: {
+                    phase: 'tool_call',
+                    stepIndex: oneBasedStepIndex,
+                    completedCalls: 0,
+                    failedCalls: 1,
+                    maxSteps: loopMaxSteps,
+                    maxToolCalls: loopMaxToolCalls,
+                    timeoutMs: loopTimeoutMs,
+                  },
+                  toolCalls: [
+                    {
+                      toolName,
+                      args,
+                      result: failedResult,
+                    },
+                  ],
+                },
+                createdAt: null,
+              },
+            ]);
+
+            const tcSuffix = `:tc:${oneBasedStepIndex}:${callIndex}`;
+            const tcMsgId = `${assistantMessageId.slice(0, 255 - tcSuffix.length)}${tcSuffix}`;
+            await upsertMessages(userId, [
+              {
+                messageId: tcMsgId,
+                taskId: acceptedTaskId,
+                channelId,
+                sessionId: acceptedSessionId,
+                threadId,
+                role: 'assistant',
+                content: '',
+                taskState: 'completed',
+                checkpointCursor: null,
+                metadata: {
+                  ...dispatchPlaceholderMetadata({
+                    resolvedBotId,
+                    resolvedSkillId,
+                    source: 'backend.respond.agent_loop',
+                    model: typeof body.model === 'string' ? body.model : null,
+                  }),
+                  agentLoop: {
+                    phase: 'tool_call_start',
+                    stepIndex: oneBasedStepIndex,
+                    callIndex,
+                    toolName,
+                    args,
+                    error: toolError,
                   },
                 },
                 createdAt: null,

--- a/apps/node_backend/src/routes/resources.ts
+++ b/apps/node_backend/src/routes/resources.ts
@@ -45,7 +45,10 @@ function readString(value: unknown, maxLength = 4096): string | null {
 }
 
 function userId(req: AuthRequest): string {
-  return req.user!.id;
+  if (!req.userId) {
+    throw new Error('Unauthorized');
+  }
+  return req.userId;
 }
 
 /** Validate a URL path parameter (already a string from express params). */

--- a/apps/node_backend/src/services/assetTableService.test.ts
+++ b/apps/node_backend/src/services/assetTableService.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { poolMock } = vi.hoisted(() => ({
+  poolMock: {
+    dialect: 'turso' as 'postgres' | 'turso',
+    query: vi.fn(),
+  },
+}));
+
+vi.mock('../db/index.js', () => ({
+  default: poolMock,
+}));
+
+describe('assetTableService SQL compatibility', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    poolMock.dialect = 'turso';
+    poolMock.query.mockReset();
+  });
+
+  it('uses Turso-compatible timestamp SQL when creating a table', async () => {
+    poolMock.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'tbl-1',
+          user_id: 'u-1',
+          resource_id: 'sports-day-prep',
+          title: 'Sports Day Preparation',
+          created_at: '2026-05-17 00:00:00',
+          updated_at: '2026-05-17 00:00:00',
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const { createTable } = await import('./assetTableService.js');
+    const table = await createTable('u-1', {
+      resourceId: 'sports-day-prep',
+      title: 'Sports Day Preparation',
+    });
+
+    const sql = poolMock.query.mock.calls[0][0] as string;
+    expect(sql).toContain('updated_at = CURRENT_TIMESTAMP');
+    expect(sql).not.toContain('NOW()');
+    expect(table).toMatchObject({
+      userId: 'u-1',
+      resourceId: 'sports-day-prep',
+      title: 'Sports Day Preparation',
+    });
+  });
+
+  it('uses Turso-compatible JSON SQL for row writes and parses JSON text rows', async () => {
+    poolMock.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'row-1',
+          user_id: 'u-1',
+          resource_id: 'sports-day-prep',
+          display_number: 1,
+          cell_data: '{"task":"Buy snacks","count":3}',
+          is_deleted: 0,
+          created_at: '2026-05-17 00:00:00',
+          updated_at: '2026-05-17 00:00:00',
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const { addRow } = await import('./assetTableService.js');
+    const row = await addRow('u-1', 'sports-day-prep', { task: 'Buy snacks' });
+
+    const sql = poolMock.query.mock.calls[0][0] as string;
+    expect(sql).toContain('$3');
+    expect(sql).not.toContain('::jsonb');
+    expect(row.cellData).toEqual({ task: 'Buy snacks', count: null });
+    expect(row.isDeleted).toBe(false);
+  });
+
+  it('uses Turso-compatible JSON merge SQL when updating a row', async () => {
+    poolMock.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'row-1',
+          user_id: 'u-1',
+          resource_id: 'sports-day-prep',
+          display_number: 1,
+          cell_data: '{"task":"Buy snacks","owner":"Alice"}',
+          is_deleted: 0,
+          created_at: '2026-05-17 00:00:00',
+          updated_at: '2026-05-17 00:01:00',
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const { updateRow } = await import('./assetTableService.js');
+    const row = await updateRow('u-1', 'sports-day-prep', 'row-1', {
+      owner: 'Alice',
+    });
+
+    const sql = poolMock.query.mock.calls[0][0] as string;
+    expect(sql).toContain("json_patch(COALESCE(cell_data, '{}'), $4)");
+    expect(sql).toContain('updated_at = CURRENT_TIMESTAMP');
+    expect(sql).not.toContain('NOW()');
+    expect(sql).not.toContain('::jsonb');
+    expect(row?.cellData).toEqual({ task: 'Buy snacks', owner: 'Alice' });
+  });
+});

--- a/apps/node_backend/src/services/assetTableService.ts
+++ b/apps/node_backend/src/services/assetTableService.ts
@@ -67,10 +67,40 @@ interface DataRow {
   user_id: string;
   resource_id: string;
   display_number: number;
-  cell_data: Record<string, string | null>;
-  is_deleted: boolean;
+  cell_data: Record<string, string | null> | string | null;
+  is_deleted: boolean | number | string;
   created_at: string;
   updated_at: string;
+}
+
+const isTurso = pool.dialect === 'turso';
+const currentTimestampSql = isTurso ? 'CURRENT_TIMESTAMP' : 'NOW()';
+const jsonValueSql = (placeholder: string): string => isTurso ? placeholder : `${placeholder}::jsonb`;
+const mergeJsonSql = (column: string, placeholder: string): string =>
+  isTurso
+    ? `json_patch(COALESCE(${column}, '{}'), ${placeholder})`
+    : `${column} || ${placeholder}::jsonb`;
+const notDeletedSql = isTurso ? 'is_deleted = 0' : 'is_deleted = FALSE';
+const deletedValueSql = isTurso ? '1' : 'TRUE';
+
+function parseCellData(raw: DataRow['cell_data']): Record<string, string | null> {
+  if (!raw) return {};
+  if (typeof raw !== 'string') return raw;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const normalized: Record<string, string | null> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      normalized[key] = typeof value === 'string' ? value : null;
+    }
+    return normalized;
+  } catch {
+    return {};
+  }
+}
+
+function parseIsDeleted(raw: DataRow['is_deleted']): boolean {
+  return raw === true || raw === 1 || raw === '1' || raw === 'true';
 }
 
 function tableToDto(row: TableRow): AssetTable {
@@ -101,8 +131,8 @@ function dataRowToDto(row: DataRow): AssetTableRow {
     id: row.id,
     resourceId: row.resource_id,
     displayNumber: row.display_number,
-    cellData: row.cell_data ?? {},
-    isDeleted: row.is_deleted,
+    cellData: parseCellData(row.cell_data),
+    isDeleted: parseIsDeleted(row.is_deleted),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -131,7 +161,7 @@ export async function createTable(
     `INSERT INTO asset_tables (user_id, resource_id, title)
           VALUES ($1, $2, $3)
           ON CONFLICT (user_id, resource_id)
-          DO UPDATE SET title = EXCLUDED.title, updated_at = NOW()
+          DO UPDATE SET title = EXCLUDED.title, updated_at = ${currentTimestampSql}
        RETURNING id, user_id, resource_id, title, created_at, updated_at`,
     [userId, input.resourceId, input.title],
   );
@@ -159,7 +189,7 @@ export async function getTable(
     pool.query<DataRow>(
       `SELECT id, user_id, resource_id, display_number, cell_data, is_deleted, created_at, updated_at
          FROM asset_table_rows
-        WHERE user_id = $1 AND resource_id = $2 AND is_deleted = FALSE
+        WHERE user_id = $1 AND resource_id = $2 AND ${notDeletedSql}
         ORDER BY display_number ASC, created_at ASC`,
       [userId, resourceId],
     ),
@@ -178,8 +208,9 @@ export async function getTable(
   // resources.ts). Coercing preserves the DTO contract for all consumers.
   const rows = rowResult.rows.map((r) => {
     const filtered: Record<string, string | null> = {};
+    const cellData = parseCellData(r.cell_data);
     for (const key of columnKeys) {
-      const raw = r.cell_data?.[key];
+      const raw = cellData[key];
       filtered[key] = typeof raw === 'string' ? raw : null;
     }
     return dataRowToDto({ ...r, cell_data: filtered });
@@ -208,7 +239,7 @@ export async function addColumn(
           DO UPDATE SET
             display_name = EXCLUDED.display_name,
             column_order = EXCLUDED.column_order,
-            updated_at = NOW()
+            updated_at = ${currentTimestampSql}
        RETURNING id, user_id, resource_id, column_key, display_name, column_order, created_at, updated_at`,
     [userId, resourceId, input.columnKey, input.displayName, input.columnOrder ?? 0],
   );
@@ -242,7 +273,7 @@ export async function addRow(
     `INSERT INTO asset_table_rows (user_id, resource_id, display_number, cell_data)
           SELECT $1, $2,
                  COALESCE((SELECT MAX(display_number) FROM asset_table_rows WHERE user_id = $1 AND resource_id = $2), 0) + 1,
-                 $3::jsonb
+                 ${jsonValueSql('$3')}
        RETURNING id, user_id, resource_id, display_number, cell_data, is_deleted, created_at, updated_at`,
     [userId, resourceId, JSON.stringify(cellData)],
   );
@@ -258,9 +289,9 @@ export async function updateRow(
   // Merge incoming cell_data onto existing using JSONB concatenation operator (||).
   const result = await pool.query<DataRow>(
     `UPDATE asset_table_rows
-        SET cell_data = cell_data || $4::jsonb,
-            updated_at = NOW()
-      WHERE user_id = $1 AND resource_id = $2 AND id = $3 AND is_deleted = FALSE
+        SET cell_data = ${mergeJsonSql('cell_data', '$4')},
+            updated_at = ${currentTimestampSql}
+      WHERE user_id = $1 AND resource_id = $2 AND id = $3 AND ${notDeletedSql}
       RETURNING id, user_id, resource_id, display_number, cell_data, is_deleted, created_at, updated_at`,
     [userId, resourceId, rowId, JSON.stringify(cellData)],
   );
@@ -274,7 +305,7 @@ export async function deleteRow(
 ): Promise<{ deleted: boolean }> {
   const result = await pool.query(
     `UPDATE asset_table_rows
-        SET is_deleted = TRUE, updated_at = NOW()
+        SET is_deleted = ${deletedValueSql}, updated_at = ${currentTimestampSql}
       WHERE user_id = $1 AND resource_id = $2 AND id = $3`,
     [userId, resourceId, rowId],
   );

--- a/apps/node_backend/src/services/localAgentLoopService.ts
+++ b/apps/node_backend/src/services/localAgentLoopService.ts
@@ -119,7 +119,7 @@ export interface ExecuteInternalToolResult {
   data: Record<string, unknown> | null;
   error:
     | {
-        code: 'invalid_args' | 'not_implemented' | 'tool_not_allowed';
+        code: 'invalid_args' | 'not_implemented' | 'tool_not_allowed' | 'not_found';
         message: string;
       }
     | null;

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: feature_map
 owner: bricks
-last_updated: 2026-05-16
+last_updated: 2026-05-17
 purpose: >
   为人类测试员和 AI 测试员提供产品功能清单与进入路径，作为回归测试与变更影响评估的入口索引。
 
@@ -26,6 +26,7 @@ products:
         smoke_checks:
           - Web 打开登录页并发起 GitHub 登录。
           - iOS release 点击 GitHub 登录时默认应打开 `https://bricks.askman.dev` 上的后端 OAuth 授权页。
+          - iOS debug 真机包在没有显式 `BRICKS_API_BASE_URL` 时，也应默认使用 `https://bricks.askman.dev`，避免手机把 `localhost` 当成本机。
           - iOS OAuth 完成后通过 `bricks://auth/github/callback` 回到应用。
           - 完成 token 回调后进入主界面。
 
@@ -66,6 +67,8 @@ products:
           - 侧边栏频道列表与顶部频道下拉菜单均按最新消息时间降序排列；有消息记录的频道排在无消息频道前面；默认频道参与排序，不固定置顶；时间相同时按 id 字典序确定顺序。
           - 顶部标题显示当前频道名且左对齐。
           - iOS/Android 登录完成后，聊天初始化不应因本地 Agents 目录不支持而失败，且应继续加载该账号的历史会话。
+          - iOS 启动聊天初始化时，本地 Agents 目录应从 app sandbox 路径解析，不依赖 `HOME` 环境变量。
+          - 本地自定义 Agent 文件读取失败时，应回退为仅使用内建 Agent，并继续加载线上频道与历史消息。
           - 切换 Agent 后仍可继续会话。
           - 首次安装且未创建自定义 Agent 时，侧边栏 Agents 分组应默认显示内建 Agent 列表（不为空）。
           - 侧边栏应在 Agents 分组上方显示 Skills 分组；当前内容为空并显示“待实现”占位。
@@ -221,6 +224,8 @@ products:
         smoke_checks:
           - 用户说"创建一个叫 Tasks 的表格，列名为 Name 和 Status"，AI 依次调用 table_create 和 table_add_column，完成后回复确认。
           - 用户说"显示 Tasks 表格"，AI 调用 table_get 并以 Markdown 表格回复。
+          - 在 Turso/libSQL 数据库下，table_create / table_add_column / table_add_row / table_update_row / table_delete_row 均应成功执行，不应因 PostgreSQL-only SQL（例如 NOW() 或 ::jsonb）失败。
+          - 当 table_create 执行时抛出数据库错误，聊天历史应显示工具错误结果，并将对应 tool_call_start 标记为已完成，不能永久显示“正在调用”。
           - 添加一列 Priority 后，已有行不变（O(1) schema change）。
           - 软删除行后，table_get 不返回该行。
 

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -1,7 +1,7 @@
 version: 1
 map_type: logic_map
 owner: bricks
-last_updated: 2026-05-16
+last_updated: 2026-05-17
 purpose: >
   为人类测试员、AI 测试员与 AI 工程师提供“功能 -> 代码/文档/关键词”映射，
   用于影响面分析、回归测试设计与遗留逻辑清理。
@@ -36,9 +36,11 @@ index:
       - token
       - auth
       - callback
+      - iOS debug API base URL
     change_risks:
       - Web 与移动端 token 回调分支行为不一致。
       - 登录成功后导航状态未同步。
+      - iOS debug 包若默认使用 localhost，会把请求发到手机本机而不是 Bricks API，导致 GitHub 登录后无法加载线上账号数据。
       - native callback scheme 配置或后端 allowlist 不一致会导致 iOS 登录无法返回应用。
 
   - feature_id: chat_session
@@ -87,6 +89,7 @@ index:
       - docs/plans/2026-05-15-16-21-+08-chat-scroll-position-gwt.md
       - docs/plans/2026-05-15-16-54-+08-local-chat-fixture-db.md
       - docs/plans/2026-05-16-17-58-+08-mobile-agents-directory-setup-fix.md
+      - docs/plans/2026-05-16-23-21-+08-ios-sandbox-path-without-home.md
       - docs/testing/local-chat-fixture-db.md
     test_index:
       - apps/mobile_chat_app/test/chat_arbitration_engine_test.dart
@@ -97,6 +100,7 @@ index:
       - apps/mobile_chat_app/test/chat_builtin_agents_test.dart
       - apps/mobile_chat_app/test/message_list_test.dart
       - apps/mobile_chat_app/test/composer_bar_test.dart
+      - packages/platform_bridge/test/platform_paths_io_test.dart
       - apps/node_backend/src/routes/chat.test.ts
       - tests/usecases/mobile_chat_openclaw_web_routing.yaml
       - apps/node_backend/src/services/chatAsyncTransportService.test.ts
@@ -148,6 +152,7 @@ index:
       - fixture sqlite db
       - mobile sandbox path
       - agents directory
+      - iOS HOME environment
     change_risks:
       - 改动路由或拓扑后，消息分发链路中断。
       - 会话持久化字段升级时出现向后兼容问题。
@@ -184,6 +189,8 @@ index:
       - 若初始历史批次没有 user 消息时仍套用 user 锚点 padding，最后一段 AI/tool/status 内容会被不自然地抬高。
       - 若初始历史加载回退为全量历史而非最后 20 条，会放大长会话进入页面的渲染和滚动定位成本。
       - 若移动端没有可写的本地 Agents 目录，登录后的 chat setup 会在历史会话加载前失败，表现为同账号移动端看不到网页历史数据。
+      - 若 iOS 本地路径解析依赖 `HOME` 环境变量，真机启动会在 chat setup 阶段失败并阻断历史会话加载。
+      - 若本地自定义 Agent 文件读取与线上会话初始化共用同一个失败边界，单个本地文件系统异常会误伤频道和历史加载。
       - 若组件直接写死颜色或误用 `primary` 作为普通气泡背景，会破坏暗色信息层级并导致关键行动不突出。
       - 若频道最新消息时间未在消息加载、追加、归档时同步更新，侧边栏排序将与实际活跃时间脱节。
       - 若仅对侧边栏频道列表使用 _sortedChannels 而未对顶部频道下拉菜单同步更新，两处展示顺序不一致会混淆用户。
@@ -551,24 +558,36 @@ index:
       - apps/node_backend/src/db/migrations/016_create_asset_tables.sql
       - apps/node_backend/src/services/assetTableService.ts
       - apps/node_backend/src/services/localAgentLoopService.ts
+      - apps/node_backend/src/llm/llm_service.ts
+      - apps/node_backend/src/routes/chat.ts
       - apps/node_backend/src/routes/resources.ts
       - apps/mobile_chat_app/lib/features/chat/asset_table_api_service.dart
     doc_index:
       - docs/plans/2026-05-16-02-20-+00-todos-tables-highlights-tools.md
+      - docs/plans/2026-05-17-00-04-+08-table-tool-error-and-turso-compatibility.md
+      - docs/kb/turso-sqlite-compatibility.md
     test_index:
       - apps/node_backend/src/services/localAgentLoopService.test.ts
+      - apps/node_backend/src/services/assetTableService.test.ts
+      - apps/node_backend/src/routes/chat.test.ts
     keywords:
       - asset_table
       - table_create
       - table_add_column
       - table_get
       - JSONB
+      - Turso
+      - libSQL
+      - SQLite compatibility
+      - tool-error
       - sparse storage
       - column registry
     change_risks:
       - getTable 在读取时用 column registry 过滤 cell_data keys；删除列后旧数据仍保留在 JSONB，仅在读时过滤——若直接查询 DB 会看到孤立 key。
       - addRow 使用子查询计算 MAX(display_number)+1，高并发下可能产生重复 display_number（可接受，仅用于排序）。
       - removeColumn 仅删除 asset_table_columns 记录，不清理已有行的 cell_data，需注意存储膨胀。
+      - 运行时 SQL 若使用 PostgreSQL-only 语法（NOW()、::jsonb、JSONB concat）会在 Turso/libSQL 下执行失败，导致工具 start 已落库但无 result。
+      - AI SDK 的 tool-error 事件若未持久化，历史消息会永久显示“正在调用 table_create”，即使工具已经失败。
 
   - feature_id: text_highlights
     capability: 用户选中助手消息文本后通过上下文菜单"划线"持久化高亮；AI 可用 highlight_list 工具查询

--- a/docs/kb/turso-sqlite-compatibility.md
+++ b/docs/kb/turso-sqlite-compatibility.md
@@ -1,0 +1,75 @@
+# Turso / SQLite Compatibility Notes
+
+## Purpose
+
+Production data can run on Turso/libSQL through `TURSO_DATABASE_URL`. Backend
+SQL must therefore stay compatible with SQLite semantics unless a query is
+explicitly guarded by the active database dialect.
+
+This note records compatibility issues that can produce runtime-only failures
+even when TypeScript and route tests pass.
+
+## Known Issue: PostgreSQL Timestamp Functions
+
+Do not use PostgreSQL-only functions such as `NOW()` in SQL that may execute
+against Turso/libSQL.
+
+Example failure observed while debugging `table_create`:
+
+```text
+SQL_INPUT_ERROR: SQLite input error: no such function: NOW
+```
+
+The failing pattern was:
+
+```sql
+ON CONFLICT (user_id, resource_id)
+DO UPDATE SET title = EXCLUDED.title, updated_at = NOW()
+```
+
+Under Turso/libSQL, use a SQLite-compatible timestamp expression or branch by
+`pool.dialect`.
+
+## Practical Rules
+
+- Treat `apps/node_backend/src/db/index.ts` as the source of truth for the
+  active dialect.
+- If SQL is shared by PostgreSQL and Turso, avoid database-specific functions.
+- If dialect-specific SQL is necessary, branch explicitly on `pool.dialect` and
+  keep both branches covered by tests.
+- Prefer integration-style probes for mutation queries that are hard to validate
+  through unit tests alone.
+- When a tool start is persisted before execution, any thrown SQL/runtime error
+  must also be persisted as a tool error so the UI does not show a stale
+  "calling" state.
+
+## Offline Validation Options
+
+Use offline checks before reaching for a remote Turso database:
+
+1. Mock the repository database pool with `pool.dialect = 'turso'` in focused
+   unit tests. Assert generated runtime SQL uses SQLite-compatible expressions
+   such as `CURRENT_TIMESTAMP`, `json_patch(...)`, and does not contain
+   PostgreSQL-only syntax such as `NOW()` or `::jsonb`.
+2. Use the existing migration adapter tests around `adaptMigrationForSqlite` for
+   migration files. This catches migration-only PostgreSQL syntax, but it does
+   not validate runtime service SQL.
+3. For stronger no-network execution coverage, create a temporary local
+   libSQL/SQLite file database through `@libsql/client` with a `file:` URL, run
+   adapted migrations, execute the service function, then delete the temporary
+   file. This can catch real execution errors such as `no such function: NOW`.
+4. SQLite CLI checks are useful for broad SQL syntax probes, but prefer local
+   `@libsql/client` tests when validating code that normally runs through the
+   Turso client path.
+
+## Review Checklist
+
+When adding or changing backend SQL, check:
+
+1. Does the query use PostgreSQL-only functions such as `NOW()`?
+2. Does the query use syntax that SQLite/libSQL does not support?
+3. Is the query executed through `pool.query`, meaning it may hit either
+   PostgreSQL or Turso?
+4. Is there coverage or a local probe for the Turso/libSQL path?
+5. If the query runs inside an AI tool, will thrown execution errors be visible
+   in chat history?

--- a/docs/plans/2026-05-16-22-43-+08-ios-debug-api-base-url.md
+++ b/docs/plans/2026-05-16-22-43-+08-ios-debug-api-base-url.md
@@ -1,0 +1,36 @@
+# iOS Debug API Base URL
+
+## Background
+
+Local debug builds currently default non-web platforms to `http://localhost:3000`.
+That is useful for desktop development, but it is wrong for iOS device testing:
+`localhost` points at the phone, not the developer machine or production API.
+
+For GitHub OAuth and real account history validation on iPhone, iOS debug builds
+should use the same production API as release builds unless a developer
+explicitly overrides `BRICKS_API_BASE_URL`.
+
+## Goals
+
+- Make iOS debug builds default to `https://bricks.askman.dev`.
+- Preserve web debug behavior: use the current browser origin.
+- Preserve local desktop/other debug behavior: use `http://localhost:3000`.
+- Keep `BRICKS_API_BASE_URL` as the highest-priority explicit override.
+
+## Implementation Plan
+
+1. Update `LlmConfigService.resolveBaseUrl()`.
+2. Add a focused test for iOS debug platform selection.
+3. Reinstall the app on the connected iPhone for validation.
+
+## Acceptance Criteria
+
+- iOS debug builds use the production API by default.
+- Existing local non-web test builds continue to use localhost.
+- Developers can still override the API base URL with `BRICKS_API_BASE_URL`.
+
+## Validation Commands
+
+- `flutter test test/llm_config_service_test.dart`
+- `flutter analyze`
+- `flutter run -d <ios-device-id>`

--- a/docs/plans/2026-05-16-23-21-+08-ios-sandbox-path-without-home.md
+++ b/docs/plans/2026-05-16-23-21-+08-ios-sandbox-path-without-home.md
@@ -1,0 +1,35 @@
+# iOS Sandbox Path Without HOME
+
+## Background
+
+The iOS debug app can show `Failed to load chat setup: Unsupported operation: HOME environment variable is not available on this platform.` during startup. The mobile platform path implementation added iOS support but still used `Platform.environment['HOME']`, which is not reliable in the iOS app sandbox.
+
+## Goals
+
+- Resolve iOS document, cache, and agents directories without reading `HOME`.
+- Keep desktop behavior unchanged.
+- Preserve Android mobile path behavior.
+- Add a small unit test for the mobile temp-directory-to-app-container path logic.
+- Keep chat history loading independent from local custom-agent file availability.
+
+## Implementation Plan
+
+1. Add a mobile app data directory resolver based on `Directory.systemTemp.path`.
+2. Use that resolver for iOS `Documents`, `Library/Caches/bricks`, and `Library/Application Support/bricks/agents`.
+3. Keep Android on the same temp-parent resolver it already effectively used.
+4. Make startup custom-agent loading best-effort so local file path failures fall back to built-in agents and do not block remote chat setup.
+5. Validate the resolver with platform-independent unit tests.
+
+## Acceptance Criteria
+
+- iOS path resolution does not call `_requiredEnv('HOME')`.
+- `agentsDirectory()` on iOS resolves under the app sandbox `Library/Application Support/bricks/agents`.
+- Startup chat setup no longer fails because `HOME` is missing.
+- Startup chat setup continues loading scopes, channel names, and active history even if local custom-agent files cannot be read.
+- Existing mobile chat API base URL behavior remains unchanged.
+
+## Validation Commands
+
+- `cd packages/platform_bridge && dart test`
+- `cd apps/mobile_chat_app && flutter test test/llm_config_service_test.dart`
+- `cd apps/mobile_chat_app && flutter analyze`

--- a/docs/plans/2026-05-17-00-04-+08-table-tool-error-and-turso-compatibility.md
+++ b/docs/plans/2026-05-17-00-04-+08-table-tool-error-and-turso-compatibility.md
@@ -1,0 +1,99 @@
+# Table Tool Error and Turso Compatibility Fix
+
+## Background
+
+The historical chat stream can show a `table_create` tool call stuck in the
+"calling" state. Database inspection showed two different failure modes in the
+same assistant response:
+
+- The first `table_create` call returned a normal tool result with
+  `ok: false` because the model omitted the required `resourceId` argument.
+- The second `table_create` call had valid arguments, but no persisted
+  `tool_call` result row. A direct non-mutating SQL probe showed the underlying
+  `createTable` query fails on Turso/libSQL because it uses PostgreSQL's
+  `NOW()` function.
+
+The UI difference comes from persistence, not from user intent. Business-level
+tool failures are persisted as result rows, while thrown tool execution errors
+from the AI SDK stream are currently ignored by the backend stream wrapper.
+
+## Goals
+
+- Make asset table mutations compatible with the repository's Turso/libSQL
+  production database.
+- Persist tool execution errors so tool starts cannot remain permanently stuck
+  in `dispatched`.
+- Preserve clear UX semantics: started, completed successfully, completed with
+  business failure, and completed with execution error should be distinguishable
+  in history.
+- Add focused regression coverage for both the SQL compatibility issue and the
+  missing `tool-error` persistence path.
+
+## Implementation Plan
+
+1. Fix Turso-compatible asset table writes.
+   - Replace PostgreSQL-only timestamp expressions in asset table write paths
+     with SQL that works under Turso/libSQL.
+   - Audit nearby table, column, and row mutation queries for other
+     PostgreSQL-only functions or syntax.
+   - Keep existing PostgreSQL behavior working if the service is still run with
+     a PostgreSQL `DATABASE_URL`.
+
+2. Persist AI SDK tool execution errors.
+   - Extend the stream event model in `apps/node_backend/src/llm/llm_service.ts`
+     to handle `tool-error` parts from `result.fullStream`.
+   - Route tool execution errors through a callback with the same step and call
+     identity used by `tool-call` start messages.
+   - Upsert a tool result/error message for the failed step and mark the
+     matching `:tc:<step>:<call>` start message as completed or failed instead
+     of leaving it `dispatched`.
+
+3. Recheck step/call identity handling.
+   - Confirm `onToolCallStart`, `onStepFinish`, and any new error callback use a
+     single consistent source of step and call indexes.
+   - Avoid creating synthetic completed rows with IDs that do not match the
+     original start row.
+
+4. Update tests.
+   - Add or extend backend tests for `table_create` against the Turso dialect or
+     a SQL conversion path that catches SQLite-incompatible expressions.
+   - Add a stream wrapper test where the SDK emits `tool-call`, then
+     `tool-error`, then final text, and assert that the persisted history has no
+     permanently dispatched start row.
+   - Add a route-level regression test if needed to verify the message IDs and
+     task states shown to clients.
+
+5. Validate with realistic data.
+   - Reproduce the historical `show me a table` scenario locally with a fixture
+     or test database.
+   - Confirm the UI/history shows a completed error state rather than a stale
+     "calling" row if execution fails.
+   - Confirm a valid `table_create` request creates or updates an asset table in
+     Turso/libSQL.
+
+6. Update documentation and maps.
+   - Keep the Turso compatibility note in `docs/kb/`.
+   - Update code maps if implementation changes feature entry points, backend
+     tool logic, or validation indexes.
+
+## Acceptance Criteria
+
+- A valid `table_create` call with `resourceId` and `title` succeeds against
+  Turso/libSQL and leaves an `asset_tables` row.
+- A `table_create` execution error is visible in chat history as a completed or
+  failed tool event, not as an indefinitely "calling" event.
+- The first invalid-arguments failure still appears as a normal tool result with
+  the returned `invalid_args` payload.
+- Message ordering remains deterministic for tool start, tool result/error, and
+  final assistant text.
+- Tests cover the Turso SQL compatibility bug and the AI SDK `tool-error`
+  persistence bug.
+
+## Validation Commands
+
+- `./tools/init_dev_env.sh`
+- `cd apps/node_backend && npm test -- --run src/services/localAgentLoopService.test.ts`
+- `cd apps/node_backend && npm test -- --run src/routes/chat.test.ts`
+- `cd apps/node_backend && npm run type-check`
+- `cd apps/mobile_chat_app && flutter test`
+- `cd apps/mobile_chat_app && flutter analyze`

--- a/packages/platform_bridge/lib/src/io/platform_paths_io.dart
+++ b/packages/platform_bridge/lib/src/io/platform_paths_io.dart
@@ -18,9 +18,11 @@ class PlatformPathsImpl implements PlatformPaths {
   }
 
   String _androidAppDataDirectory() {
-    final cacheDir = Directory.systemTemp;
-    final appDataDir = cacheDir.parent;
-    return appDataDir.path;
+    return mobileAppDataDirectoryFromTempPath(Directory.systemTemp.path);
+  }
+
+  String _iosAppDataDirectory() {
+    return mobileAppDataDirectoryFromTempPath(Directory.systemTemp.path);
   }
 
   @override
@@ -32,7 +34,7 @@ class PlatformPathsImpl implements PlatformPaths {
       return '${_requiredEnv('USERPROFILE')}\\Documents';
     }
     if (Platform.isIOS) {
-      return '${_requiredEnv('HOME')}/Documents';
+      return '${_iosAppDataDirectory()}/Documents';
     }
     if (Platform.isAndroid) {
       return '${_androidAppDataDirectory()}/files';
@@ -54,7 +56,7 @@ class PlatformPathsImpl implements PlatformPaths {
       return '${_requiredEnv('LOCALAPPDATA')}\\bricks\\cache';
     }
     if (Platform.isIOS) {
-      return '${_requiredEnv('HOME')}/Library/Caches/bricks';
+      return '${_iosAppDataDirectory()}/Library/Caches/bricks';
     }
     if (Platform.isAndroid) {
       return '${_androidAppDataDirectory()}/cache/bricks';
@@ -82,7 +84,7 @@ class PlatformPathsImpl implements PlatformPaths {
       return '${_requiredEnv('LOCALAPPDATA')}\\bricks\\agents';
     }
     if (Platform.isIOS) {
-      return '${_requiredEnv('HOME')}/Library/Application Support/bricks/agents';
+      return '${_iosAppDataDirectory()}/Library/Application Support/bricks/agents';
     }
     if (Platform.isAndroid) {
       return '${_androidAppDataDirectory()}/files/bricks/agents';
@@ -91,4 +93,13 @@ class PlatformPathsImpl implements PlatformPaths {
       'agentsDirectory is not supported on this platform.',
     );
   }
+}
+
+/// Returns the app data container from the platform temp directory.
+///
+/// iOS exposes temp files under `<app-container>/tmp`, and Android exposes
+/// them under `<app-data>/cache`. In both cases the parent is the app data
+/// container that should be used for app-owned files.
+String mobileAppDataDirectoryFromTempPath(String tempPath) {
+  return Directory(tempPath).parent.path;
 }

--- a/packages/platform_bridge/test/platform_paths_io_test.dart
+++ b/packages/platform_bridge/test/platform_paths_io_test.dart
@@ -1,0 +1,23 @@
+import 'package:platform_bridge/src/io/platform_paths_io.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('resolves mobile app data directory from iOS temp directory', () {
+    final appDataDirectory = mobileAppDataDirectoryFromTempPath(
+      '/private/var/mobile/Containers/Data/Application/APP-ID/tmp',
+    );
+
+    expect(
+      appDataDirectory,
+      '/private/var/mobile/Containers/Data/Application/APP-ID',
+    );
+  });
+
+  test('resolves mobile app data directory from Android cache directory', () {
+    final appDataDirectory = mobileAppDataDirectoryFromTempPath(
+      '/data/user/0/dev.askman.bricks/cache',
+    );
+
+    expect(appDataDirectory, '/data/user/0/dev.askman.bricks');
+  });
+}


### PR DESCRIPTION
## Summary
- fix Turso/libSQL compatibility for asset table runtime queries
- persist AI SDK tool execution errors so tool calls do not stay stuck in calling state
- fix iOS chat setup defaults and sandbox path handling for debug/mobile startup
- document Turso compatibility guidance, plans, and code map updates

## Validation
- ./tools/init_dev_env.sh
- cd apps/node_backend && npm test -- --run src/db/migrate.test.ts src/services/assetTableService.test.ts src/routes/chat.test.ts
- cd apps/node_backend && npm run type-check
- npx js-yaml docs/code_maps/feature_map.yaml > /dev/null && npx js-yaml docs/code_maps/logic_map.yaml > /dev/null
- Turso live probe: create/update/delete temporary asset table resources, then verified cleanup counts were [0,0,0]