### PR TITLE
Fix highlight list rendering and unify auth API client

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/asset_table_api_service.dart
+++ b/apps/mobile_chat_app/lib/features/chat/asset_table_api_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+import '../../services/authenticated_api_client.dart';
 import '../settings/llm_config_service.dart';
 
 // ---------------------------------------------------------------------------
@@ -117,39 +118,39 @@ class AssetTableSummary {
 // ---------------------------------------------------------------------------
 
 class AssetTableApiService {
-  AssetTableApiService({http.Client? httpClient})
-      : _httpClient = httpClient ?? http.Client(),
-        _ownsHttpClient = httpClient == null;
+  AssetTableApiService({
+    http.Client? httpClient,
+    AuthenticatedApiClient? apiClient,
+  })  : _apiClient =
+            apiClient ?? AuthenticatedApiClient(httpClient: httpClient),
+        _ownsApiClient = apiClient == null;
 
-  final http.Client _httpClient;
-  final bool _ownsHttpClient;
+  final AuthenticatedApiClient _apiClient;
+  final bool _ownsApiClient;
 
   void dispose() {
-    if (_ownsHttpClient) {
-      _httpClient.close();
+    if (_ownsApiClient) {
+      _apiClient.close();
     }
   }
 
   String get _base => LlmConfigService.resolveBaseUrl();
   Uri get _tablesUri => Uri.parse('$_base/api/resources/tables');
-  Uri _tableUri(String resourceId) =>
-      Uri.parse('$_base/api/resources/tables/${Uri.encodeComponent(resourceId)}');
-  Uri _columnsUri(String resourceId) =>
-      Uri.parse('$_base/api/resources/tables/${Uri.encodeComponent(resourceId)}/columns');
+  Uri _tableUri(String resourceId) => Uri.parse(
+      '$_base/api/resources/tables/${Uri.encodeComponent(resourceId)}');
+  Uri _columnsUri(String resourceId) => Uri.parse(
+      '$_base/api/resources/tables/${Uri.encodeComponent(resourceId)}/columns');
   Uri _columnUri(String resourceId, String columnKey) => Uri.parse(
         '$_base/api/resources/tables/${Uri.encodeComponent(resourceId)}/columns/${Uri.encodeComponent(columnKey)}',
       );
-  Uri _rowsUri(String resourceId) =>
-      Uri.parse('$_base/api/resources/tables/${Uri.encodeComponent(resourceId)}/rows');
+  Uri _rowsUri(String resourceId) => Uri.parse(
+      '$_base/api/resources/tables/${Uri.encodeComponent(resourceId)}/rows');
   Uri _rowUri(String resourceId, String rowId) => Uri.parse(
         '$_base/api/resources/tables/${Uri.encodeComponent(resourceId)}/rows/${Uri.encodeComponent(rowId)}',
       );
 
-  Future<List<AssetTableSummary>> listTables({required String token}) async {
-    final response = await _httpClient.get(
-      _tablesUri,
-      headers: {'Authorization': 'Bearer $token'},
-    );
+  Future<List<AssetTableSummary>> listTables() async {
+    final response = await _apiClient.get(_tablesUri);
     if (response.statusCode != 200) {
       throw Exception('Failed to list tables: ${response.statusCode}');
     }
@@ -162,13 +163,9 @@ class AssetTableApiService {
   }
 
   Future<AssetTableDetail> getTable({
-    required String token,
     required String resourceId,
   }) async {
-    final response = await _httpClient.get(
-      _tableUri(resourceId),
-      headers: {'Authorization': 'Bearer $token'},
-    );
+    final response = await _apiClient.get(_tableUri(resourceId));
     if (response.statusCode != 200) {
       throw Exception('Failed to get table: ${response.statusCode}');
     }
@@ -178,14 +175,12 @@ class AssetTableApiService {
   }
 
   Future<AssetTableSummary> createTable({
-    required String token,
     required String resourceId,
     required String title,
   }) async {
-    final response = await _httpClient.post(
+    final response = await _apiClient.post(
       _tablesUri,
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({'resourceId': resourceId, 'title': title}),
@@ -199,16 +194,14 @@ class AssetTableApiService {
   }
 
   Future<AssetTableColumn> addColumn({
-    required String token,
     required String resourceId,
     required String columnKey,
     required String displayName,
     int columnOrder = 0,
   }) async {
-    final response = await _httpClient.post(
+    final response = await _apiClient.post(
       _columnsUri(resourceId),
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({
@@ -226,28 +219,22 @@ class AssetTableApiService {
   }
 
   Future<void> removeColumn({
-    required String token,
     required String resourceId,
     required String columnKey,
   }) async {
-    final response = await _httpClient.delete(
-      _columnUri(resourceId, columnKey),
-      headers: {'Authorization': 'Bearer $token'},
-    );
+    final response = await _apiClient.delete(_columnUri(resourceId, columnKey));
     if (response.statusCode != 200) {
       throw Exception('Failed to remove column: ${response.statusCode}');
     }
   }
 
   Future<AssetTableRow> addRow({
-    required String token,
     required String resourceId,
     Map<String, String?> cellData = const {},
   }) async {
-    final response = await _httpClient.post(
+    final response = await _apiClient.post(
       _rowsUri(resourceId),
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({'cellData': cellData}),
@@ -261,15 +248,13 @@ class AssetTableApiService {
   }
 
   Future<AssetTableRow> updateRow({
-    required String token,
     required String resourceId,
     required String rowId,
     required Map<String, String?> cellData,
   }) async {
-    final response = await _httpClient.patch(
+    final response = await _apiClient.patch(
       _rowUri(resourceId, rowId),
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({'cellData': cellData}),
@@ -283,14 +268,10 @@ class AssetTableApiService {
   }
 
   Future<void> deleteRow({
-    required String token,
     required String resourceId,
     required String rowId,
   }) async {
-    final response = await _httpClient.delete(
-      _rowUri(resourceId, rowId),
-      headers: {'Authorization': 'Bearer $token'},
-    );
+    final response = await _apiClient.delete(_rowUri(resourceId, rowId));
     if (response.statusCode != 200) {
       throw Exception('Failed to delete row: ${response.statusCode}');
     }

--- a/apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
+import '../../services/authenticated_api_client.dart';
 import '../settings/llm_config_service.dart';
 import 'chat_message.dart';
 import 'chat_message_sort.dart';
@@ -75,14 +76,15 @@ class ChatChannelNameSetting {
 }
 
 class ChatHistoryApiService {
-  ChatHistoryApiService({http.Client? httpClient})
-      : _httpClient = httpClient ?? http.Client(),
-        _ownsHttpClient = httpClient == null;
+  ChatHistoryApiService({
+    http.Client? httpClient,
+    AuthenticatedApiClient? apiClient,
+  })  : _apiClient =
+            apiClient ?? AuthenticatedApiClient(httpClient: httpClient),
+        _ownsApiClient = apiClient == null;
 
-  final http.Client _httpClient;
-  final bool _ownsHttpClient;
-
-  http.Client get _client => _httpClient;
+  final AuthenticatedApiClient _apiClient;
+  final bool _ownsApiClient;
 
   /// Fields from [ChatMessage.toMap] that carry server-relevant information.
   /// UI-only state (isStreaming, arbitration flags, score details, etc.) is
@@ -101,8 +103,8 @@ class ChatHistoryApiService {
   ];
 
   void dispose() {
-    if (_ownsHttpClient) {
-      _httpClient.close();
+    if (_ownsApiClient) {
+      _apiClient.close();
     }
   }
 
@@ -139,11 +141,8 @@ class ChatHistoryApiService {
     return null;
   }
 
-  Future<List<ChatPersistedScope>> loadScopes({required String token}) async {
-    final response = await _client.get(
-      _scopesUri,
-      headers: {'Authorization': 'Bearer $token'},
-    );
+  Future<List<ChatPersistedScope>> loadScopes() async {
+    final response = await _apiClient.get(_scopesUri);
     if (response.statusCode != 200) {
       throw Exception('Failed to load chat scopes (${response.statusCode})');
     }
@@ -167,13 +166,8 @@ class ChatHistoryApiService {
         .toList(growable: false);
   }
 
-  Future<List<ChatScopeSetting>> loadScopeSettings({
-    required String token,
-  }) async {
-    final response = await _client.get(
-      _scopeSettingsUri,
-      headers: {'Authorization': 'Bearer $token'},
-    );
+  Future<List<ChatScopeSetting>> loadScopeSettings() async {
+    final response = await _apiClient.get(_scopeSettingsUri);
     if (response.statusCode != 200) {
       throw Exception(
         'Failed to load chat scope settings (${response.statusCode})',
@@ -207,13 +201,8 @@ class ChatHistoryApiService {
     }).toList(growable: false);
   }
 
-  Future<List<ChatChannelNameSetting>> loadChannelNames({
-    required String token,
-  }) async {
-    final response = await _client.get(
-      _channelNamesUri,
-      headers: {'Authorization': 'Bearer $token'},
-    );
+  Future<List<ChatChannelNameSetting>> loadChannelNames() async {
+    final response = await _apiClient.get(_channelNamesUri);
     if (response.statusCode != 200) {
       throw Exception(
         'Failed to load chat channel names (${response.statusCode})',
@@ -240,14 +229,10 @@ class ChatHistoryApiService {
   }
 
   Future<ChatHistorySnapshot> load({
-    required String token,
     required String sessionId,
     int limit = 20,
   }) async {
-    final response = await _client.get(
-      _historyUri(sessionId, limit: limit),
-      headers: {'Authorization': 'Bearer $token'},
-    );
+    final response = await _apiClient.get(_historyUri(sessionId, limit: limit));
     if (response.statusCode != 200) {
       throw Exception('Failed to load chat history (${response.statusCode})');
     }
@@ -273,14 +258,11 @@ class ChatHistoryApiService {
   }
 
   Future<ChatHistorySnapshot> sync({
-    required String token,
     required String sessionId,
     required int afterSeq,
   }) async {
-    final response = await _client.get(
-      _syncUri(sessionId, afterSeq: afterSeq),
-      headers: {'Authorization': 'Bearer $token'},
-    );
+    final response =
+        await _apiClient.get(_syncUri(sessionId, afterSeq: afterSeq));
     if (response.statusCode != 200) {
       throw Exception('Failed to sync chat history (${response.statusCode})');
     }
@@ -308,17 +290,15 @@ class ChatHistoryApiService {
   /// messages.  The stream completes when the underlying HTTP connection
   /// closes; callers are responsible for reconnecting as needed.
   Stream<ChatHistorySnapshot> listenEvents({
-    required String token,
     required String sessionId,
     required int afterSeq,
   }) async* {
     final request =
         http.Request('GET', _eventsUri(sessionId, afterSeq: afterSeq));
-    request.headers['Authorization'] = 'Bearer $token';
     request.headers['Accept'] = 'text/event-stream';
     request.headers['Cache-Control'] = 'no-cache';
 
-    final response = await _client.send(request);
+    final response = await _apiClient.send(request);
     if (response.statusCode != 200) {
       throw Exception(
         'Failed to open chat events stream (${response.statusCode})',
@@ -379,7 +359,6 @@ class ChatHistoryApiService {
   }
 
   Future<ChatRespondResult> respond({
-    required String token,
     required String taskId,
     required String idempotencyKey,
     required ChatSessionScope scope,
@@ -395,10 +374,9 @@ class ChatHistoryApiService {
     String? systemPrompt,
     DateTime? createdAt,
   }) async {
-    final response = await _client.post(
+    final response = await _apiClient.post(
       Uri.parse('$_base/api/chat/respond'),
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({
@@ -438,7 +416,6 @@ class ChatHistoryApiService {
   }
 
   Future<void> saveScopeSetting({
-    required String token,
     required ChatScopeType scopeType,
     required String channelId,
     String? threadId,
@@ -446,10 +423,9 @@ class ChatHistoryApiService {
     String? nodeId,
     String? instructions,
   }) async {
-    final response = await _client.put(
+    final response = await _apiClient.put(
       _scopeSettingsUri,
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({
@@ -469,14 +445,12 @@ class ChatHistoryApiService {
   }
 
   Future<void> saveChannelName({
-    required String token,
     required String channelId,
     String? displayName,
   }) async {
-    final response = await _client.put(
+    final response = await _apiClient.put(
       _channelNamesUri,
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({
@@ -492,17 +466,15 @@ class ChatHistoryApiService {
   }
 
   Future<ChatAcceptedTask> acceptTask({
-    required String token,
     required String taskId,
     required String idempotencyKey,
     required ChatSessionScope scope,
     String? resolvedBotId,
     String? resolvedSkillId,
   }) async {
-    final response = await _client.post(
+    final response = await _apiClient.post(
       _acceptTaskUri,
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({
@@ -545,16 +517,14 @@ class ChatHistoryApiService {
   }
 
   Future<int> upsertMessages({
-    required String token,
     required List<ChatMessage> messages,
   }) async {
     final persistableMessages = messagesForPersistence(messages);
     if (persistableMessages.isEmpty) return 0;
 
-    final response = await _client.put(
+    final response = await _apiClient.put(
       _batchMessagesUri,
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({

--- a/apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
@@ -90,7 +90,6 @@ class ChatNavigationPage extends StatefulWidget {
     this.onRequestClose,
     this.closeOnChannelSelected = true,
     this.todoApiService,
-    this.authToken,
   });
 
   final ValueChanged<ChatNavigationAction> onActionSelected;
@@ -121,9 +120,6 @@ class ChatNavigationPage extends StatefulWidget {
 
   /// Optional service used to fetch todo items inside [_ResourcePreviewPage].
   final TodoApiService? todoApiService;
-
-  /// Auth token forwarded to [_ResourcePreviewPage] for API calls.
-  final String? authToken;
 
   /// Called when the navigation requests to be closed. This is triggered by
   /// the back arrow, action selections (rename/archive), and channel taps when
@@ -227,7 +223,6 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
         builder: (_) => _ResourcePreviewPage(
           resource: resource,
           todoApiService: widget.todoApiService,
-          authToken: widget.authToken,
         ),
       ),
     );
@@ -245,170 +240,173 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
       onHorizontalDragEnd: _handleHorizontalDragEnd,
       child: Column(
         children: [
-        // Header row
-        SizedBox(
-          height: kToolbarHeight,
-          child: Row(
-            children: [
-              SizedBox(
-                width: kToolbarHeight,
-                height: kToolbarHeight,
-                child: IconButton(
-                  onPressed: () => _closeNavigation(context),
-                  icon: const Icon(Icons.arrow_back),
-                  tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+          // Header row
+          SizedBox(
+            height: kToolbarHeight,
+            child: Row(
+              children: [
+                SizedBox(
+                  width: kToolbarHeight,
+                  height: kToolbarHeight,
+                  child: IconButton(
+                    onPressed: () => _closeNavigation(context),
+                    icon: const Icon(Icons.arrow_back),
+                    tooltip:
+                        MaterialLocalizations.of(context).closeButtonTooltip,
+                  ),
                 ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  'Navigation',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.titleLarge,
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Navigation',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
                 ),
-              ),
-              IconButton(
-                onPressed: () =>
-                    _selectAction(context, ChatNavigationAction.appSettings),
-                icon: const Icon(Icons.settings_outlined),
-                tooltip: 'Settings',
-              ),
+                IconButton(
+                  onPressed: () =>
+                      _selectAction(context, ChatNavigationAction.appSettings),
+                  icon: const Icon(Icons.settings_outlined),
+                  tooltip: 'Settings',
+                ),
+              ],
+            ),
+          ),
+          // Tab bar
+          TabBar(
+            controller: _tabController,
+            tabs: const [
+              Tab(text: 'Channels'),
+              Tab(text: 'Resources'),
+              Tab(text: 'Nodes'),
             ],
           ),
-        ),
-        // Tab bar
-        TabBar(
-          controller: _tabController,
-          tabs: const [
-            Tab(text: 'Channels'),
-            Tab(text: 'Resources'),
-            Tab(text: 'Nodes'),
-          ],
-        ),
-        // Tab content
-        Expanded(
-          child: TabBarView(
-            controller: _tabController,
-            physics: const NeverScrollableScrollPhysics(),
-            children: [
-              // Channels tab
-              ListView(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 8, 4),
-                    child: Row(
-                      children: [
-                        const Spacer(),
-                        TextButton.icon(
-                          onPressed: () => _selectAction(
-                              context, ChatNavigationAction.createChannel),
-                          icon: const Icon(Icons.add_circle_outline, size: 18),
-                          label: const Text('新建频道'),
-                        ),
-                      ],
+          // Tab content
+          Expanded(
+            child: TabBarView(
+              controller: _tabController,
+              physics: const NeverScrollableScrollPhysics(),
+              children: [
+                // Channels tab
+                ListView(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 8, 8, 4),
+                      child: Row(
+                        children: [
+                          const Spacer(),
+                          TextButton.icon(
+                            onPressed: () => _selectAction(
+                                context, ChatNavigationAction.createChannel),
+                            icon:
+                                const Icon(Icons.add_circle_outline, size: 18),
+                            label: const Text('新建频道'),
+                          ),
+                        ],
+                      ),
                     ),
-                  ),
-                  if (channels.isEmpty)
-                    const ListTile(
-                      title: Text('No channels'),
-                      subtitle: Text('Create your first channel'),
-                    )
-                  else
-                    ...channels.map((channel) {
-                      final isSelected = selected == channel.id;
-                      return ListTile(
-                        leading: Icon(
-                          channel.isDefault
-                              ? Icons.home_filled
-                              : Icons.forum_outlined,
-                        ),
-                        title: Text(channel.name),
-                        subtitle: channel.isDefault
-                            ? const Text('Default channel')
-                            : null,
-                        selected: isSelected,
-                        onTap: () {
-                          if (widget.closeOnChannelSelected) {
-                            _closeNavigation(context);
-                          }
-                          widget.onChannelSelected?.call(channel.id);
-                        },
-                        onLongPress: channel.isDefault
-                            ? null
-                            : () {
-                                _showChannelMenu(channel);
-                              },
-                      );
-                    }),
-                  const SizedBox(height: 24),
-                ],
-              ),
-              // Resources tab
-              ListView(
-                children: [
-                  if (widget.resources.isEmpty)
-                    const ListTile(
-                      title: Text('No resources'),
-                      subtitle: Text('Todo lists and tables will appear here'),
-                    )
-                  else
-                    ...widget.resources.map((resource) {
-                      final notes = resource.notes?.trim();
-                      return ListTile(
-                        leading: Icon(
-                          resource.type == ChatResourceType.todoList
-                              ? Icons.checklist_outlined
-                              : Icons.table_chart_outlined,
-                        ),
-                        title: Text(resource.title),
-                        subtitle: notes != null && notes.isNotEmpty
-                            ? Text(
-                                notes,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                              )
-                            : null,
-                        trailing: const Icon(Icons.chevron_right),
-                        onTap: () {
-                          if (widget.onResourceSelected != null) {
-                            widget.onResourceSelected!.call(resource);
-                          } else {
-                            _openResourcePreview(resource);
-                          }
-                        },
-                      );
-                    }),
-                  const SizedBox(height: 24),
-                ],
-              ),
-              // Nodes tab
-              ListView(
-                children: [
-                  if (widget.nodes.isEmpty)
-                    const ListTile(
-                      title: Text('No nodes'),
-                      subtitle: Text('Connect an AI node to get started'),
-                    )
-                  else
-                    ...widget.nodes.map((node) {
-                      return ListTile(
-                        leading: const Icon(Icons.memory_outlined),
-                        title: Text(node.name),
-                        trailing: const Icon(Icons.chevron_right),
-                        onTap: () {
-                          if (widget.onNodeSelected != null) {
-                            widget.onNodeSelected!.call(node.id);
-                          } else {
-                            _openNodeDetail(node);
-                          }
-                        },
-                      );
-                    }),
-                  const SizedBox(height: 24),
-                ],
-              ),
-            ],
+                    if (channels.isEmpty)
+                      const ListTile(
+                        title: Text('No channels'),
+                        subtitle: Text('Create your first channel'),
+                      )
+                    else
+                      ...channels.map((channel) {
+                        final isSelected = selected == channel.id;
+                        return ListTile(
+                          leading: Icon(
+                            channel.isDefault
+                                ? Icons.home_filled
+                                : Icons.forum_outlined,
+                          ),
+                          title: Text(channel.name),
+                          subtitle: channel.isDefault
+                              ? const Text('Default channel')
+                              : null,
+                          selected: isSelected,
+                          onTap: () {
+                            if (widget.closeOnChannelSelected) {
+                              _closeNavigation(context);
+                            }
+                            widget.onChannelSelected?.call(channel.id);
+                          },
+                          onLongPress: channel.isDefault
+                              ? null
+                              : () {
+                                  _showChannelMenu(channel);
+                                },
+                        );
+                      }),
+                    const SizedBox(height: 24),
+                  ],
+                ),
+                // Resources tab
+                ListView(
+                  children: [
+                    if (widget.resources.isEmpty)
+                      const ListTile(
+                        title: Text('No resources'),
+                        subtitle:
+                            Text('Todo lists and tables will appear here'),
+                      )
+                    else
+                      ...widget.resources.map((resource) {
+                        final notes = resource.notes?.trim();
+                        return ListTile(
+                          leading: Icon(
+                            resource.type == ChatResourceType.todoList
+                                ? Icons.checklist_outlined
+                                : Icons.table_chart_outlined,
+                          ),
+                          title: Text(resource.title),
+                          subtitle: notes != null && notes.isNotEmpty
+                              ? Text(
+                                  notes,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                )
+                              : null,
+                          trailing: const Icon(Icons.chevron_right),
+                          onTap: () {
+                            if (widget.onResourceSelected != null) {
+                              widget.onResourceSelected!.call(resource);
+                            } else {
+                              _openResourcePreview(resource);
+                            }
+                          },
+                        );
+                      }),
+                    const SizedBox(height: 24),
+                  ],
+                ),
+                // Nodes tab
+                ListView(
+                  children: [
+                    if (widget.nodes.isEmpty)
+                      const ListTile(
+                        title: Text('No nodes'),
+                        subtitle: Text('Connect an AI node to get started'),
+                      )
+                    else
+                      ...widget.nodes.map((node) {
+                        return ListTile(
+                          leading: const Icon(Icons.memory_outlined),
+                          title: Text(node.name),
+                          trailing: const Icon(Icons.chevron_right),
+                          onTap: () {
+                            if (widget.onNodeSelected != null) {
+                              widget.onNodeSelected!.call(node.id);
+                            } else {
+                              _openNodeDetail(node);
+                            }
+                          },
+                        );
+                      }),
+                    const SizedBox(height: 24),
+                  ],
+                ),
+              ],
             ),
           ),
         ],
@@ -481,19 +479,17 @@ class _NodeDetailPage extends StatelessWidget {
 
 /// Preview page for a resource item (todo-list or asset table).
 ///
-/// When the resource is a todo-list and [todoApiService] + [authToken] are
-/// provided, the page fetches the list's todo items and renders them with
-/// their status and creation time.
+/// When the resource is a todo-list and [todoApiService] is provided, the page
+/// fetches the list's todo items and renders them with their status and
+/// creation time.
 class _ResourcePreviewPage extends StatefulWidget {
   const _ResourcePreviewPage({
     required this.resource,
     this.todoApiService,
-    this.authToken,
   });
 
   final ChatResourceItem resource;
   final TodoApiService? todoApiService;
-  final String? authToken;
 
   @override
   State<_ResourcePreviewPage> createState() => _ResourcePreviewPageState();
@@ -514,8 +510,7 @@ class _ResourcePreviewPageState extends State<_ResourcePreviewPage> {
 
   Future<void> _fetchItems() async {
     final service = widget.todoApiService;
-    final token = widget.authToken;
-    if (service == null || token == null || token.isEmpty) return;
+    if (service == null) return;
 
     setState(() {
       _loading = true;
@@ -523,7 +518,6 @@ class _ResourcePreviewPageState extends State<_ResourcePreviewPage> {
     });
     try {
       final raw = await service.listTodos(
-        token: token,
         listId: widget.resource.id,
       );
       // Sort a copy: incomplete first (by displayOrder), then completed.
@@ -643,9 +637,7 @@ class _TodoItemTile extends StatelessWidget {
         item.isCompleted
             ? Icons.check_circle_outline
             : Icons.radio_button_unchecked,
-        color: item.isCompleted
-            ? Theme.of(context).colorScheme.primary
-            : null,
+        color: item.isCompleted ? Theme.of(context).colorScheme.primary : null,
       ),
       title: Text(
         item.title,

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -69,7 +69,7 @@ class _ChatScreenState extends State<ChatScreen> {
   StreamSubscription<AgentSessionEvent>? _currentSubscription;
   List<AgentDefinition> _agents = [];
   AgentDefinition? _activeAgent;
-  final LlmConfigService _llmConfigService = const LlmConfigService();
+  final LlmConfigService _llmConfigService = LlmConfigService();
   List<LlmConfig> _llmConfigs = const [];
   List<PlatformNodeConfig> _platformNodes = const [];
   Map<String, List<PlatformAgentConfig>> _openClawAgentsByNodeId = const {};
@@ -157,67 +157,58 @@ class _ChatScreenState extends State<ChatScreen> {
       Map<String, List<PlatformAgentConfig>> openClawAgentsByNodeId = const {};
       List<TodoList> todoLists = const [];
       List<AssetTableSummary> assetTables = const [];
-      if (authToken != null && authToken.isNotEmpty) {
-        try {
-          persistedScopes = await _chatHistoryApiService.loadScopes(
-            token: authToken,
-          );
-        } catch (e) {
-          // Scope hydration is best-effort; a backend failure (e.g. 404 during
-          // rollout or transient error) must not block the rest of chat setup.
-          debugPrint(
-            'loadScopes failed, continuing without scope hydration: $e',
-          );
-        }
-        try {
-          scopeSettings = await _chatHistoryApiService.loadScopeSettings(
-            token: authToken,
-          );
-        } catch (e) {
-          debugPrint(
-            'loadScopeSettings failed, continuing without router hydration: $e',
-          );
-        }
-        try {
-          channelNames = await _chatHistoryApiService.loadChannelNames(
-            token: authToken,
-          );
-        } catch (e) {
-          debugPrint(
-            'loadChannelNames failed, continuing without channel name hydration: $e',
-          );
-        }
-        try {
-          platformNodes = await _llmConfigService.fetchPlatformNodes();
-          final agentResults = await Future.wait(
-            platformNodes.map(
-              (node) => _llmConfigService
-                  .fetchPlatformAgents(
-                    nodeId: node.nodeId,
-                    sourcePlatform: 'openclaw',
-                  )
-                  .then((agents) => MapEntry(node.nodeId, agents)),
-            ),
-          );
-          openClawAgentsByNodeId = Map.fromEntries(agentResults);
-        } catch (e) {
-          debugPrint(
-            'loadOpenClawAgents failed, continuing without OpenClaw @ menu agents: $e',
-          );
-        }
-        try {
-          todoLists = await _todoApiService.listTodoLists(token: authToken);
-        } catch (e) {
-          debugPrint('loadTodoLists failed, continuing without todo lists: $e');
-        }
-        try {
-          assetTables =
-              await _assetTableApiService.listTables(token: authToken);
-        } catch (e) {
-          debugPrint(
-            'loadAssetTables failed, continuing without asset tables: $e',
-          );
-        }
+      try {
+        persistedScopes = await _chatHistoryApiService.loadScopes();
+      } catch (e) {
+        // Scope hydration is best-effort; a backend failure (e.g. 404 during
+        // rollout or transient error) must not block the rest of chat setup.
+        debugPrint(
+          'loadScopes failed, continuing without scope hydration: $e',
+        );
+      }
+      try {
+        scopeSettings = await _chatHistoryApiService.loadScopeSettings();
+      } catch (e) {
+        debugPrint(
+          'loadScopeSettings failed, continuing without router hydration: $e',
+        );
+      }
+      try {
+        channelNames = await _chatHistoryApiService.loadChannelNames();
+      } catch (e) {
+        debugPrint(
+          'loadChannelNames failed, continuing without channel name hydration: $e',
+        );
+      }
+      try {
+        platformNodes = await _llmConfigService.fetchPlatformNodes();
+        final agentResults = await Future.wait(
+          platformNodes.map(
+            (node) => _llmConfigService
+                .fetchPlatformAgents(
+                  nodeId: node.nodeId,
+                  sourcePlatform: 'openclaw',
+                )
+                .then((agents) => MapEntry(node.nodeId, agents)),
+          ),
+        );
+        openClawAgentsByNodeId = Map.fromEntries(agentResults);
+      } catch (e) {
+        debugPrint(
+          'loadOpenClawAgents failed, continuing without OpenClaw @ menu agents: $e',
+        );
+      }
+      try {
+        todoLists = await _todoApiService.listTodoLists();
+      } catch (e) {
+        debugPrint('loadTodoLists failed, continuing without todo lists: $e');
+      }
+      try {
+        assetTables = await _assetTableApiService.listTables();
+      } catch (e) {
+        debugPrint(
+          'loadAssetTables failed, continuing without asset tables: $e',
+        );
       }
       final defaultConfig = llmConfigs.firstWhere(
         (cfg) => cfg.isDefault,
@@ -844,20 +835,16 @@ class _ChatScreenState extends State<ChatScreen> {
           _lastSyncedSeq = 0;
         });
         _configureActiveScopeSync();
-        final token = _authToken;
-        if (token != null && token.isNotEmpty) {
-          unawaited(
-            _chatHistoryApiService
-                .saveChannelName(
-              token: token,
-              channelId: id,
-              displayName: name,
-            )
-                .catchError((Object error, StackTrace stackTrace) {
-              debugPrint('Failed to save channel name "$id": $error');
-            }),
-          );
-        }
+        unawaited(
+          _chatHistoryApiService
+              .saveChannelName(
+            channelId: id,
+            displayName: name,
+          )
+              .catchError((Object error, StackTrace stackTrace) {
+            debugPrint('Failed to save channel name "$id": $error');
+          }),
+        );
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(SnackBar(content: Text('已创建频道：${channel.name}')));
@@ -894,20 +881,16 @@ class _ChatScreenState extends State<ChatScreen> {
             isDefault: existingChannel.isDefault,
           );
         });
-        final token = _authToken;
-        if (token != null && token.isNotEmpty) {
-          unawaited(
-            _chatHistoryApiService
-                .saveChannelName(
-              token: token,
-              channelId: channelId,
-              displayName: name,
-            )
-                .catchError((Object error, StackTrace stackTrace) {
-              debugPrint('Failed to save channel name "$channelId": $error');
-            }),
-          );
-        }
+        unawaited(
+          _chatHistoryApiService
+              .saveChannelName(
+            channelId: channelId,
+            displayName: name,
+          )
+              .catchError((Object error, StackTrace stackTrace) {
+            debugPrint('Failed to save channel name "$channelId": $error');
+          }),
+        );
       },
     );
   }
@@ -941,20 +924,16 @@ class _ChatScreenState extends State<ChatScreen> {
     if (wasActive) {
       unawaited(_loadMessagesForActiveScope());
     }
-    final token = _authToken;
-    if (token != null && token.isNotEmpty) {
-      unawaited(
-        _chatHistoryApiService
-            .saveChannelName(
-          token: token,
-          channelId: channelId,
-          displayName: null,
-        )
-            .catchError((Object error, StackTrace stackTrace) {
-          debugPrint('Failed to archive channel "$channelId": $error');
-        }),
-      );
-    }
+    unawaited(
+      _chatHistoryApiService
+          .saveChannelName(
+        channelId: channelId,
+        displayName: null,
+      )
+          .catchError((Object error, StackTrace stackTrace) {
+        debugPrint('Failed to archive channel "$channelId": $error');
+      }),
+    );
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('已归档频道：${channel.name}')),
     );
@@ -1094,19 +1073,6 @@ class _ChatScreenState extends State<ChatScreen> {
   String get _sessionIdForScope => _activeScope.sessionId;
 
   Future<void> _loadMessagesForActiveScope() async {
-    final token = _authToken;
-    if (token == null || token.isEmpty) {
-      if (!mounted) return;
-      setState(() {
-        _messages.clear();
-        _highlights = const {};
-        _latestCheckpointCursor = null;
-        _lastSyncedSeq = 0;
-      });
-      _configureActiveScopeSync();
-      return;
-    }
-
     // Capture scope identity before the async gap so we can discard stale
     // responses if the user navigates away while the request is in-flight.
     // capturedSessionId encodes both channelId and subSection, so a single
@@ -1120,7 +1086,6 @@ class _ChatScreenState extends State<ChatScreen> {
 
     try {
       final snapshot = await _chatHistoryApiService.load(
-        token: token,
         sessionId: capturedSessionId,
       );
       if (!mounted || _isScopeStale()) return;
@@ -1472,14 +1437,6 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Future<void> _saveChannelRouter(ChatRouter router, {String? nodeId}) async {
-    final token = _authToken;
-    if (token == null || token.isEmpty) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Missing auth token')));
-      return;
-    }
-
     final channelId = _activeChannelId;
     final previous = _channelRouters[channelId];
     final previousNodeId = _channelNodeIds[channelId];
@@ -1505,7 +1462,6 @@ class _ChatScreenState extends State<ChatScreen> {
 
     try {
       await _chatHistoryApiService.saveScopeSetting(
-        token: token,
         scopeType: ChatScopeType.channel,
         channelId: channelId,
         router: effectiveRouter,
@@ -1534,14 +1490,6 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Future<void> _saveThreadRouter(ChatRouter? router, {String? nodeId}) async {
-    final token = _authToken;
-    if (token == null || token.isEmpty) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Missing auth token')));
-      return;
-    }
-
     final channelId = _activeChannelId;
     final threadId = _activeSubSection;
     final key = _subSectionKey(channelId, threadId);
@@ -1569,7 +1517,6 @@ class _ChatScreenState extends State<ChatScreen> {
 
     try {
       await _chatHistoryApiService.saveScopeSetting(
-        token: token,
         scopeType: ChatScopeType.thread,
         channelId: channelId,
         threadId: threadId,
@@ -1634,14 +1581,6 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Future<void> _saveChannelInstructions(String? instructions) async {
-    final token = _authToken;
-    if (token == null || token.isEmpty) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Missing auth token')));
-      return;
-    }
-
     final channelId = _activeChannelId;
     final normalized = instructions?.trim();
     final previous = _channelInstructions[channelId];
@@ -1657,7 +1596,6 @@ class _ChatScreenState extends State<ChatScreen> {
 
     try {
       await _chatHistoryApiService.saveScopeSetting(
-        token: token,
         scopeType: ChatScopeType.channel,
         channelId: channelId,
         router: effectiveRouter,
@@ -1683,14 +1621,6 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Future<void> _saveThreadInstructions(String? instructions) async {
-    final token = _authToken;
-    if (token == null || token.isEmpty) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Missing auth token')));
-      return;
-    }
-
     if (!_isThreadConversation()) return;
 
     final channelId = _activeChannelId;
@@ -1710,7 +1640,6 @@ class _ChatScreenState extends State<ChatScreen> {
 
     try {
       await _chatHistoryApiService.saveScopeSetting(
-        token: token,
         scopeType: ChatScopeType.thread,
         channelId: channelId,
         threadId: threadId,
@@ -1827,8 +1756,6 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   bool _shouldSyncActiveScope() {
-    final token = _authToken;
-    if (token == null || token.isEmpty) return false;
     if (_effectiveRouterForScope() == ChatRouter.plugin) return true;
     if (_isSending || _isStreaming) return true;
     return _hasPendingAssistantTasks() || _hasPendingUserTasks();
@@ -1845,8 +1772,6 @@ class _ChatScreenState extends State<ChatScreen> {
   void _connectSse() {
     _disconnectSse();
     if (!_shouldSyncActiveScope()) return;
-    final token = _authToken;
-    if (token == null || token.isEmpty) return;
 
     final capturedSessionId = _sessionIdForScope;
     final capturedChannelId = _activeChannelId;
@@ -1854,7 +1779,6 @@ class _ChatScreenState extends State<ChatScreen> {
 
     _sseSubscription = _chatHistoryApiService
         .listenEvents(
-      token: token,
       sessionId: capturedSessionId,
       afterSeq: _lastSyncedSeq,
     )
@@ -2116,20 +2040,11 @@ class _ChatScreenState extends State<ChatScreen> {
       _isStreaming = false;
     });
 
-    final token = _authToken;
     final runtimeSettings = _settingsForAgent(agent);
-    if (token == null || token.isEmpty) {
-      setState(() {
-        _isSending = false;
-        _isStreaming = false;
-      });
-      return;
-    }
 
     final generation = ++_respondGeneration;
     _chatHistoryApiService
         .respond(
-      token: token,
       taskId: taskId,
       idempotencyKey: idempotencyKey,
       scope: _activeScope,
@@ -2306,14 +2221,6 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Future<void> _refreshPlatformNodes() async {
-    final token = _authToken;
-    if (token == null || token.isEmpty) {
-      if (!mounted) return;
-      setState(() {
-        _platformNodes = const [];
-      });
-      return;
-    }
     try {
       final nodes = await _llmConfigService.fetchPlatformNodes();
       if (!mounted) return;
@@ -2429,7 +2336,6 @@ class _ChatScreenState extends State<ChatScreen> {
           onRequestClose: onRequestClose,
           closeOnChannelSelected: closeOnChannelSelected,
           todoApiService: _todoApiService,
-          authToken: _authToken,
           onActionSelected: (action) {
             switch (action) {
               case ChatNavigationAction.appSettings:

--- a/apps/mobile_chat_app/lib/features/chat/todo_api_service.dart
+++ b/apps/mobile_chat_app/lib/features/chat/todo_api_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+import '../../services/authenticated_api_client.dart';
 import '../settings/llm_config_service.dart';
 
 // ---------------------------------------------------------------------------
@@ -25,6 +26,7 @@ class TodoList {
   final int displayOrder;
   final DateTime createdAt;
   final DateTime updatedAt;
+
   /// Items are only present when fetched via getTodoList (not listTodoLists).
   final List<TodoItem> items;
 
@@ -93,16 +95,19 @@ class TodoItem {
 // ---------------------------------------------------------------------------
 
 class TodoApiService {
-  TodoApiService({http.Client? httpClient})
-      : _httpClient = httpClient ?? http.Client(),
-        _ownsHttpClient = httpClient == null;
+  TodoApiService({
+    http.Client? httpClient,
+    AuthenticatedApiClient? apiClient,
+  })  : _apiClient =
+            apiClient ?? AuthenticatedApiClient(httpClient: httpClient),
+        _ownsApiClient = apiClient == null;
 
-  final http.Client _httpClient;
-  final bool _ownsHttpClient;
+  final AuthenticatedApiClient _apiClient;
+  final bool _ownsApiClient;
 
   void dispose() {
-    if (_ownsHttpClient) {
-      _httpClient.close();
+    if (_ownsApiClient) {
+      _apiClient.close();
     }
   }
 
@@ -119,11 +124,8 @@ class TodoApiService {
   // Todo list CRUD
   // ---------------------------------------------------------------------------
 
-  Future<List<TodoList>> listTodoLists({required String token}) async {
-    final response = await _httpClient.get(
-      _todoListsUri,
-      headers: {'Authorization': 'Bearer $token'},
-    );
+  Future<List<TodoList>> listTodoLists() async {
+    final response = await _apiClient.get(_todoListsUri);
     if (response.statusCode != 200) {
       throw Exception('Failed to list todo lists: ${response.statusCode}');
     }
@@ -136,13 +138,9 @@ class TodoApiService {
   }
 
   Future<TodoList> getTodoList({
-    required String token,
     required String listId,
   }) async {
-    final response = await _httpClient.get(
-      _todoListUri(listId),
-      headers: {'Authorization': 'Bearer $token'},
-    );
+    final response = await _apiClient.get(_todoListUri(listId));
     if (response.statusCode != 200) {
       throw Exception('Failed to get todo list: ${response.statusCode}');
     }
@@ -152,14 +150,12 @@ class TodoApiService {
   }
 
   Future<TodoList> createTodoList({
-    required String token,
     required String title,
     String? notes,
   }) async {
-    final response = await _httpClient.post(
+    final response = await _apiClient.post(
       _todoListsUri,
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({
@@ -176,7 +172,6 @@ class TodoApiService {
   }
 
   Future<TodoList> updateTodoList({
-    required String token,
     required String listId,
     String? title,
     String? notes,
@@ -185,10 +180,9 @@ class TodoApiService {
     if (title != null) patch['title'] = title;
     if (notes != null) patch['notes'] = notes;
 
-    final response = await _httpClient.patch(
+    final response = await _apiClient.patch(
       _todoListUri(listId),
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode(patch),
@@ -202,13 +196,9 @@ class TodoApiService {
   }
 
   Future<void> deleteTodoList({
-    required String token,
     required String listId,
   }) async {
-    final response = await _httpClient.delete(
-      _todoListUri(listId),
-      headers: {'Authorization': 'Bearer $token'},
-    );
+    final response = await _apiClient.delete(_todoListUri(listId));
     if (response.statusCode != 200) {
       throw Exception('Failed to delete todo list: ${response.statusCode}');
     }
@@ -219,17 +209,13 @@ class TodoApiService {
   // ---------------------------------------------------------------------------
 
   Future<List<TodoItem>> listTodos({
-    required String token,
     required String listId,
     bool includeCompleted = true,
   }) async {
     final uri = _todosUri(listId).replace(
       queryParameters: {'includeCompleted': includeCompleted.toString()},
     );
-    final response = await _httpClient.get(
-      uri,
-      headers: {'Authorization': 'Bearer $token'},
-    );
+    final response = await _apiClient.get(uri);
     if (response.statusCode != 200) {
       throw Exception('Failed to list todos: ${response.statusCode}');
     }
@@ -242,15 +228,13 @@ class TodoApiService {
   }
 
   Future<TodoItem> createTodo({
-    required String token,
     required String listId,
     required String title,
     String? notes,
   }) async {
-    final response = await _httpClient.post(
+    final response = await _apiClient.post(
       _todosUri(listId),
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({
@@ -267,7 +251,6 @@ class TodoApiService {
   }
 
   Future<TodoItem> updateTodo({
-    required String token,
     required String listId,
     required String id,
     String? title,
@@ -279,10 +262,9 @@ class TodoApiService {
     if (notes != null) patch['notes'] = notes;
     if (isCompleted != null) patch['isCompleted'] = isCompleted;
 
-    final response = await _httpClient.patch(
+    final response = await _apiClient.patch(
       _todoUri(listId, id),
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode(patch),
@@ -297,24 +279,18 @@ class TodoApiService {
 
   /// Convenience wrapper: marks a todo item as completed.
   Future<TodoItem> completeTodo({
-    required String token,
     required String listId,
     required String id,
   }) =>
-      updateTodo(token: token, listId: listId, id: id, isCompleted: true);
+      updateTodo(listId: listId, id: id, isCompleted: true);
 
   Future<void> deleteTodo({
-    required String token,
     required String listId,
     required String id,
   }) async {
-    final response = await _httpClient.delete(
-      _todoUri(listId, id),
-      headers: {'Authorization': 'Bearer $token'},
-    );
+    final response = await _apiClient.delete(_todoUri(listId, id));
     if (response.statusCode != 200) {
       throw Exception('Failed to delete todo: ${response.statusCode}');
     }
   }
 }
-

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -435,6 +435,98 @@ class _MessageListState extends State<MessageList> {
     _hideSelectionToolbar();
   }
 
+  bool _isToolLoopMessage(ChatMessage message) {
+    if (message.role == 'user') return false;
+    return message.agentLoopPhase == 'tool_call_start' ||
+        message.agentLoopPhase == 'tool_call';
+  }
+
+  int _toolGroupEndIndex(List<ChatMessage> messages, int startIndex) {
+    var endIndex = startIndex;
+    while (endIndex + 1 < messages.length &&
+        _isToolLoopMessage(messages[endIndex + 1])) {
+      endIndex++;
+    }
+    return endIndex;
+  }
+
+  Widget _buildToolGroupItem(
+    BuildContext context,
+    int startIndex,
+    int endIndex,
+  ) {
+    final messages = widget.messages;
+    final first = messages[startIndex];
+    final groupMessages = messages.sublist(startIndex, endIndex + 1);
+    final chatColors =
+        Theme.of(context).extension<ChatColors>() ?? ChatColors.light;
+    final itemKey = startIndex == _focusedIndex ? _focusedItemKey : null;
+    final startMessages = groupMessages
+        .where((message) => message.agentLoopPhase == 'tool_call_start')
+        .toList(growable: false);
+    final total = startMessages.isNotEmpty
+        ? startMessages.length
+        : groupMessages
+            .where((message) => message.agentLoopPhase == 'tool_call')
+            .length;
+    final completed = startMessages.isNotEmpty
+        ? startMessages
+            .where((message) => message.taskState == ChatTaskState.completed)
+            .length
+        : total;
+    final isFinalized = completed >= total && total > 0;
+    final labelPrefix = isFinalized ? '思考过程' : '正在思考';
+    final label = '$labelPrefix $completed/$total';
+
+    return Align(
+      key: itemKey,
+      alignment: Alignment.centerLeft,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (first.agentName != null || first.model != null)
+            Padding(
+              padding: const EdgeInsets.only(
+                left: BricksSpacing.xs,
+                bottom: BricksSpacing.xs,
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.smart_toy_outlined, size: 14),
+                  const SizedBox(width: BricksSpacing.xs),
+                  Text(
+                    first.agentName ?? first.model ?? '',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: chatColors.agentIdentity,
+                        ),
+                  ),
+                ],
+              ),
+            ),
+          _AgentLoopToolGroupRow(
+            label: label,
+            isFinalized: isFinalized,
+            chatColors: chatColors,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(
+              left: BricksSpacing.xs,
+              right: BricksSpacing.xs,
+              bottom: BricksSpacing.md,
+            ),
+            child: Text(
+              _messageMetaLine(first),
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: chatColors.metaText,
+                  ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   // Builds a single message row for the given [index] in [widget.messages].
   // Extracted from build() so that the non-builder ListView can call it in a
   // simple for-loop while keeping the item rendering logic in one place.
@@ -704,6 +796,16 @@ class _MessageListState extends State<MessageList> {
         (_hasUserMessage()
             ? MediaQuery.sizeOf(context).height * _kBottomPaddingRatio
             : 0);
+    final messageItems = <Widget>[];
+    for (var i = 0; i < messages.length; i++) {
+      if (_isToolLoopMessage(messages[i])) {
+        final endIndex = _toolGroupEndIndex(messages, i);
+        messageItems.add(_buildToolGroupItem(context, i, endIndex));
+        i = endIndex;
+        continue;
+      }
+      messageItems.add(_buildMessageItem(context, i));
+    }
 
     // All messages in the initial load are bounded (≤ 20 items). Building
     // them eagerly with a non-builder ListView gives an accurate
@@ -775,10 +877,7 @@ class _MessageListState extends State<MessageList> {
                 _listBottomPadding,
               ),
               child: Column(
-                children: [
-                  for (var i = 0; i < messages.length; i++)
-                    _buildMessageItem(context, i),
-                ],
+                children: messageItems,
               ),
             ),
           ),
@@ -2633,5 +2732,56 @@ class _AgentLoopStatusRowState extends State<_AgentLoopStatusRow> {
           ),
         );
     }
+  }
+}
+
+class _AgentLoopToolGroupRow extends StatelessWidget {
+  const _AgentLoopToolGroupRow({
+    required this.label,
+    required this.isFinalized,
+    required this.chatColors,
+  });
+
+  final String label;
+  final bool isFinalized;
+  final ChatColors chatColors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(
+        left: BricksSpacing.xs,
+        right: BricksSpacing.xs,
+        bottom: BricksSpacing.xs,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 14,
+            height: 14,
+            child: isFinalized
+                ? Icon(
+                    Icons.check_circle_outline,
+                    size: 14,
+                    color: chatColors.agentAccent,
+                  )
+                : CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(
+                      chatColors.agentAccent,
+                    ),
+                  ),
+          ),
+          const SizedBox(width: BricksSpacing.xs),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: chatColors.metaText,
+                ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -1482,8 +1482,9 @@ class _AssistantMarkdownTextState extends State<_AssistantMarkdownText> {
       );
       if (block.type == _MarkdownBlockType.unorderedList ||
           block.type == _MarkdownBlockType.orderedList) {
+        final listLeftPadding = BricksSpacing.md * (block.listLevel + 1);
         widgets.add(Padding(
-          padding: const EdgeInsets.only(left: BricksSpacing.md),
+          padding: EdgeInsets.only(left: listLeftPadding),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -1945,15 +1946,17 @@ class _MarkdownBlock {
     required this.type,
     required this.text,
     this.marker = '',
+    this.listLevel = 0,
   });
 
   final _MarkdownBlockType type;
   final String text;
   final String marker;
+  final int listLevel;
 
   static final RegExp _headingPattern = RegExp(r'^\s{0,3}(#{1,6})\s+(.*)$');
-  static final RegExp _unorderedListPattern = RegExp(r'^\s*([-*+])\s+(.*)$');
-  static final RegExp _orderedListPattern = RegExp(r'^\s*(\d+)\.\s+(.*)$');
+  static final RegExp _unorderedListPattern = RegExp(r'^(\s*)([-*+])\s+(.*)$');
+  static final RegExp _orderedListPattern = RegExp(r'^(\s*)(\d+)\.\s+(.*)$');
 
   static _MarkdownBlock tryParse(String line) {
     final headingMatch = _headingPattern.firstMatch(line);
@@ -1968,8 +1971,9 @@ class _MarkdownBlock {
     if (unorderedMatch != null) {
       return _MarkdownBlock(
         type: _MarkdownBlockType.unorderedList,
-        marker: unorderedMatch.group(1) ?? '•',
-        text: unorderedMatch.group(2) ?? '',
+        marker: unorderedMatch.group(2) ?? '•',
+        text: unorderedMatch.group(3) ?? '',
+        listLevel: _listLevelFromIndent(unorderedMatch.group(1) ?? ''),
       );
     }
 
@@ -1977,13 +1981,19 @@ class _MarkdownBlock {
     if (orderedMatch != null) {
       return _MarkdownBlock(
         type: _MarkdownBlockType.orderedList,
-        marker: '${orderedMatch.group(1)}.',
-        text: orderedMatch.group(2) ?? '',
+        marker: '${orderedMatch.group(2)}.',
+        text: orderedMatch.group(3) ?? '',
+        listLevel: _listLevelFromIndent(orderedMatch.group(1) ?? ''),
       );
     }
 
     return _MarkdownBlock(type: _MarkdownBlockType.paragraph, text: line);
   }
+}
+
+int _listLevelFromIndent(String indent) {
+  final spaces = indent.replaceAll('\t', '    ').length;
+  return spaces ~/ 2;
 }
 
 List<_OffsetTextSpan> _parseInlineMarkdownWithOffsets(

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -453,8 +453,9 @@ class _MessageListState extends State<MessageList> {
   Widget _buildToolGroupItem(
     BuildContext context,
     int startIndex,
-    int endIndex,
-  ) {
+    int endIndex, {
+    bool hideMeta = false,
+  }) {
     final messages = widget.messages;
     final first = messages[startIndex];
     final groupMessages = messages.sublist(startIndex, endIndex + 1);
@@ -485,43 +486,100 @@ class _MessageListState extends State<MessageList> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (first.agentName != null || first.model != null)
-            Padding(
-              padding: const EdgeInsets.only(
-                left: BricksSpacing.xs,
-                bottom: BricksSpacing.xs,
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(Icons.smart_toy_outlined, size: 14),
-                  const SizedBox(width: BricksSpacing.xs),
-                  Text(
-                    first.agentName ?? first.model ?? '',
-                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: chatColors.agentIdentity,
-                        ),
-                  ),
-                ],
-              ),
+            _assistantAttributionHeader(
+              context: context,
+              message: first,
+              chatColors: chatColors,
             ),
           _AgentLoopToolGroupRow(
             label: label,
             isFinalized: isFinalized,
             chatColors: chatColors,
           ),
-          Padding(
-            padding: const EdgeInsets.only(
-              left: BricksSpacing.xs,
-              right: BricksSpacing.xs,
-              bottom: BricksSpacing.md,
-            ),
-            child: Text(
-              _messageMetaLine(first),
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                    color: chatColors.metaText,
-                  ),
-            ),
+          if (!hideMeta)
+            Padding(
+              padding: const EdgeInsets.only(
+                left: BricksSpacing.xs,
+                right: BricksSpacing.xs,
+                bottom: BricksSpacing.md,
+              ),
+              child: Text(
+                _messageMetaLine(first),
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: chatColors.metaText,
+                    ),
+              ),
+            )
+          else
+            const SizedBox(height: BricksSpacing.xs),
+        ],
+      ),
+    );
+  }
+
+  bool _shouldAttachAssistantTextToPreviousToolGroup(
+    List<ChatMessage> messages,
+    int index,
+  ) {
+    if (index <= 0) return false;
+    final message = messages[index];
+    if (message.role != 'assistant') return false;
+    if (message.agentLoopPhase != null) return false;
+    if (_isAssistantDispatchPlaceholder(message)) return false;
+    return _isToolLoopMessage(messages[index - 1]);
+  }
+
+  bool _toolGroupShouldAttachNextText(
+    List<ChatMessage> messages,
+    int endIndex,
+  ) {
+    if (endIndex + 1 >= messages.length) return false;
+    return _shouldAttachAssistantTextToPreviousToolGroup(
+      messages,
+      endIndex + 1,
+    );
+  }
+
+  Widget _assistantAttributionHeader({
+    required BuildContext context,
+    required ChatMessage message,
+    required ChatColors chatColors,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.only(
+        left: BricksSpacing.xs,
+        bottom: BricksSpacing.xs,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.smart_toy_outlined, size: 14),
+          const SizedBox(width: BricksSpacing.xs),
+          Text(
+            message.agentName ?? message.model ?? '',
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: chatColors.agentIdentity,
+                ),
           ),
+          if (message.nodeType?.trim().isNotEmpty == true) ...[
+            const SizedBox(width: BricksSpacing.xs),
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 5,
+                vertical: 1,
+              ),
+              decoration: BoxDecoration(
+                color: chatColors.agentBadgeContainer,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                message.nodeType!.trim(),
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: chatColors.onAgentBadgeContainer,
+                    ),
+              ),
+            ),
+          ],
         ],
       ),
     );
@@ -530,7 +588,11 @@ class _MessageListState extends State<MessageList> {
   // Builds a single message row for the given [index] in [widget.messages].
   // Extracted from build() so that the non-builder ListView can call it in a
   // simple for-loop while keeping the item rendering logic in one place.
-  Widget _buildMessageItem(BuildContext context, int index) {
+  Widget _buildMessageItem(
+    BuildContext context,
+    int index, {
+    bool suppressAssistantHeader = false,
+  }) {
     final allMessages = widget.messages;
     final msg = allMessages[index];
     final isUser = msg.role == 'user';
@@ -556,44 +618,13 @@ class _MessageListState extends State<MessageList> {
           // Show agent attribution chip as soon as assistant identity is
           // known, including dispatch placeholders pushed by SSE before
           // any assistant text is available.
-          if (!isUser && (msg.agentName != null || msg.model != null))
-            Padding(
-              padding: const EdgeInsets.only(
-                left: BricksSpacing.xs,
-                bottom: BricksSpacing.xs,
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(Icons.smart_toy_outlined, size: 14),
-                  const SizedBox(width: BricksSpacing.xs),
-                  Text(
-                    msg.agentName ?? msg.model ?? '',
-                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: chatColors.agentIdentity,
-                        ),
-                  ),
-                  if (msg.nodeType?.trim().isNotEmpty == true) ...[
-                    const SizedBox(width: BricksSpacing.xs),
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 5,
-                        vertical: 1,
-                      ),
-                      decoration: BoxDecoration(
-                        color: chatColors.agentBadgeContainer,
-                        borderRadius: BorderRadius.circular(4),
-                      ),
-                      child: Text(
-                        msg.nodeType!.trim(),
-                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                              color: chatColors.onAgentBadgeContainer,
-                            ),
-                      ),
-                    ),
-                  ],
-                ],
-              ),
+          if (!isUser &&
+              !suppressAssistantHeader &&
+              (msg.agentName != null || msg.model != null))
+            _assistantAttributionHeader(
+              context: context,
+              message: msg,
+              chatColors: chatColors,
             ),
           if (isAssistantDispatchPlaceholder)
             Padding(
@@ -800,11 +831,25 @@ class _MessageListState extends State<MessageList> {
     for (var i = 0; i < messages.length; i++) {
       if (_isToolLoopMessage(messages[i])) {
         final endIndex = _toolGroupEndIndex(messages, i);
-        messageItems.add(_buildToolGroupItem(context, i, endIndex));
+        messageItems.add(
+          _buildToolGroupItem(
+            context,
+            i,
+            endIndex,
+            hideMeta: _toolGroupShouldAttachNextText(messages, endIndex),
+          ),
+        );
         i = endIndex;
         continue;
       }
-      messageItems.add(_buildMessageItem(context, i));
+      messageItems.add(
+        _buildMessageItem(
+          context,
+          i,
+          suppressAssistantHeader:
+              _shouldAttachAssistantTextToPreviousToolGroup(messages, i),
+        ),
+      );
     }
 
     // All messages in the initial load are bounded (≤ 20 items). Building

--- a/apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
+++ b/apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
-import '../auth/auth_service.dart';
+import '../../services/authenticated_api_client.dart';
 
 enum LlmProvider { anthropic, googleAiStudio }
 
@@ -73,7 +73,12 @@ class LlmConfig {
 }
 
 class LlmConfigService {
-  const LlmConfigService();
+  LlmConfigService({
+    http.Client? httpClient,
+    AuthenticatedApiClient? apiClient,
+  }) : _apiClient = apiClient ?? AuthenticatedApiClient(httpClient: httpClient);
+
+  final AuthenticatedApiClient _apiClient;
 
   static const String productionApiBaseUrl = 'https://bricks.askman.dev';
 
@@ -97,15 +102,8 @@ class LlmConfigService {
   }
 
   Future<List<LlmConfig>> fetchConfigs() async {
-    final token = await AuthService.getToken();
-    if (token == null || token.isEmpty) return const [];
-
-    final response = await http.get(
-      _buildUri('/api/config', {'category': 'llm'}),
-      headers: {
-        'Authorization': 'Bearer $token',
-      },
-    );
+    final response =
+        await _apiClient.get(_buildUri('/api/config', {'category': 'llm'}));
 
     if (response.statusCode != 200) {
       throw Exception('Failed to load model settings (${response.statusCode})');
@@ -135,11 +133,6 @@ class LlmConfigService {
   }
 
   Future<LlmConfig> save(LlmConfig config) async {
-    final token = await AuthService.getToken();
-    if (token == null || token.isEmpty) {
-      throw Exception('Not authenticated');
-    }
-
     final modelName = config.defaultModel.trim();
     final resolvedSlotId =
         modelName.isEmpty ? config.slotId : normalizedSlotIdForModel(modelName);
@@ -164,19 +157,10 @@ class LlmConfigService {
     final uri = config.id == null
         ? _buildUri('/api/config')
         : _buildUri('/api/config/${config.id}');
-    final request = config.id == null
-        ? http.post
-        : (Uri u, {Map<String, String>? headers, Object? body}) =>
-            http.put(u, headers: headers, body: body);
-
-    final response = await request(
-      uri,
-      headers: {
-        'Authorization': 'Bearer $token',
-        'Content-Type': 'application/json',
-      },
-      body: payload,
-    );
+    final headers = {'Content-Type': 'application/json'};
+    final response = config.id == null
+        ? await _apiClient.post(uri, headers: headers, body: payload)
+        : await _apiClient.put(uri, headers: headers, body: payload);
 
     if (response.statusCode != 200 && response.statusCode != 201) {
       throw Exception('Failed to save model settings (${response.statusCode})');
@@ -190,19 +174,10 @@ class LlmConfigService {
   }
 
   Future<void> deleteConfig(String id) async {
-    final token = await AuthService.getToken();
-    if (token == null || token.isEmpty) {
-      throw Exception('Not authenticated');
-    }
-
     final encodedId = Uri.encodeComponent(id);
 
-    final response = await http.delete(
-      _buildUri('/api/config/$encodedId'),
-      headers: {
-        'Authorization': 'Bearer $token',
-      },
-    );
+    final response =
+        await _apiClient.delete(_buildUri('/api/config/$encodedId'));
 
     if (response.statusCode != 200 && response.statusCode != 204) {
       throw Exception(
@@ -211,15 +186,7 @@ class LlmConfigService {
   }
 
   Future<List<PlatformNodeConfig>> fetchPlatformNodes() async {
-    final token = await AuthService.getToken();
-    if (token == null || token.isEmpty) {
-      throw Exception('Not authenticated');
-    }
-
-    final response = await http.get(
-      _buildUri('/api/config/nodes'),
-      headers: {'Authorization': 'Bearer $token'},
-    );
+    final response = await _apiClient.get(_buildUri('/api/config/nodes'));
     if (response.statusCode != 200) {
       throw Exception(
           'Failed to fetch platform nodes (${response.statusCode})');
@@ -244,15 +211,9 @@ class LlmConfigService {
   }
 
   Future<PlatformNodeConfig> createPlatformNode({String? displayName}) async {
-    final token = await AuthService.getToken();
-    if (token == null || token.isEmpty) {
-      throw Exception('Not authenticated');
-    }
-
-    final response = await http.post(
+    final response = await _apiClient.post(
       _buildUri('/api/config/nodes'),
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({
@@ -277,15 +238,9 @@ class LlmConfigService {
     required String nodeId,
     required String displayName,
   }) async {
-    final token = await AuthService.getToken();
-    if (token == null || token.isEmpty) {
-      throw Exception('Not authenticated');
-    }
-
-    final response = await http.patch(
+    final response = await _apiClient.patch(
       _buildUri('/api/config/nodes/${Uri.encodeComponent(nodeId)}'),
       headers: {
-        'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
       },
       body: jsonEncode({'displayName': displayName.trim()}),
@@ -308,19 +263,13 @@ class LlmConfigService {
     required String nodeId,
     String? sourcePlatform,
   }) async {
-    final token = await AuthService.getToken();
-    if (token == null || token.isEmpty) {
-      throw Exception('Not authenticated');
-    }
-
-    final response = await http.get(
+    final response = await _apiClient.get(
       _buildUri(
         '/api/config/nodes/${Uri.encodeComponent(nodeId)}/agents',
         sourcePlatform == null || sourcePlatform.trim().isEmpty
             ? null
             : {'sourcePlatform': sourcePlatform.trim()},
       ),
-      headers: {'Authorization': 'Bearer $token'},
     );
     if (response.statusCode != 200) {
       throw Exception(
@@ -355,19 +304,11 @@ class LlmConfigService {
     String? nodeId,
     String pluginId = 'plugin_local_main',
   }) async {
-    final token = await AuthService.getToken();
-    if (token == null || token.isEmpty) {
-      throw Exception('Not authenticated');
-    }
-
-    final response = await http.get(
+    final response = await _apiClient.get(
       _buildUri('/api/config/platform-token', {
         if (nodeId != null && nodeId.trim().isNotEmpty) 'nodeId': nodeId.trim(),
         if (nodeId == null || nodeId.trim().isEmpty) 'pluginId': pluginId,
       }),
-      headers: {
-        'Authorization': 'Bearer $token',
-      },
     );
 
     if (response.statusCode != 200) {

--- a/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
+++ b/apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
@@ -9,9 +9,9 @@ const kApiKeyStoredHint = '(已设置，出于安全原因未显示)';
 
 class ModelSettingsScreen extends StatefulWidget {
   const ModelSettingsScreen({super.key, LlmConfigService? service})
-      : _service = service ?? const LlmConfigService();
+      : _service = service;
 
-  final LlmConfigService _service;
+  final LlmConfigService? _service;
 
   @override
   State<ModelSettingsScreen> createState() => _ModelSettingsScreenState();
@@ -36,7 +36,7 @@ class _ModelSettingsScreenState extends State<ModelSettingsScreen> {
   @override
   void initState() {
     super.initState();
-    _service = widget._service;
+    _service = widget._service ?? LlmConfigService();
     _load();
   }
 

--- a/apps/mobile_chat_app/lib/features/settings/node_settings_screen.dart
+++ b/apps/mobile_chat_app/lib/features/settings/node_settings_screen.dart
@@ -5,9 +5,9 @@ import 'llm_config_service.dart';
 
 class NodeSettingsScreen extends StatefulWidget {
   const NodeSettingsScreen({super.key, LlmConfigService? service})
-      : _service = service ?? const LlmConfigService();
+      : _service = service;
 
-  final LlmConfigService _service;
+  final LlmConfigService? _service;
 
   @override
   State<NodeSettingsScreen> createState() => _NodeSettingsScreenState();
@@ -23,7 +23,7 @@ class _NodeSettingsScreenState extends State<NodeSettingsScreen> {
   @override
   void initState() {
     super.initState();
-    _service = widget._service;
+    _service = widget._service ?? LlmConfigService();
     _loadNodes();
   }
 

--- a/apps/mobile_chat_app/lib/services/authenticated_api_client.dart
+++ b/apps/mobile_chat_app/lib/services/authenticated_api_client.dart
@@ -25,10 +25,18 @@ class AuthenticatedApiClient {
     http.Client? httpClient,
     AuthTokenProvider? tokenProvider,
   })  : _httpClient = httpClient ?? http.Client(),
+        _ownsHttpClient = httpClient == null,
         _tokenProvider = tokenProvider ?? AuthService.getToken;
 
   final http.Client _httpClient;
+  final bool _ownsHttpClient;
   final AuthTokenProvider _tokenProvider;
+
+  void close() {
+    if (_ownsHttpClient) {
+      _httpClient.close();
+    }
+  }
 
   Future<http.Response> get(
     Uri uri, {
@@ -55,6 +63,32 @@ class AuthenticatedApiClient {
     );
   }
 
+  Future<http.Response> put(
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+  }) {
+    return _send(
+      uri,
+      headers: headers,
+      sender: (authorizedHeaders) =>
+          _httpClient.put(uri, headers: authorizedHeaders, body: body),
+    );
+  }
+
+  Future<http.Response> patch(
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+  }) {
+    return _send(
+      uri,
+      headers: headers,
+      sender: (authorizedHeaders) =>
+          _httpClient.patch(uri, headers: authorizedHeaders, body: body),
+    );
+  }
+
   Future<http.Response> delete(
     Uri uri, {
     Map<String, String>? headers,
@@ -66,6 +100,19 @@ class AuthenticatedApiClient {
       sender: (authorizedHeaders) =>
           _httpClient.delete(uri, headers: authorizedHeaders, body: body),
     );
+  }
+
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final token = await _tokenProvider();
+    if (token == null || token.isEmpty) {
+      throw const MissingAuthTokenException();
+    }
+    request.headers['Authorization'] = 'Bearer $token';
+    final response = await _httpClient.send(request);
+    if (response.statusCode == 401) {
+      throw UnauthorizedApiException(request.url);
+    }
+    return response;
   }
 
   Future<http.Response> _send(

--- a/apps/mobile_chat_app/test/chat_history_api_service_test.dart
+++ b/apps/mobile_chat_app/test/chat_history_api_service_test.dart
@@ -7,6 +7,7 @@ import 'package:http/testing.dart';
 import 'package:mobile_chat_app/features/chat/chat_history_api_service.dart';
 import 'package:mobile_chat_app/features/chat/chat_message.dart';
 import 'package:mobile_chat_app/features/chat/chat_topology.dart';
+import 'package:mobile_chat_app/services/authenticated_api_client.dart';
 
 /// A minimal [http.BaseClient] whose [send] method is fully injectable for
 /// testing streaming (SSE) responses that [MockClient] cannot model.
@@ -19,6 +20,17 @@ class _MockStreamedClient extends http.BaseClient {
   Future<http.StreamedResponse> send(http.BaseRequest request) =>
       _handler(request);
 }
+
+ChatHistoryApiService _serviceFor(
+  http.Client client, {
+  String token = 'token-1',
+}) =>
+    ChatHistoryApiService(
+      apiClient: AuthenticatedApiClient(
+        httpClient: client,
+        tokenProvider: () async => token,
+      ),
+    );
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -53,10 +65,10 @@ void main() {
       );
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
+    final service = _serviceFor(client);
     final snapshot = await service.load(
-      token: 'token-1',
       sessionId: 'session:default:main',
+      limit: 100,
     );
 
     expect(snapshot.messages, hasLength(2));
@@ -90,9 +102,8 @@ void main() {
       );
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
+    final service = _serviceFor(client);
     final snapshot = await service.load(
-      token: 'token-1',
       sessionId: 'session:default:main',
     );
 
@@ -130,9 +141,8 @@ void main() {
       );
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
+    final service = _serviceFor(client);
     final snapshot = await service.sync(
-      token: 'token-1',
       sessionId: 'session:default:main',
       afterSeq: 10,
     );
@@ -165,15 +175,13 @@ void main() {
       return http.Response(jsonEncode({'lastSeqId': 7}), 200);
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
+    final service = _serviceFor(client);
     final accepted = await service.acceptTask(
-      token: 'token-1',
       taskId: 'task-1',
       idempotencyKey: 'idem-1',
       scope: const ChatSessionScope(channelId: 'default', threadId: 'main'),
     );
     final lastSeq = await service.upsertMessages(
-      token: 'token-1',
       messages: [
         ChatMessage(
           messageId: 'msg-1',
@@ -202,9 +210,8 @@ void main() {
         return http.Response(jsonEncode({'lastSeqId': 8}), 200);
       });
 
-      final service = ChatHistoryApiService(httpClient: client);
+      final service = _serviceFor(client);
       final lastSeq = await service.upsertMessages(
-        token: 'token-1',
         messages: [
           ChatMessage(
             messageId: 'msg-user',
@@ -247,9 +254,8 @@ void main() {
       );
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
+    final service = _serviceFor(client);
     final result = await service.respond(
-      token: 'token-1',
       taskId: 'task-2',
       idempotencyKey: 'idem-2',
       scope: const ChatSessionScope(channelId: 'default', threadId: 'main'),
@@ -288,9 +294,8 @@ void main() {
         );
       });
 
-      final service = ChatHistoryApiService(httpClient: client);
+      final service = _serviceFor(client);
       final result = await service.respond(
-        token: 'token-1',
         taskId: 'task-openclaw-accepted',
         idempotencyKey: 'idem-openclaw-accepted',
         scope: const ChatSessionScope(channelId: 'default', threadId: 'main'),
@@ -326,9 +331,8 @@ void main() {
         );
       });
 
-      final service = ChatHistoryApiService(httpClient: client);
+      final service = _serviceFor(client);
       final result = await service.respond(
-        token: 'token-1',
         taskId: 'task-openclaw-completed',
         idempotencyKey: 'idem-openclaw-completed',
         scope: const ChatSessionScope(channelId: 'default', threadId: 'main'),
@@ -369,8 +373,8 @@ void main() {
       );
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
-    final scopes = await service.loadScopes(token: 'token-1');
+    final service = _serviceFor(client);
+    final scopes = await service.loadScopes();
 
     expect(scopes, hasLength(2));
     expect(scopes.first.channelId, equals('channel-1'));
@@ -414,10 +418,9 @@ void main() {
       );
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
-    final settings = await service.loadScopeSettings(token: 'token-1');
+    final service = _serviceFor(client);
+    final settings = await service.loadScopeSettings();
     await service.saveScopeSetting(
-      token: 'token-1',
       scopeType: ChatScopeType.thread,
       channelId: 'default',
       threadId: 'main',
@@ -464,10 +467,9 @@ void main() {
       );
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
-    final channelNames = await service.loadChannelNames(token: 'token-1');
+    final service = _serviceFor(client);
+    final channelNames = await service.loadChannelNames();
     await service.saveChannelName(
-      token: 'token-1',
       channelId: 'channel-1',
       displayName: 'latest-channel-name',
     );
@@ -488,9 +490,8 @@ void main() {
       return http.StreamedResponse(controller.stream, 200);
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
+    final service = _serviceFor(client, token: 'sse-token');
     final events = service.listenEvents(
-      token: 'sse-token',
       sessionId: 'session:default:main',
       afterSeq: 5,
     );
@@ -524,9 +525,8 @@ void main() {
       return http.StreamedResponse(controller.stream, 200);
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
+    final service = _serviceFor(client);
     final events = service.listenEvents(
-      token: 'token-1',
       sessionId: 'session:default:main',
       afterSeq: 0,
     );
@@ -581,8 +581,8 @@ void main() {
       );
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
-    final settings = await service.loadScopeSettings(token: 'token-1');
+    final service = _serviceFor(client);
+    final settings = await service.loadScopeSettings();
 
     expect(settings, hasLength(3));
     final channelSetting =
@@ -615,9 +615,8 @@ void main() {
       );
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
+    final service = _serviceFor(client);
     await service.saveScopeSetting(
-      token: 'token-1',
       scopeType: ChatScopeType.channel,
       channelId: 'ch-1',
       router: ChatRouter.local,
@@ -652,9 +651,8 @@ void main() {
       );
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
-    final snapshot =
-        await service.load(token: 'token-1', sessionId: 'session:default:main');
+    final service = _serviceFor(client);
+    final snapshot = await service.load(sessionId: 'session:default:main');
 
     expect(snapshot.messages, hasLength(1));
     final msg = snapshot.messages.first;
@@ -683,9 +681,8 @@ void main() {
       );
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
-    final snapshot =
-        await service.load(token: 'token-1', sessionId: 'session:default:main');
+    final service = _serviceFor(client);
+    final snapshot = await service.load(sessionId: 'session:default:main');
 
     expect(snapshot.messages, hasLength(1));
     final msg = snapshot.messages.first;
@@ -707,9 +704,8 @@ void main() {
       );
     });
 
-    final service = ChatHistoryApiService(httpClient: client);
+    final service = _serviceFor(client);
     await service.respond(
-      token: 'token-1',
       taskId: 'task-1',
       idempotencyKey: 'idem-1',
       scope: const ChatSessionScope(channelId: 'ch-1', threadId: 'main'),

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -563,6 +563,40 @@ void main() {
       expect(padding.padding, const EdgeInsets.only(left: BricksSpacing.md));
     });
 
+    testWidgets('renders nested markdown list items with deeper indentation',
+        (tester) async {
+      final assistant = ChatMessage(
+        messageId: 'assistant-markdown-nested-list',
+        role: 'assistant',
+        content: '- parent\n  - child target\n    1. grandchild',
+        timestamp: DateTime.utc(2026, 1, 1),
+      );
+
+      await tester.pumpWidget(_build([assistant]));
+      await tester.pumpAndSettle();
+
+      EdgeInsets paddingForText(String text) {
+        return tester
+            .widget<Padding>(
+              find
+                  .ancestor(
+                    of: find.text(text),
+                    matching: find.byType(Padding),
+                  )
+                  .first,
+            )
+            .padding as EdgeInsets;
+      }
+
+      final parentPadding = paddingForText('parent');
+      final childPadding = paddingForText('child target');
+      final grandchildPadding = paddingForText('grandchild');
+
+      expect(childPadding.left, greaterThan(parentPadding.left));
+      expect(grandchildPadding.left, greaterThan(childPadding.left));
+      expect(find.text('1.'), findsOneWidget);
+    });
+
     testWidgets('renders markdown tables as table widgets', (tester) async {
       final assistant = ChatMessage(
         messageId: 'assistant-markdown-table',
@@ -717,6 +751,39 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(Table), findsOneWidget);
+      final decorated = _decoratedLeafSpans(tester);
+      expect(decorated.map((span) => span.text).toList(), ['target']);
+    });
+
+    testWidgets('renders stored ranges inside nested markdown list items',
+        (tester) async {
+      const content = '- parent\n  - child target\n    1. grandchild';
+      final assistant = ChatMessage(
+        messageId: 'assistant-highlight-nested-list',
+        role: 'assistant',
+        content: content,
+        timestamp: DateTime.utc(2026, 1, 1),
+      );
+      final start = content.indexOf('target');
+
+      await tester.pumpWidget(
+        _build(
+          [assistant],
+          highlights: {
+            'assistant-highlight-nested-list': [
+              HighlightSpan(
+                highlightId: 'h1',
+                selectedText: 'target',
+                startOffset: start,
+                endOffset: start + 'target'.length,
+                color: 'yellow',
+              ),
+            ],
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
       final decorated = _decoratedLeafSpans(tester);
       expect(decorated.map((span) => span.text).toList(), ['target']);
     });

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -1264,7 +1264,7 @@ void main() {
   });
 
   group('Agent-loop status rows', () {
-    testWidgets('tool_call_start renders spinning indicator and label',
+    testWidgets('tool_call_start renders active thinking group',
         (tester) async {
       final msg = ChatMessage(
         messageId: 'tc-start-1',
@@ -1281,24 +1281,103 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
-      expect(find.textContaining('search_web'), findsOneWidget);
+      expect(find.text('正在思考 0/1'), findsOneWidget);
+      expect(find.textContaining('search_web'), findsNothing);
     });
 
-    testWidgets('tool_call_start without toolName renders generic label',
+    testWidgets('completed tool_call_start renders finalized thinking group',
         (tester) async {
       final msg = ChatMessage(
         messageId: 'tc-start-2',
         role: 'assistant',
         content: '',
         agentLoopPhase: 'tool_call_start',
+        taskState: ChatTaskState.completed,
         timestamp: DateTime.utc(2026, 1, 1),
       );
 
       await tester.pumpWidget(_build([msg]));
-      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pumpAndSettle();
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
-      expect(find.text('正在调用工具…'), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+      expect(find.text('思考过程 1/1'), findsOneWidget);
+    });
+
+    testWidgets('adjacent tool messages merge into one thinking group',
+        (tester) async {
+      final messages = [
+        ChatMessage(
+          messageId: 'tc-start-1',
+          role: 'assistant',
+          content: '',
+          agentLoopPhase: 'tool_call_start',
+          taskState: ChatTaskState.completed,
+          timestamp: DateTime.utc(2026, 1, 1),
+        ),
+        ChatMessage(
+          messageId: 'tc-result-1',
+          role: 'assistant',
+          content: 'Tool: first\nResult: {"ok":true}',
+          agentLoopPhase: 'tool_call',
+          timestamp: DateTime.utc(2026, 1, 1, 0, 0, 1),
+        ),
+        ChatMessage(
+          messageId: 'tc-start-2',
+          role: 'assistant',
+          content: '',
+          agentLoopPhase: 'tool_call_start',
+          taskState: ChatTaskState.completed,
+          timestamp: DateTime.utc(2026, 1, 1, 0, 0, 2),
+        ),
+        ChatMessage(
+          messageId: 'tc-result-2',
+          role: 'assistant',
+          content: 'Tool: second\nResult: {"items":[1,2]}',
+          agentLoopPhase: 'tool_call',
+          timestamp: DateTime.utc(2026, 1, 1, 0, 0, 3),
+        ),
+      ];
+
+      await tester.pumpWidget(_build(messages));
+      await tester.pumpAndSettle();
+
+      expect(find.text('思考过程 2/2'), findsOneWidget);
+      expect(find.textContaining('Tool: first'), findsNothing);
+      expect(find.textContaining('Tool: second'), findsNothing);
+    });
+
+    testWidgets('non-adjacent tool messages remain separate thinking groups',
+        (tester) async {
+      final messages = [
+        ChatMessage(
+          messageId: 'tc-start-1',
+          role: 'assistant',
+          content: '',
+          agentLoopPhase: 'tool_call_start',
+          taskState: ChatTaskState.completed,
+          timestamp: DateTime.utc(2026, 1, 1),
+        ),
+        ChatMessage(
+          messageId: 'assistant-text',
+          role: 'assistant',
+          content: 'normal text between tools',
+          timestamp: DateTime.utc(2026, 1, 1, 0, 0, 1),
+        ),
+        ChatMessage(
+          messageId: 'tc-start-2',
+          role: 'assistant',
+          content: '',
+          agentLoopPhase: 'tool_call_start',
+          taskState: ChatTaskState.completed,
+          timestamp: DateTime.utc(2026, 1, 1, 0, 0, 2),
+        ),
+      ];
+
+      await tester.pumpWidget(_build(messages));
+      await tester.pumpAndSettle();
+
+      expect(find.text('思考过程 1/1'), findsNWidgets(2));
+      expect(find.text('normal text between tools'), findsOneWidget);
     });
 
     testWidgets('reasoning renders collapsed thought block by default',
@@ -1370,8 +1449,7 @@ void main() {
       expect(find.byType(IntrinsicHeight), findsOneWidget);
     });
 
-    testWidgets(
-        'tool_call phase falls through to normal assistant bubble rendering',
+    testWidgets('tool_call phase is hidden behind a thinking group',
         (tester) async {
       final msg = ChatMessage(
         messageId: 'tc-result-1',
@@ -1384,10 +1462,8 @@ void main() {
       await tester.pumpWidget(_build([msg]));
       await tester.pumpAndSettle();
 
-      // Content visible in the normal rendering path
-      expect(find.textContaining('Tool: search'), findsOneWidget);
-      // No spinner (would only appear for tool_call_start)
-      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text('思考过程 1/1'), findsOneWidget);
+      expect(find.textContaining('Tool: search'), findsNothing);
     });
   });
 }

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -1346,6 +1346,43 @@ void main() {
       expect(find.textContaining('Tool: second'), findsNothing);
     });
 
+    testWidgets('assistant answer after tool group shares the tool header',
+        (tester) async {
+      final messages = [
+        ChatMessage(
+          messageId: 'tc-start-1',
+          role: 'assistant',
+          content: '',
+          agentName: 'gemini-flash-latest',
+          agentLoopPhase: 'tool_call_start',
+          taskState: ChatTaskState.completed,
+          timestamp: DateTime.utc(2026, 1, 1),
+        ),
+        ChatMessage(
+          messageId: 'tc-result-1',
+          role: 'assistant',
+          content: 'Tool: todo_list\nResult: {"ok":true}',
+          agentLoopPhase: 'tool_call',
+          timestamp: DateTime.utc(2026, 1, 1, 0, 0, 1),
+        ),
+        ChatMessage(
+          messageId: 'assistant-final',
+          role: 'assistant',
+          content: '目前你总共有 7 个任务。',
+          agentName: 'gemini-flash-latest',
+          timestamp: DateTime.utc(2026, 1, 1, 0, 0, 2),
+        ),
+      ];
+
+      await tester.pumpWidget(_build(messages));
+      await tester.pumpAndSettle();
+
+      expect(find.text('gemini-flash-latest'), findsOneWidget);
+      expect(find.text('思考过程 1/1'), findsOneWidget);
+      expect(find.text('目前你总共有 7 个任务。'), findsOneWidget);
+      expect(find.textContaining('Tool: todo_list'), findsNothing);
+    });
+
     testWidgets('non-adjacent tool messages remain separate thinking groups',
         (tester) async {
       final messages = [

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -185,6 +185,8 @@ products:
         entry_paths:
           - service: TodoApiService
             route_hint: apps/mobile_chat_app/lib/features/chat/todo_api_service.dart
+          - service: AuthenticatedApiClient
+            route_hint: apps/mobile_chat_app/lib/services/authenticated_api_client.dart
           - route: GET /api/resources/todo-lists
             route_hint: apps/node_backend/src/routes/resources.ts
           - route: POST /api/resources/todo-lists
@@ -211,6 +213,8 @@ products:
         entry_paths:
           - service: AssetTableApiService
             route_hint: apps/mobile_chat_app/lib/features/chat/asset_table_api_service.dart
+          - service: AuthenticatedApiClient
+            route_hint: apps/mobile_chat_app/lib/services/authenticated_api_client.dart
           - route: GET/POST /api/resources/tables
             route_hint: apps/node_backend/src/routes/resources.ts
           - route: GET /api/resources/tables/:resourceId
@@ -257,6 +261,7 @@ products:
           - 点击"划线"后，客户端发出带 Authorization header 的 POST /api/resources/highlights 请求，成功后选中文字出现黄色背景和横线。
           - 缺少 token 或 token 失效时，点击"划线"不应静默无反馈。
           - 当同一消息中存在重复文本时，只应划中用户实际选择的那一段。
+          - 层级 Markdown 列表中的子项应保留更深缩进，且存储 offset 的划线应显示在正确子项文本上。
           - 选区跨 markdown 段落、代码块或表格单元格时，同一条划线应渲染成多个连续 subsegment。
           - 选中已有划线范围时，工具栏应提供"删除划线"。
           - 点击已有黄色划线区域时，应显示同款浮动工具栏，包含"复制"和"删除划线"。

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -230,7 +230,7 @@ products:
           - 用户说"显示 Tasks 表格"，AI 调用 table_get 并以 Markdown 表格回复。
           - 在 Turso/libSQL 数据库下，table_create / table_add_column / table_add_row / table_update_row / table_delete_row 均应成功执行，不应因 PostgreSQL-only SQL（例如 NOW() 或 ::jsonb）失败。
           - 当 table_create 执行时抛出数据库错误，聊天历史应显示工具错误结果，并将对应 tool_call_start 标记为已完成，不能永久显示“正在调用”。
-          - 相邻工具调用在聊天流中应折叠为一个"正在思考/思考过程 completed/total"标志，不直接显示工具名或长 JSON。
+          - 相邻工具调用在聊天流中应折叠为一个"正在思考/思考过程 completed/total"标志，不直接显示工具名或长 JSON；紧随其后的助手文本不重复显示头像/模型名。
           - 添加一列 Priority 后，已有行不变（O(1) schema change）。
           - 软删除行后，table_get 不返回该行。
 

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -230,6 +230,7 @@ products:
           - 用户说"显示 Tasks 表格"，AI 调用 table_get 并以 Markdown 表格回复。
           - 在 Turso/libSQL 数据库下，table_create / table_add_column / table_add_row / table_update_row / table_delete_row 均应成功执行，不应因 PostgreSQL-only SQL（例如 NOW() 或 ::jsonb）失败。
           - 当 table_create 执行时抛出数据库错误，聊天历史应显示工具错误结果，并将对应 tool_call_start 标记为已完成，不能永久显示“正在调用”。
+          - 相邻工具调用在聊天流中应折叠为一个"正在思考/思考过程 completed/total"标志，不直接显示工具名或长 JSON。
           - 添加一列 Priority 后，已有行不变（O(1) schema change）。
           - 软删除行后，table_get 不返回该行。
 

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -53,6 +53,7 @@ index:
       - apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
       - apps/mobile_chat_app/lib/features/chat/chat_builtin_agents.dart
       - apps/mobile_chat_app/lib/features/agents/agents_screen.dart
+      - apps/mobile_chat_app/lib/services/authenticated_api_client.dart
       - apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
       - apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
       - apps/mobile_chat_app/lib/features/chat/chat_message_sort.dart
@@ -90,6 +91,7 @@ index:
       - docs/plans/2026-05-15-16-54-+08-local-chat-fixture-db.md
       - docs/plans/2026-05-16-17-58-+08-mobile-agents-directory-setup-fix.md
       - docs/plans/2026-05-16-23-21-+08-ios-sandbox-path-without-home.md
+      - docs/plans/2026-05-19-13-02-CST-highlight-list-and-auth-api-architecture.md
       - docs/testing/local-chat-fixture-db.md
     test_index:
       - apps/mobile_chat_app/test/chat_arbitration_engine_test.dart
@@ -191,6 +193,7 @@ index:
       - 若移动端没有可写的本地 Agents 目录，登录后的 chat setup 会在历史会话加载前失败，表现为同账号移动端看不到网页历史数据。
       - 若 iOS 本地路径解析依赖 `HOME` 环境变量，真机启动会在 chat setup 阶段失败并阻断历史会话加载。
       - 若本地自定义 Agent 文件读取与线上会话初始化共用同一个失败边界，单个本地文件系统异常会误伤频道和历史加载。
+      - ChatHistoryApiService 依赖 AuthenticatedApiClient 注入 token；若重新在 ChatScreen 用 _authToken 阻断 load/respond/SSE，会回到 UI 静默失败路径。
       - 若组件直接写死颜色或误用 `primary` 作为普通气泡背景，会破坏暗色信息层级并导致关键行动不突出。
       - 若频道最新消息时间未在消息加载、追加、归档时同步更新，侧边栏排序将与实际活跃时间脱节。
       - 若仅对侧边栏频道列表使用 _sortedChannels 而未对顶部频道下拉菜单同步更新，两处展示顺序不一致会混淆用户。
@@ -200,6 +203,7 @@ index:
     capability: 频道与分区级别的会话指令配置及提示词组合
     code_index:
       - apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+      - apps/mobile_chat_app/lib/services/authenticated_api_client.dart
       - apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
       - apps/mobile_chat_app/lib/features/chat/chat_topology.dart
       - apps/node_backend/src/routes/chat.ts
@@ -207,6 +211,7 @@ index:
       - apps/node_backend/src/db/migrations/013_add_instructions_to_chat_scope_settings.sql
     doc_index:
       - docs/plans/2026-04-30-17-51-+08-scope-instructions-config.md
+      - docs/plans/2026-05-19-13-02-CST-highlight-list-and-auth-api-architecture.md
     test_index:
       - apps/mobile_chat_app/test/chat_history_api_service_test.dart
       - apps/node_backend/src/services/chatRouterService.test.ts
@@ -267,6 +272,7 @@ index:
     capability: 模型配置读写
     code_index:
       - apps/mobile_chat_app/lib/features/settings/model_settings_screen.dart
+      - apps/mobile_chat_app/lib/services/authenticated_api_client.dart
       - apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
       - apps/node_backend/src/routes/config.ts
       - config/models.yaml
@@ -276,6 +282,7 @@ index:
       - docs/model_settings_plan.md
       - docs/architecture.md
       - docs/openclaw_pull_only_integration_dev_doc.md
+      - docs/plans/2026-05-19-13-02-CST-highlight-list-and-auth-api-architecture.md
     test_index:
       - apps/mobile_chat_app/test/model_settings_screen_test.dart
       - apps/mobile_chat_app/test/llm_config_service_test.dart
@@ -290,6 +297,7 @@ index:
       - api url
     change_risks:
       - 字段格式变化导致保存后读取失败。
+      - LlmConfigService 依赖 AuthenticatedApiClient 注入 token；设置页测试应注入 fake service，服务测试应注入测试 token provider。
       - 后端默认模型与前端选择策略不一致。
       - release native API base URL 默认值错误会导致登录、配置读取和聊天请求打到本机 localhost。
 
@@ -298,6 +306,7 @@ index:
     code_index:
       - apps/mobile_chat_app/lib/features/settings/settings_screen.dart
       - apps/mobile_chat_app/lib/features/settings/node_settings_screen.dart
+      - apps/mobile_chat_app/lib/services/authenticated_api_client.dart
       - apps/mobile_chat_app/lib/features/settings/llm_config_service.dart
       - apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
       - apps/node_backend/src/routes/config.ts
@@ -533,8 +542,10 @@ index:
       - apps/node_backend/src/services/localAgentLoopService.ts
       - apps/node_backend/src/routes/resources.ts
       - apps/mobile_chat_app/lib/features/chat/todo_api_service.dart
+      - apps/mobile_chat_app/lib/services/authenticated_api_client.dart
     doc_index:
       - docs/plans/2026-05-16-02-20-+00-todos-tables-highlights-tools.md
+      - docs/plans/2026-05-19-13-02-CST-highlight-list-and-auth-api-architecture.md
     test_index:
       - apps/node_backend/src/services/localAgentLoopService.test.ts
     keywords:
@@ -551,6 +562,7 @@ index:
       - todoListService.deleteTodoList 依赖 DB CASCADE 删除子 asset_todos；若 FK 未正确迁移，cascade 不生效。
       - 修改 INTERNAL_TOOLS 常量列表若遗漏新工具会导致 tool_not_allowed 错误。
       - todoService 的 updateTodo 使用动态 SET 子句；若新增字段须同步 DTO 和路由 PATCH 处理。
+      - TodoApiService 不再接收 token 参数；资源预览和聊天页加载应依赖 AuthenticatedApiClient 的统一缺 token/401 错误路径。
 
   - feature_id: asset_tables
     capability: 用户通过自然语言让 AI 管理动态 JSONB 表格（O(1) 列操作，行软删除）；AI 调用 table_* 工具
@@ -562,9 +574,11 @@ index:
       - apps/node_backend/src/routes/chat.ts
       - apps/node_backend/src/routes/resources.ts
       - apps/mobile_chat_app/lib/features/chat/asset_table_api_service.dart
+      - apps/mobile_chat_app/lib/services/authenticated_api_client.dart
     doc_index:
       - docs/plans/2026-05-16-02-20-+00-todos-tables-highlights-tools.md
       - docs/plans/2026-05-17-00-04-+08-table-tool-error-and-turso-compatibility.md
+      - docs/plans/2026-05-19-13-02-CST-highlight-list-and-auth-api-architecture.md
       - docs/kb/turso-sqlite-compatibility.md
     test_index:
       - apps/node_backend/src/services/localAgentLoopService.test.ts
@@ -582,12 +596,14 @@ index:
       - tool-error
       - sparse storage
       - column registry
+      - authenticated API client
     change_risks:
       - getTable 在读取时用 column registry 过滤 cell_data keys；删除列后旧数据仍保留在 JSONB，仅在读时过滤——若直接查询 DB 会看到孤立 key。
       - addRow 使用子查询计算 MAX(display_number)+1，高并发下可能产生重复 display_number（可接受，仅用于排序）。
       - removeColumn 仅删除 asset_table_columns 记录，不清理已有行的 cell_data，需注意存储膨胀。
       - 运行时 SQL 若使用 PostgreSQL-only 语法（NOW()、::jsonb、JSONB concat）会在 Turso/libSQL 下执行失败，导致工具 start 已落库但无 result。
       - AI SDK 的 tool-error 事件若未持久化，历史消息会永久显示“正在调用 table_create”，即使工具已经失败。
+      - AssetTableApiService 不再接收 token 参数；资源加载失败应通过统一 authenticated client 错误路径处理。
 
   - feature_id: text_highlights
     capability: 用户选中助手消息文本后通过浮动工具栏"划线"持久化高亮；高亮按消息 offset 渲染，可拆成多个 markdown/code/table subsegment；AI 可用 highlight_list 工具查询
@@ -604,6 +620,7 @@ index:
       - docs/plans/2026-05-18-22-22-+08-highlight-selection-offsets.md
       - docs/plans/2026-05-19-10-50-+08-unified-authenticated-api-client.md
       - docs/plans/2026-05-19-11-55-+08-highlight-toolbar-union-ranges.md
+      - docs/plans/2026-05-19-13-02-CST-highlight-list-and-auth-api-architecture.md
       - docs/design/text-highlight-floating-toolbar.design.md
     test_index:
       - apps/mobile_chat_app/test/message_list_test.dart
@@ -623,6 +640,7 @@ index:
       - tap highlighted span
       - highlight range union
       - markdown highlight offsets
+      - nested markdown list highlights
       - code block highlights
       - table cell highlights
       - subsegment rendering
@@ -637,6 +655,7 @@ index:
       - 划线创建和删除依赖 AuthenticatedApiClient 注入 Authorization header；若 UI 层重新用 _authToken gate action，可能再次出现工具栏可见但点击不发请求的静默失败。
       - Backend resources routes must read `AuthRequest.userId`; reading a non-existent `req.user.id` can reject an async Express 4 handler and leave the browser request pending.
       - 选区 offset 映射依赖前端 markdown renderer 与 rendered-text index 对 markdown 标记、代码块、表格文本的处理保持一致；渲染规则变化时需同步更新映射测试。
+      - 层级列表渲染依赖 _MarkdownBlock.listLevel 保留缩进层级；若列表解析规则变化，需要同步 nested list highlight 测试。
       - 表格单元格或重复文本若使用文本搜索而不是 stored startOffset/endOffset，会导致划线显示或删除到错误位置。
       - Flutter Web 上 TextSpan TapGestureRecognizer 会干扰 SelectionArea 拖拽选择；web 删除路径应继续通过选择工具栏实现。
       - 旧数据若缺少 startOffset/endOffset，仍会回退为 selectedText 搜索；重复文本场景下旧记录可能显示多处，需要后续数据迁移或重新创建高亮才能完全消除歧义。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -197,7 +197,7 @@ index:
       - 若 iOS 本地路径解析依赖 `HOME` 环境变量，真机启动会在 chat setup 阶段失败并阻断历史会话加载。
       - 若本地自定义 Agent 文件读取与线上会话初始化共用同一个失败边界，单个本地文件系统异常会误伤频道和历史加载。
       - ChatHistoryApiService 依赖 AuthenticatedApiClient 注入 token；若重新在 ChatScreen 用 _authToken 阻断 load/respond/SSE，会回到 UI 静默失败路径。
-      - 相邻 tool_call_start/tool_call 消息应在 MessageList 中折叠成一个思考过程标志；如果分组边界跨过普通 assistant/user 消息，会错误隐藏正常对话内容。
+      - 相邻 tool_call_start/tool_call 消息应在 MessageList 中折叠成一个思考过程标志；紧随其后的普通 assistant 文本会隐藏重复 header。如果分组边界跨过普通 assistant/user 消息，会错误隐藏正常对话内容。
       - 若组件直接写死颜色或误用 `primary` 作为普通气泡背景，会破坏暗色信息层级并导致关键行动不突出。
       - 若频道最新消息时间未在消息加载、追加、归档时同步更新，侧边栏排序将与实际活跃时间脱节。
       - 若仅对侧边栏频道列表使用 _sortedChannels 而未对顶部频道下拉菜单同步更新，两处展示顺序不一致会混淆用户。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -92,6 +92,7 @@ index:
       - docs/plans/2026-05-16-17-58-+08-mobile-agents-directory-setup-fix.md
       - docs/plans/2026-05-16-23-21-+08-ios-sandbox-path-without-home.md
       - docs/plans/2026-05-19-13-02-CST-highlight-list-and-auth-api-architecture.md
+      - docs/plans/2026-05-19-14-27-CST-tool-call-thinking-group.md
       - docs/testing/local-chat-fixture-db.md
     test_index:
       - apps/mobile_chat_app/test/chat_arbitration_engine_test.dart
@@ -110,6 +111,8 @@ index:
       - chat
       - arbitration
       - topology
+      - tool call thinking group
+      - adjacent tool grouping
       - channel
       - rename
       - archive
@@ -194,6 +197,7 @@ index:
       - 若 iOS 本地路径解析依赖 `HOME` 环境变量，真机启动会在 chat setup 阶段失败并阻断历史会话加载。
       - 若本地自定义 Agent 文件读取与线上会话初始化共用同一个失败边界，单个本地文件系统异常会误伤频道和历史加载。
       - ChatHistoryApiService 依赖 AuthenticatedApiClient 注入 token；若重新在 ChatScreen 用 _authToken 阻断 load/respond/SSE，会回到 UI 静默失败路径。
+      - 相邻 tool_call_start/tool_call 消息应在 MessageList 中折叠成一个思考过程标志；如果分组边界跨过普通 assistant/user 消息，会错误隐藏正常对话内容。
       - 若组件直接写死颜色或误用 `primary` 作为普通气泡背景，会破坏暗色信息层级并导致关键行动不突出。
       - 若频道最新消息时间未在消息加载、追加、归档时同步更新，侧边栏排序将与实际活跃时间脱节。
       - 若仅对侧边栏频道列表使用 _sortedChannels 而未对顶部频道下拉菜单同步更新，两处展示顺序不一致会混淆用户。

--- a/docs/plans/2026-05-19-13-02-CST-highlight-list-and-auth-api-architecture.md
+++ b/docs/plans/2026-05-19-13-02-CST-highlight-list-and-auth-api-architecture.md
@@ -1,0 +1,63 @@
+# Highlight List Rendering and Authenticated API Architecture
+
+## Background
+
+The merged text highlight work made the floating toolbar visible, persisted highlights through the backend, rendered normal stored ranges, and added toolbar actions for existing highlights. Main now has a usable baseline, but two larger follow-up areas remain.
+
+First, hierarchical Markdown list content can send highlight create requests and receive responses, but the rendered structure does not reliably show the persisted highlight. The current assistant message renderer parses each Markdown list line into a marker and text row, but it does not preserve nested list structure as first-class render metadata. Highlight spans are applied to visible text ranges, while indentation and markers are rendered separately.
+
+Second, authenticated API calls are not yet architecturally consistent. Text highlight calls now use `AuthenticatedApiClient`, but chat history, todo resources, asset table resources, LLM config, and parts of `ChatScreen` still manually fetch, cache, pass, or format auth tokens.
+
+## Goals
+
+- Make text highlights render reliably in hierarchical Markdown list items without losing structure, duplicating text, or depending on selected-text search.
+- Represent a logical highlight as one or more visible subsegments when the source range crosses rendered Markdown structures.
+- Add regression coverage for nested list highlighting, including persisted highlights after reload-like rendering.
+- Move authenticated mobile API calls toward a single `AuthenticatedApiClient` path so UI code no longer formats `Authorization` headers or passes token strings as business parameters.
+- Keep the two tracks staged so highlight rendering fixes can ship independently from the broader auth migration.
+
+## Implementation Plan
+
+1. Stabilize the highlight renderer for hierarchical lists.
+   - Add focused widget tests for nested unordered and ordered list content with stored highlight ranges.
+   - Verify whether failures come from source-offset mapping, list item rendering, or marker/text split boundaries.
+   - Extend the Markdown block/list metadata so rendered list text keeps source ranges, nesting level, marker identity, and visible text ranges.
+   - Apply highlight splitting against visible source-backed segments, allowing one persisted highlight to render as multiple subsegments when needed.
+   - Preserve current behavior for paragraphs, code blocks, tables, overlapping ranges, tapped highlight toolbar, and selection toolbar actions.
+
+2. Improve highlight selection normalization.
+   - Normalize selections that include list indentation or markers to a durable visible-text range when the selected text is inside a list item.
+   - Keep backend payload compatibility with `messageId`, `selectedText`, `startOffset`, `endOffset`, and `color`.
+   - Avoid creating duplicate visual text when new highlights overlap existing highlight records.
+
+3. Define the authenticated API migration boundary.
+   - Treat `AuthenticatedApiClient` as the only transport for logged-in REST APIs in the mobile app.
+   - Extend it only where needed for migrated services, such as additional HTTP verbs and JSON request helpers.
+   - Keep auth errors typed through `MissingAuthTokenException` and `UnauthorizedApiException`.
+
+4. Migrate authenticated API services in low-risk phases.
+   - First migrate resource services that are close to text highlights: todo lists and asset tables.
+   - Then migrate chat history calls, which have wider UI impact.
+   - Then migrate LLM config service away from repeated manual `AuthService.getToken()` calls.
+   - Finally remove UI-level token plumbing where services no longer require it.
+
+5. Update documentation and code maps.
+   - Update `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` if feature entry points, highlight logic, tests, or API architecture indexes change.
+   - Keep the highlight floating toolbar design note aligned if toolbar behavior changes.
+
+## Acceptance Criteria
+
+- A stored highlight inside a nested Markdown list item renders visibly at the correct text after widget rebuild.
+- Nested list indentation and markers remain visually correct while the highlighted text is rendered once.
+- A highlight range that overlaps list structure boundaries is normalized or split so visible list text is highlighted instead of silently disappearing.
+- Existing highlight tests for paragraphs, code blocks, tables, overlapping ranges, toolbar copy, and delete behavior continue to pass.
+- Migrated services no longer accept `required String token` or manually create `Authorization: Bearer ...` headers.
+- UI code does not block migrated API actions only because a cached `_authToken` field is null; missing auth is reported through the service error path.
+- Code maps identify the highlight renderer and authenticated API client as regression-sensitive areas.
+
+## Validation Commands
+
+- `./tools/init_dev_env.sh`
+- `cd apps/mobile_chat_app && flutter test test/message_list_test.dart test/highlight_selection_toolbar_web_test.dart test/text_highlight_api_service_test.dart`
+- `cd apps/mobile_chat_app && flutter test`
+- `npx js-yaml docs/code_maps/feature_map.yaml > /dev/null && npx js-yaml docs/code_maps/logic_map.yaml > /dev/null && echo "code maps yaml ok"`

--- a/docs/plans/2026-05-19-14-27-CST-tool-call-thinking-group.md
+++ b/docs/plans/2026-05-19-14-27-CST-tool-call-thinking-group.md
@@ -1,0 +1,33 @@
+# Tool Call Thinking Group
+
+## Background
+
+Tool call result messages can render large JSON payloads inline in the chat stream. Users need to know that the assistant is processing, but the raw tool type, arguments, and payload are diagnostic details rather than primary chat content.
+
+## Goals
+
+- Collapse adjacent tool call messages into one compact inline status object.
+- Use the user-facing labels `正在思考 completed/total` while the group is active and `思考过程 completed/total` when the group is complete.
+- Do not show tool names, tool types, arguments, or JSON payloads in the outer chat stream.
+- Keep non-adjacent tool groups separate.
+
+## Implementation Plan
+
+1. Identify agent-loop tool messages in `MessageList`, including tool start and tool result phases.
+2. Group only consecutive tool messages during message list rendering.
+3. Render a single status row for each group with completed and total counts.
+4. Keep reasoning and step-text agent-loop phases on their existing rendering path.
+5. Add widget tests for active/completed groups, adjacent merging, and non-adjacent separation.
+
+## Acceptance Criteria
+
+- A single in-progress tool displays `正在思考 0/1`.
+- A completed tool displays `思考过程 1/1`.
+- Adjacent completed tools display one row, for example `思考过程 2/2`.
+- Non-adjacent tool calls display separate rows.
+- Raw `Tool: ...` JSON content is not visible in the chat stream for grouped tool calls.
+
+## Validation Commands
+
+- `cd apps/mobile_chat_app && flutter test test/message_list_test.dart`
+- `cd apps/mobile_chat_app && flutter analyze`

--- a/docs/plans/2026-05-19-14-27-CST-tool-call-thinking-group.md
+++ b/docs/plans/2026-05-19-14-27-CST-tool-call-thinking-group.md
@@ -7,6 +7,7 @@ Tool call result messages can render large JSON payloads inline in the chat stre
 ## Goals
 
 - Collapse adjacent tool call messages into one compact inline status object.
+- Visually attach the assistant answer immediately after a tool group to that group by suppressing the repeated assistant header.
 - Use the user-facing labels `正在思考 completed/total` while the group is active and `思考过程 completed/total` when the group is complete.
 - Do not show tool names, tool types, arguments, or JSON payloads in the outer chat stream.
 - Keep non-adjacent tool groups separate.
@@ -16,8 +17,9 @@ Tool call result messages can render large JSON payloads inline in the chat stre
 1. Identify agent-loop tool messages in `MessageList`, including tool start and tool result phases.
 2. Group only consecutive tool messages during message list rendering.
 3. Render a single status row for each group with completed and total counts.
-4. Keep reasoning and step-text agent-loop phases on their existing rendering path.
-5. Add widget tests for active/completed groups, adjacent merging, and non-adjacent separation.
+4. When a plain assistant text message immediately follows a tool group, suppress its repeated agent header and let its metadata close the combined visual turn.
+5. Keep reasoning and step-text agent-loop phases on their existing rendering path.
+6. Add widget tests for active/completed groups, adjacent merging, non-adjacent separation, and header suppression after a tool group.
 
 ## Acceptance Criteria
 
@@ -25,6 +27,7 @@ Tool call result messages can render large JSON payloads inline in the chat stre
 - A completed tool displays `思考过程 1/1`.
 - Adjacent completed tools display one row, for example `思考过程 2/2`.
 - Non-adjacent tool calls display separate rows.
+- The assistant text immediately after a tool group does not show a duplicate assistant header.
 - Raw `Tool: ...` JSON content is not visible in the chat stream for grouped tool calls.
 
 ## Validation Commands


### PR DESCRIPTION
## Summary
- Preserve nested Markdown list indentation and add stored-range highlight coverage for nested list items.
- Move todo, asset table, chat history, and LLM config mobile services onto AuthenticatedApiClient.
- Remove token parameters and manual Authorization header formatting from migrated service APIs.
- Add implementation plan and update code maps for highlight and authenticated API regression areas.

## Validation
- cd apps/mobile_chat_app && PATH=/Users/admin/.local/tools/flutter/bin:/Users/admin/.local/bin:$PATH flutter analyze
- cd apps/mobile_chat_app && PATH=/Users/admin/.local/tools/flutter/bin:/Users/admin/.local/bin:$PATH flutter test
- npx js-yaml docs/code_maps/feature_map.yaml > /dev/null && npx js-yaml docs/code_maps/logic_map.yaml > /dev/null && echo "code maps yaml ok"

## Notes
- Flutter commands still print existing file_picker platform metadata warnings, but tests and analyze pass.