### PR TITLE
Clarify main thread menu label

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -1590,7 +1590,7 @@ class _ChatScreenState extends State<ChatScreen> {
       items.add(
         const PopupMenuItem<String>(
           value: 'main',
-          child: Text('Back to Thread'),
+          child: Text('Back to Main Thread'),
         ),
       );
     }


### PR DESCRIPTION
## Summary
- Rename the subsection menu action from "Back to Thread" to "Back to Main Thread" to match its existing behavior of selecting the main thread.

## Validation
- PATH=/Users/admin/.local/tools/flutter/bin:/Users/admin/.codex/tmp/arg0/codex-arg0YRgAIV:/Users/admin/.local/bin:/Users/admin/.local/bin:/Users/admin/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/admin/.cargo/bin:/Applications/Ghostty.app/Contents/MacOS:/Users/admin/.lmstudio/bin flutter test test/chat_navigation_page_test.dart