### PR TITLE
Show highlights in resources navigation

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/asset_table_api_service.dart
+++ b/apps/mobile_chat_app/lib/features/chat/asset_table_api_service.dart
@@ -98,17 +98,23 @@ class AssetTableSummary {
     required this.id,
     required this.resourceId,
     required this.title,
+    required this.createdAt,
+    required this.updatedAt,
   });
 
   final String id;
   final String resourceId;
   final String title;
+  final DateTime createdAt;
+  final DateTime updatedAt;
 
   factory AssetTableSummary.fromJson(Map<String, dynamic> json) {
     return AssetTableSummary(
       id: json['id'] as String,
       resourceId: json['resourceId'] as String,
       title: json['title'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
     );
   }
 }

--- a/apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
@@ -6,6 +6,9 @@ enum ChatNavigationAction { appSettings, sessions, createChannel, manageAgents }
 
 enum ChatChannelMenuAction { rename, archive }
 
+/// Type filter for the Resources tab.
+enum ChatResourceTypeFilter { all, todoList, assetTable, textHighlight }
+
 class ChatChannelItem {
   const ChatChannelItem({
     required this.id,
@@ -33,23 +36,71 @@ class ChatAgentItem {
 }
 
 /// Type of resource shown in the Resources tab.
-enum ChatResourceType { todoList, assetTable }
+enum ChatResourceType { todoList, assetTable, textHighlight }
 
-/// A resource item (todo-list or asset table) shown in the Resources tab.
+/// A resource item shown in the Resources tab.
 class ChatResourceItem {
   const ChatResourceItem({
     required this.id,
     required this.type,
     required this.title,
+    required this.updatedAt,
     this.notes,
   });
 
   final String id;
   final ChatResourceType type;
   final String title;
+  final DateTime updatedAt;
 
-  /// Optional subtitle – notes for a todo-list, or null for an asset table.
+  /// Optional subtitle shown under the resource title.
   final String? notes;
+}
+
+ChatResourceTypeFilter _filterForResourceType(ChatResourceType type) {
+  switch (type) {
+    case ChatResourceType.todoList:
+      return ChatResourceTypeFilter.todoList;
+    case ChatResourceType.assetTable:
+      return ChatResourceTypeFilter.assetTable;
+    case ChatResourceType.textHighlight:
+      return ChatResourceTypeFilter.textHighlight;
+  }
+}
+
+String _labelForResourceFilter(ChatResourceTypeFilter filter) {
+  switch (filter) {
+    case ChatResourceTypeFilter.all:
+      return 'All';
+    case ChatResourceTypeFilter.todoList:
+      return 'Todo Lists';
+    case ChatResourceTypeFilter.assetTable:
+      return 'Tables';
+    case ChatResourceTypeFilter.textHighlight:
+      return 'Highlights';
+  }
+}
+
+IconData _iconForResourceType(ChatResourceType type) {
+  switch (type) {
+    case ChatResourceType.todoList:
+      return Icons.checklist_outlined;
+    case ChatResourceType.assetTable:
+      return Icons.table_chart_outlined;
+    case ChatResourceType.textHighlight:
+      return Icons.format_color_text_outlined;
+  }
+}
+
+String _labelForResourceType(ChatResourceType type) {
+  switch (type) {
+    case ChatResourceType.todoList:
+      return 'Todo List';
+    case ChatResourceType.assetTable:
+      return 'Table';
+    case ChatResourceType.textHighlight:
+      return 'Text Highlight';
+  }
 }
 
 /// Represents a connected AI node shown in the Nodes tab.
@@ -138,6 +189,7 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
   static const double _closeSwipeVelocityThreshold = 300;
 
   late final TabController _tabController;
+  ChatResourceTypeFilter _resourceFilter = ChatResourceTypeFilter.all;
 
   @override
   void initState() {
@@ -234,6 +286,7 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
     final selected = channels.any((item) => item.id == widget.selectedChannelId)
         ? widget.selectedChannelId
         : (channels.isNotEmpty ? channels.first.id : null);
+    final resources = _filteredResources();
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -344,21 +397,22 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
                 // Resources tab
                 ListView(
                   children: [
-                    if (widget.resources.isEmpty)
+                    _ResourceTypeFilterBar(
+                      selected: _resourceFilter,
+                      onSelected: (filter) {
+                        setState(() => _resourceFilter = filter);
+                      },
+                    ),
+                    if (resources.isEmpty)
                       const ListTile(
                         title: Text('No resources'),
-                        subtitle:
-                            Text('Todo lists and tables will appear here'),
+                        subtitle: Text('Resources will appear here'),
                       )
                     else
-                      ...widget.resources.map((resource) {
+                      ...resources.map((resource) {
                         final notes = resource.notes?.trim();
                         return ListTile(
-                          leading: Icon(
-                            resource.type == ChatResourceType.todoList
-                                ? Icons.checklist_outlined
-                                : Icons.table_chart_outlined,
-                          ),
+                          leading: Icon(_iconForResourceType(resource.type)),
                           title: Text(resource.title),
                           subtitle: notes != null && notes.isNotEmpty
                               ? Text(
@@ -409,6 +463,48 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
               ],
             ),
           ),
+        ],
+      ),
+    );
+  }
+
+  List<ChatResourceItem> _filteredResources() {
+    final sorted = List<ChatResourceItem>.from(widget.resources)
+      ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+    if (_resourceFilter == ChatResourceTypeFilter.all) {
+      return sorted;
+    }
+    return sorted
+        .where((item) => _filterForResourceType(item.type) == _resourceFilter)
+        .toList(growable: false);
+  }
+}
+
+class _ResourceTypeFilterBar extends StatelessWidget {
+  const _ResourceTypeFilterBar({
+    required this.selected,
+    required this.onSelected,
+  });
+
+  final ChatResourceTypeFilter selected;
+  final ValueChanged<ChatResourceTypeFilter> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          for (final filter in ChatResourceTypeFilter.values)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: FilterChip(
+                label: Text(_labelForResourceFilter(filter)),
+                selected: selected == filter,
+                onSelected: (_) => onSelected(filter),
+              ),
+            ),
         ],
       ),
     );
@@ -477,7 +573,7 @@ class _NodeDetailPage extends StatelessWidget {
   }
 }
 
-/// Preview page for a resource item (todo-list or asset table).
+/// Preview page for a resource item.
 ///
 /// When the resource is a todo-list and [todoApiService] is provided, the page
 /// fetches the list's todo items and renders them with their status and
@@ -556,12 +652,8 @@ class _ResourcePreviewPageState extends State<_ResourcePreviewPage> {
         children: [
           // Type chip row
           ListTile(
-            leading: Icon(
-              isTodoList
-                  ? Icons.checklist_outlined
-                  : Icons.table_chart_outlined,
-            ),
-            title: Text(isTodoList ? 'Todo List' : 'Table'),
+            leading: Icon(_iconForResourceType(resource.type)),
+            title: Text(_labelForResourceType(resource.type)),
           ),
           if (notes != null && notes.isNotEmpty)
             ListTile(

--- a/apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
@@ -468,9 +468,25 @@ class _ChatNavigationPageState extends State<ChatNavigationPage>
     );
   }
 
+  int _compareResources(ChatResourceItem a, ChatResourceItem b) {
+    final updatedAtComparison = b.updatedAt.compareTo(a.updatedAt);
+    if (updatedAtComparison != 0) {
+      return updatedAtComparison;
+    }
+
+    final typeComparison = _filterForResourceType(a.type).index.compareTo(
+      _filterForResourceType(b.type).index,
+    );
+    if (typeComparison != 0) {
+      return typeComparison;
+    }
+
+    return a.id.compareTo(b.id);
+  }
+
   List<ChatResourceItem> _filteredResources() {
     final sorted = List<ChatResourceItem>.from(widget.resources)
-      ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+      ..sort(_compareResources);
     if (_resourceFilter == ChatResourceTypeFilter.all) {
       return sorted;
     }

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -100,6 +100,7 @@ class _ChatScreenState extends State<ChatScreen> {
   final TextHighlightApiService _highlightApiService =
       TextHighlightApiService();
   Map<String, List<HighlightSpan>> _highlights = const {};
+  List<TextHighlight> _textHighlights = const [];
   StreamSubscription<ChatHistorySnapshot>? _sseSubscription;
   static const Duration _sseReconnectDelay = Duration(seconds: 3);
   final Map<String, ChatRouter> _channelRouters = {};
@@ -1107,6 +1108,7 @@ class _ChatScreenState extends State<ChatScreen> {
       setState(() {
         _messages.clear();
         _highlights = const {};
+        _textHighlights = const [];
         _latestCheckpointCursor = null;
         _lastSyncedSeq = 0;
       });
@@ -1128,6 +1130,7 @@ class _ChatScreenState extends State<ChatScreen> {
       }
       setState(() {
         _highlights = updated;
+        _textHighlights = list;
       });
     } catch (e) {
       debugPrint('loadHighlights failed: $e');
@@ -1157,6 +1160,7 @@ class _ChatScreenState extends State<ChatScreen> {
             HighlightSpan.fromHighlight(created),
           ],
         };
+        _textHighlights = [..._textHighlights, created];
       });
     } catch (e) {
       debugPrint('createHighlight failed: $e');
@@ -1182,6 +1186,8 @@ class _ChatScreenState extends State<ChatScreen> {
             entry.key:
                 entry.value.where((h) => h.highlightId != highlightId).toList(),
         }..removeWhere((_, v) => v.isEmpty);
+        _textHighlights =
+            _textHighlights.where((h) => h.id != highlightId).toList();
       });
     } catch (e) {
       debugPrint('deleteHighlight failed: $e');
@@ -2277,6 +2283,14 @@ class _ChatScreenState extends State<ChatScreen> {
     );
   }
 
+  String _highlightResourceTitle(TextHighlight highlight) {
+    final normalized = highlight.selectedText.trim().replaceAll(
+          RegExp(r'\s+'),
+          ' ',
+        );
+    return normalized.isEmpty ? 'Untitled highlight' : normalized;
+  }
+
   Widget _buildNavigationContent({
     required ThemeData theme,
     required Color drawerBackgroundColor,
@@ -2318,6 +2332,7 @@ class _ChatScreenState extends State<ChatScreen> {
                 id: t.id,
                 type: ChatResourceType.todoList,
                 title: t.title,
+                updatedAt: t.updatedAt,
                 notes: t.notes,
               ),
             ),
@@ -2326,6 +2341,16 @@ class _ChatScreenState extends State<ChatScreen> {
                 id: t.resourceId,
                 type: ChatResourceType.assetTable,
                 title: t.title,
+                updatedAt: t.updatedAt,
+              ),
+            ),
+            ..._textHighlights.map(
+              (h) => ChatResourceItem(
+                id: h.id,
+                type: ChatResourceType.textHighlight,
+                title: _highlightResourceTitle(h),
+                updatedAt: h.createdAt,
+                notes: 'Highlighted text',
               ),
             ),
           ],

--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -2349,7 +2349,7 @@ class _ChatScreenState extends State<ChatScreen> {
                 id: h.id,
                 type: ChatResourceType.textHighlight,
                 title: _highlightResourceTitle(h),
-                updatedAt: h.createdAt,
+                updatedAt: h.updatedAt,
                 notes: 'Highlighted text',
               ),
             ),

--- a/apps/mobile_chat_app/lib/features/chat/text_highlight_api_service.dart
+++ b/apps/mobile_chat_app/lib/features/chat/text_highlight_api_service.dart
@@ -18,6 +18,7 @@ class TextHighlight {
     this.endOffset,
     required this.color,
     required this.createdAt,
+    required this.updatedAt,
   });
 
   final String id;
@@ -27,8 +28,10 @@ class TextHighlight {
   final int? endOffset;
   final String color;
   final DateTime createdAt;
+  final DateTime updatedAt;
 
   factory TextHighlight.fromJson(Map<String, dynamic> json) {
+    final createdAt = DateTime.parse(json['createdAt'] as String);
     return TextHighlight(
       id: json['id'] as String,
       messageId: json['messageId'] as String,
@@ -36,7 +39,10 @@ class TextHighlight {
       startOffset: (json['startOffset'] as num?)?.toInt(),
       endOffset: (json['endOffset'] as num?)?.toInt(),
       color: json['color'] as String? ?? 'yellow',
-      createdAt: DateTime.parse(json['createdAt'] as String),
+      createdAt: createdAt,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.parse(json['updatedAt'] as String)
+          : createdAt,
     );
   }
 }

--- a/apps/mobile_chat_app/test/chat_navigation_page_test.dart
+++ b/apps/mobile_chat_app/test/chat_navigation_page_test.dart
@@ -94,7 +94,8 @@ void main() {
       await tester.pumpWidget(_buildPage(onRequestClose: () => closeCount++));
       await tester.pumpAndSettle();
 
-      await tester.fling(find.byType(ChatNavigationPage), const Offset(-400, 0), 1000);
+      await tester.fling(
+          find.byType(ChatNavigationPage), const Offset(-400, 0), 1000);
       await tester.pumpAndSettle();
 
       expect(closeCount, 1);
@@ -171,7 +172,8 @@ void main() {
       expect(find.text('No nodes'), findsOneWidget);
     });
 
-    testWidgets('Nodes tab shows node list when nodes provided', (tester) async {
+    testWidgets('Nodes tab shows node list when nodes provided',
+        (tester) async {
       await tester.pumpWidget(_buildPage(
         nodes: const [
           ChatNodeItem(id: 'node_1', name: 'openclaw 1'),
@@ -215,9 +217,7 @@ void main() {
             agents: [
               ChatAgentItem(name: 'Planner', prompt: ''),
               ChatAgentItem(
-                  name: 'Reviewer',
-                  prompt: '',
-                  description: 'Custom reviewer'),
+                  name: 'Reviewer', prompt: '', description: 'Custom reviewer'),
             ],
           ),
         ],
@@ -246,20 +246,29 @@ void main() {
       expect(find.text('No resources'), findsOneWidget);
     });
 
-    testWidgets('Resources tab shows flat list of todo-lists and tables',
+    testWidgets('Resources tab shows atomic resources by updated time',
         (tester) async {
       await tester.pumpWidget(_buildPage(
-        resources: const [
+        resources: [
           ChatResourceItem(
             id: 'todo_1',
             type: ChatResourceType.todoList,
             title: 'My Todo List',
+            updatedAt: DateTime.utc(2026, 5, 19, 8),
             notes: 'Some notes',
           ),
           ChatResourceItem(
             id: 'table_1',
             type: ChatResourceType.assetTable,
             title: 'Asset Table',
+            updatedAt: DateTime.utc(2026, 5, 19, 9),
+          ),
+          ChatResourceItem(
+            id: 'highlight_1',
+            type: ChatResourceType.textHighlight,
+            title: 'Important highlighted text',
+            updatedAt: DateTime.utc(2026, 5, 19, 10),
+            notes: 'Highlighted text',
           ),
         ],
       ));
@@ -270,18 +279,62 @@ void main() {
 
       expect(find.text('My Todo List'), findsOneWidget);
       expect(find.text('Asset Table'), findsOneWidget);
+      expect(find.text('Important highlighted text'), findsOneWidget);
       expect(find.byIcon(Icons.checklist_outlined), findsOneWidget);
       expect(find.byIcon(Icons.table_chart_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.format_color_text_outlined), findsOneWidget);
+
+      final highlightTop = tester.getTopLeft(
+        find.widgetWithText(ListTile, 'Important highlighted text'),
+      );
+      final tableTop = tester.getTopLeft(
+        find.widgetWithText(ListTile, 'Asset Table'),
+      );
+      final todoTop = tester.getTopLeft(
+        find.widgetWithText(ListTile, 'My Todo List'),
+      );
+      expect(highlightTop.dy, lessThan(tableTop.dy));
+      expect(tableTop.dy, lessThan(todoTop.dy));
+    });
+
+    testWidgets('Resources tab can filter by highlight type', (tester) async {
+      await tester.pumpWidget(_buildPage(
+        resources: [
+          ChatResourceItem(
+            id: 'todo_1',
+            type: ChatResourceType.todoList,
+            title: 'My Todo List',
+            updatedAt: DateTime.utc(2026, 5, 19, 8),
+          ),
+          ChatResourceItem(
+            id: 'highlight_1',
+            type: ChatResourceType.textHighlight,
+            title: 'Important highlighted text',
+            updatedAt: DateTime.utc(2026, 5, 19, 10),
+          ),
+        ],
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Resources'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Highlights'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Important highlighted text'), findsOneWidget);
+      expect(find.text('My Todo List'), findsNothing);
     });
 
     testWidgets('tapping resource item opens resource preview page',
         (tester) async {
       await tester.pumpWidget(_buildPage(
-        resources: const [
+        resources: [
           ChatResourceItem(
             id: 'todo_1',
             type: ChatResourceType.todoList,
             title: 'My Todo List',
+            updatedAt: DateTime.utc(2026, 5, 19, 8),
             notes: 'A note',
           ),
         ],
@@ -297,6 +350,31 @@ void main() {
       // Preview page opens with the resource title in AppBar and type info
       expect(find.text('Todo List'), findsOneWidget);
       expect(find.text('A note'), findsOneWidget);
+    });
+
+    testWidgets('tapping highlight item opens text highlight preview page',
+        (tester) async {
+      await tester.pumpWidget(_buildPage(
+        resources: [
+          ChatResourceItem(
+            id: 'highlight_1',
+            type: ChatResourceType.textHighlight,
+            title: 'Important highlighted text',
+            updatedAt: DateTime.utc(2026, 5, 19, 10),
+            notes: 'Highlighted text',
+          ),
+        ],
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Resources'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Important highlighted text'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Text Highlight'), findsOneWidget);
+      expect(find.text('Highlighted text'), findsOneWidget);
     });
 
     testWidgets('tapping 新建频道 fires createChannel action', (tester) async {

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -175,9 +175,13 @@ products:
             route_hint: apps/mobile_chat_app/lib/features/skills/skills_screen.dart
           - screen: ResourcesScreen
             route_hint: apps/mobile_chat_app/lib/features/resources/resources_screen.dart
+          - widget: ChatNavigationPage Resources tab
+            route_hint: apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
         smoke_checks:
           - 从侧边导航进入每个页面。
           - 页面可正常渲染且无崩溃。
+          - Chat navigation 的 Resources tab 将 todo lists、asset tables、text highlights 作为原子资源按更新时间倒序显示。
+          - Resources tab 顶部 type filter 可按资源类型过滤列表。
 
       - feature_id: conversational_todos
         name: 对话式待办列表与待办事项
@@ -246,6 +250,8 @@ products:
             route_hint: docs/design/text-highlight-floating-toolbar.design.md
           - service: TextHighlightApiService
             route_hint: apps/mobile_chat_app/lib/features/chat/text_highlight_api_service.dart
+          - widget: ChatNavigationPage Resources tab highlight item
+            route_hint: apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
           - service: AuthenticatedApiClient
             route_hint: apps/mobile_chat_app/lib/services/authenticated_api_client.dart
           - route: GET /api/resources/highlights
@@ -268,6 +274,7 @@ products:
           - 点击已有黄色划线区域时，应显示同款浮动工具栏，包含"复制"和"删除划线"。
           - 新划线与旧划线重叠、覆盖或相邻时，渲染应表现为区间并集，不应重复显示文字。
           - 刷新页面后，高亮仍然显示。
+          - Resources tab 选择 Highlights 过滤器后，只显示已保存的划线资源，点击后打开 Text Highlight 预览。
           - 用户说"我有哪些划线"，AI 调用 highlight_list 工具并列出已保存的文本。
 
   - product_id: node_backend

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -351,10 +351,12 @@ index:
       - apps/mobile_chat_app/lib/features/projects/projects_screen.dart
       - apps/mobile_chat_app/lib/features/skills/skills_screen.dart
       - apps/mobile_chat_app/lib/features/resources/resources_screen.dart
+      - apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
     doc_index:
       - docs/product/overview.md
       - docs/faq/common-issues.md
       - docs/architecture.md
+      - docs/plans/2026-05-19-17-06-CST-navigation-resources-highlights.md
     test_index:
       - apps/mobile_chat_app/test/app_test.dart
       - apps/mobile_chat_app/test/chat_navigation_page_test.dart
@@ -364,9 +366,15 @@ index:
       - skills
       - resources
       - navigation
+      - resources tab
+      - type filter
+      - updatedAt descending
+      - atomic resources
     change_risks:
       - 侧边栏入口迁移后页面不可达。
       - 页面间返回路径断裂造成死路由。
+      - Resources tab 若按类型分组拼接而不是统一按 updatedAt 排序，会破坏跨资源时间线浏览。
+      - 新资源类型必须提供稳定 updatedAt，否则倒序排序会不确定。
 
   - feature_id: backend_auth
     capability: 后端 GitHub OAuth 认证
@@ -618,6 +626,8 @@ index:
       - apps/node_backend/src/routes/resources.ts
       - apps/mobile_chat_app/lib/services/authenticated_api_client.dart
       - apps/mobile_chat_app/lib/features/chat/text_highlight_api_service.dart
+      - apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+      - apps/mobile_chat_app/lib/features/chat/chat_navigation_page.dart
       - apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
     doc_index:
       - docs/plans/2026-05-16-02-20-+00-todos-tables-highlights-tools.md
@@ -625,11 +635,13 @@ index:
       - docs/plans/2026-05-19-10-50-+08-unified-authenticated-api-client.md
       - docs/plans/2026-05-19-11-55-+08-highlight-toolbar-union-ranges.md
       - docs/plans/2026-05-19-13-02-CST-highlight-list-and-auth-api-architecture.md
+      - docs/plans/2026-05-19-17-06-CST-navigation-resources-highlights.md
       - docs/design/text-highlight-floating-toolbar.design.md
     test_index:
       - apps/mobile_chat_app/test/message_list_test.dart
       - apps/mobile_chat_app/test/highlight_selection_toolbar_web_test.dart
       - apps/mobile_chat_app/test/text_highlight_api_service_test.dart
+      - apps/mobile_chat_app/test/chat_navigation_page_test.dart
       - apps/node_backend/src/routes/resources.test.ts
       - apps/node_backend/src/services/localAgentLoopService.test.ts
     keywords:
@@ -652,6 +664,9 @@ index:
       - _AssistantMarkdownText
       - authenticated API client
       - Authorization header
+      - Resources tab highlight item
+      - text highlight resource
+      - type filter
     change_risks:
       - Flutter Web 鼠标拖选依赖外层 list-level SelectionArea 弹出工具栏；将 SelectionArea 下放到单条消息会导致 Chrome 选择文本后不显示浮动工具条。
       - 浮动工具栏按钮若依赖 TextButton.onPressed，点击时 SelectionArea 可能先清除选区并销毁按钮，导致复制/划线 action 不触发；应保持 pointer-down 即时触发。
@@ -663,6 +678,7 @@ index:
       - 表格单元格或重复文本若使用文本搜索而不是 stored startOffset/endOffset，会导致划线显示或删除到错误位置。
       - Flutter Web 上 TextSpan TapGestureRecognizer 会干扰 SelectionArea 拖拽选择；web 删除路径应继续通过选择工具栏实现。
       - 旧数据若缺少 startOffset/endOffset，仍会回退为 selectedText 搜索；重复文本场景下旧记录可能显示多处，需要后续数据迁移或重新创建高亮才能完全消除歧义。
+      - ChatScreen 必须在 highlight 创建、加载、删除后同步 _textHighlights，否则 Resources tab 可能显示过期划线资源。
 
 maintenance_rules:
   update_required_when:

--- a/docs/plans/2026-05-19-17-06-CST-navigation-resources-highlights.md
+++ b/docs/plans/2026-05-19-17-06-CST-navigation-resources-highlights.md
@@ -1,0 +1,35 @@
+# Navigation Resources Highlights
+
+## Background
+
+The chat navigation drawer has a Resources tab that currently lists todo lists and asset tables. Text highlights are persisted through `/api/resources/highlights` and rendered in assistant messages, but they are not visible from the Resources navigation surface.
+
+## Goals
+
+- Show saved text highlights in the chat navigation Resources tab alongside other atomic resources.
+- Sort Resources tab items by update time descending across all resource types.
+- Add a type filter at the top of the Resources tab.
+- Preserve the existing todo-list and asset-table resource behavior.
+- Update code maps because the change affects a user-visible navigation entry point and highlight resource behavior.
+
+## Implementation Plan
+
+1. Extend the chat navigation resource model with a text-highlight resource type and an `updatedAt` sort key.
+2. Update the Resources tab to sort atomic resources by update time descending and expose type filter chips.
+3. Feed loaded highlights from `ChatScreen` into the navigation resources collection.
+4. Add or update widget tests covering highlight resources, sorting, filtering, and preview behavior.
+5. Update `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml`.
+
+## Acceptance Criteria
+
+- Saved highlights appear in the Resources tab after highlights are loaded.
+- Resources are not grouped by type; all resource items are shown as atomic rows sorted by newest update time first.
+- The Resources tab has a top filter that can narrow the list by resource type.
+- Highlight resources use a distinct highlight icon and show the highlighted text as the resource title.
+- Tapping a highlight resource opens a preview page identifying it as a text highlight.
+- Existing todo-list and asset-table resources still render with their current labels and icons.
+
+## Validation Commands
+
+- `cd apps/mobile_chat_app && flutter test test/chat_navigation_page_test.dart`
+- `npx js-yaml docs/code_maps/feature_map.yaml > /dev/null && npx js-yaml docs/code_maps/logic_map.yaml > /dev/null && echo "code maps yaml ok"`


### PR DESCRIPTION
## Summary
- show text highlights as atomic resources in the chat navigation Resources tab
- sort todo lists, asset tables, and highlights together by updated time descending
- add Resources tab type filters for all, todo lists, tables, and highlights
- update navigation tests, implementation plan, and code maps

## Validation
- cd apps/mobile_chat_app && flutter test test/chat_navigation_page_test.dart
- cd apps/mobile_chat_app && flutter analyze
- npx js-yaml docs/code_maps/feature_map.yaml > /dev/null && npx js-yaml docs/code_maps/logic_map.yaml > /dev/null && echo "code maps yaml ok"

Note: Flutter commands still print the existing file_picker 6.2.1 desktop default plugin warning, but tests and analyze pass.