### PR TITLE
[codex] Show README showcase screenshots side by side

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,9 @@ Bricks keeps useful information available after the chat moves on.
 
 ## Showcase
 
-### Topic-based agent work
-
-![Bricks channel and thread workspace](docs/assets/showcase/chat-knowledge-organization.png)
-
-### Saved highlights and notes
-
-![Bricks resources for highlights and notes](docs/assets/showcase/resources-highlights.png)
+| Topic-based agent work | Saved highlights and notes |
+| --- | --- |
+| ![Bricks channel and thread workspace](docs/assets/showcase/chat-knowledge-organization.png) | ![Bricks resources for highlights and notes](docs/assets/showcase/resources-highlights.png) |
 
 ## What's on the roadmap
 

--- a/docs/tasks/done/2026-06-22-22-57-CST-readme-showcase-two-column.md
+++ b/docs/tasks/done/2026-06-22-22-57-CST-readme-showcase-two-column.md
@@ -1,0 +1,25 @@
+# README Showcase Two-Column Layout
+
+## Background
+
+The README Showcase section displayed two screenshots as stacked subsections.
+
+## Goals
+
+- Show the two showcase screenshots in one row with two columns.
+- Keep the screenshot labels and alt text readable in GitHub Markdown.
+
+## Implementation Plan
+
+1. Replace the stacked screenshot subsections with a two-column Markdown table.
+2. Keep the existing screenshot asset paths unchanged.
+
+## Acceptance Criteria
+
+- The README Showcase section renders both screenshots in one table row.
+- The two columns retain meaningful labels.
+- No app behavior changes are made.
+
+## Validation Commands
+
+- `sed -n '20,42p' README.md`


### PR DESCRIPTION
## Summary

- Replaced the stacked README Showcase screenshots with a two-column Markdown table.
- Added the completed task lifecycle note for this docs-only update.

## Validation

- Reviewed `README.md` around the Showcase section with `sed -n '20,42p' README.md`.

## Code Maps

Not updated because this is a README presentation-only change with no functional entry, business logic, test index, or documentation-index behavior change.