### PR TITLE
Fix media upload previews and Gemini image input

### DIFF
--- a/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
+++ b/apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -53,6 +53,8 @@ class _ChatScreenState extends State<ChatScreen> {
   bool _isSending = false;
   bool _isStreaming = false;
   bool _isUploadingAttachment = false;
+  int _imageUploadGeneration = 0;
+  ComposerDraftUpload? _draftUpload;
   final List<ChatMediaAttachment> _pendingMediaAttachments = [];
   bool _loadingAgents = true;
   bool _loadingLlmConfigs = true;
@@ -2511,18 +2513,24 @@ class _ChatScreenState extends State<ChatScreen> {
           result == null || result.files.isEmpty ? null : result.files.first;
       final bytes = file?.bytes;
       if (file == null || bytes == null || bytes.isEmpty) return;
-      setState(() => _isUploadingAttachment = true);
-      final attachment = await _chatHistoryApiService.uploadImage(
-        scope: _activeScope,
-        filename: file.name,
-        mimeType: _mimeTypeForPickedFile(file),
-        dataBase64: base64Encode(bytes),
-      );
-      if (!mounted) return;
+      final mimeType = _mimeTypeForPickedFile(file);
+      final dataBase64 = base64Encode(bytes);
+      final generation = ++_imageUploadGeneration;
       setState(() {
-        _pendingMediaAttachments.add(attachment);
-        _isUploadingAttachment = false;
+        _isUploadingAttachment = true;
+        _draftUpload = ComposerDraftUpload(
+          filename: file.name,
+          mimeType: mimeType,
+          dataBase64: dataBase64,
+          isUploading: true,
+        );
       });
+      await _uploadDraftImage(
+        filename: file.name,
+        mimeType: mimeType,
+        dataBase64: dataBase64,
+        generation: generation,
+      );
     } catch (error) {
       if (!mounted) return;
       setState(() => _isUploadingAttachment = false);
@@ -2530,6 +2538,74 @@ class _ChatScreenState extends State<ChatScreen> {
         SnackBar(content: Text('Image upload failed: $error')),
       );
     }
+  }
+
+  Future<void> _uploadDraftImage({
+    required String filename,
+    required String mimeType,
+    required String dataBase64,
+    required int generation,
+  }) async {
+    try {
+      final attachment = await _chatHistoryApiService.uploadImage(
+        scope: _activeScope,
+        filename: filename,
+        mimeType: mimeType,
+        dataBase64: dataBase64,
+      );
+      if (!mounted || generation != _imageUploadGeneration) return;
+      setState(() {
+        _pendingMediaAttachments.add(attachment);
+        _draftUpload = null;
+        _isUploadingAttachment = false;
+      });
+    } catch (error) {
+      if (!mounted || generation != _imageUploadGeneration) return;
+      setState(() {
+        _draftUpload = ComposerDraftUpload(
+          filename: filename,
+          mimeType: mimeType,
+          dataBase64: dataBase64,
+          isUploading: false,
+          errorText: error.toString(),
+        );
+        _isUploadingAttachment = false;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Image upload failed: $error')),
+      );
+    }
+  }
+
+  void _retryDraftImageUpload() {
+    final draft = _draftUpload;
+    if (draft == null || draft.isUploading || _isSending) return;
+    final generation = ++_imageUploadGeneration;
+    setState(() {
+      _isUploadingAttachment = true;
+      _draftUpload = ComposerDraftUpload(
+        filename: draft.filename,
+        mimeType: draft.mimeType,
+        dataBase64: draft.dataBase64,
+        isUploading: true,
+      );
+    });
+    unawaited(
+      _uploadDraftImage(
+        filename: draft.filename,
+        mimeType: draft.mimeType,
+        dataBase64: draft.dataBase64,
+        generation: generation,
+      ),
+    );
+  }
+
+  void _cancelDraftImageUpload() {
+    _imageUploadGeneration++;
+    setState(() {
+      _draftUpload = null;
+      _isUploadingAttachment = false;
+    });
   }
 
   void _removePendingAttachment(String mediaId) {
@@ -2608,6 +2684,7 @@ class _ChatScreenState extends State<ChatScreen> {
       _isSending = true;
       _isStreaming = false;
       _pendingMediaAttachments.clear();
+      _draftUpload = null;
     });
 
     final runtimeSettings = _settingsForAgent(agent);
@@ -3249,8 +3326,11 @@ class _ChatScreenState extends State<ChatScreen> {
               onSend: _isSending ? null : _sendMessage,
               onAttachImage:
                   _isUploadingAttachment ? null : _attachImageToDraft,
+              onCancelDraftUpload: _cancelDraftImageUpload,
+              onRetryDraftUpload: _retryDraftImageUpload,
               onRemoveAttachment: _removePendingAttachment,
               attachments: _pendingMediaAttachments,
+              draftUpload: _draftUpload,
               onStop: _stopStreaming,
               isStreaming: _isStreaming,
             );

--- a/apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
@@ -1,7 +1,11 @@
+import 'dart:convert';
+
 import 'package:chat_domain/chat_domain.dart';
 import 'package:design_system/design_system.dart';
 import 'package:flutter/material.dart';
 
+import '../../auth/auth_service.dart';
+import '../../settings/llm_config_service.dart';
 import '../chat_message.dart';
 
 /// Actions available in the composer popup menu.
@@ -21,6 +25,24 @@ class ComposerAtAction {
   final String? insertText;
 }
 
+class ComposerDraftUpload {
+  const ComposerDraftUpload({
+    required this.filename,
+    required this.mimeType,
+    required this.dataBase64,
+    required this.isUploading,
+    this.errorText,
+  });
+
+  final String filename;
+  final String mimeType;
+  final String dataBase64;
+  final bool isUploading;
+  final String? errorText;
+
+  bool get hasError => errorText != null && errorText!.trim().isNotEmpty;
+}
+
 /// The input composer bar at the bottom of the chat screen.
 class ComposerBar extends StatefulWidget {
   const ComposerBar({
@@ -33,8 +55,11 @@ class ComposerBar extends StatefulWidget {
     this.slashCommands = const [],
     this.atActions = const [],
     this.attachments = const [],
+    this.draftUpload,
     this.onSend,
     this.onAttachImage,
+    this.onCancelDraftUpload,
+    this.onRetryDraftUpload,
     this.onRemoveAttachment,
     this.onAgentSelected,
     this.onAtActionSelected,
@@ -53,8 +78,11 @@ class ComposerBar extends StatefulWidget {
   final List<String> slashCommands;
   final List<ComposerAtAction> atActions;
   final List<ChatMediaAttachment> attachments;
+  final ComposerDraftUpload? draftUpload;
   final void Function(String text)? onSend;
   final VoidCallback? onAttachImage;
+  final VoidCallback? onCancelDraftUpload;
+  final VoidCallback? onRetryDraftUpload;
   final void Function(String mediaId)? onRemoveAttachment;
 
   @Deprecated(
@@ -93,8 +121,9 @@ class _ComposerBarState extends State<ComposerBar>
   }
 
   void _onDraftChanged() {
-    final nextHasDraft =
-        _controller.text.trim().isNotEmpty || widget.attachments.isNotEmpty;
+    final nextHasDraft = _controller.text.trim().isNotEmpty ||
+        widget.attachments.isNotEmpty ||
+        widget.draftUpload != null;
     if (_hasDraft == nextHasDraft) return;
     setState(() => _hasDraft = nextHasDraft);
   }
@@ -102,14 +131,17 @@ class _ComposerBarState extends State<ComposerBar>
   @override
   void didUpdateWidget(covariant ComposerBar oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.attachments.length != widget.attachments.length) {
+    if (oldWidget.attachments.length != widget.attachments.length ||
+        oldWidget.draftUpload != widget.draftUpload) {
       _onDraftChanged();
     }
   }
 
   void _submit() {
     final text = _controller.text.trim();
-    if ((text.isEmpty && widget.attachments.isEmpty) || widget.onSend == null) {
+    if ((text.isEmpty && widget.attachments.isEmpty) ||
+        widget.draftUpload != null ||
+        widget.onSend == null) {
       return;
     }
     widget.onSend!(text);
@@ -157,6 +189,7 @@ class _ComposerBarState extends State<ComposerBar>
   @override
   Widget build(BuildContext context) {
     final isSending = widget.onSend == null;
+    final hasDraftUpload = widget.draftUpload != null;
     final chatColors =
         Theme.of(context).extension<ChatColors>() ?? ChatColors.light;
 
@@ -178,7 +211,8 @@ class _ComposerBarState extends State<ComposerBar>
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  if (widget.attachments.isNotEmpty)
+                  if (widget.attachments.isNotEmpty ||
+                      widget.draftUpload != null)
                     Padding(
                       padding: const EdgeInsets.fromLTRB(
                         BricksSpacing.sm,
@@ -190,11 +224,21 @@ class _ComposerBarState extends State<ComposerBar>
                         height: 72,
                         child: ListView.separated(
                           scrollDirection: Axis.horizontal,
-                          itemCount: widget.attachments.length,
+                          itemCount: widget.attachments.length +
+                              (widget.draftUpload == null ? 0 : 1),
                           separatorBuilder: (_, __) =>
                               const SizedBox(width: BricksSpacing.xs),
                           itemBuilder: (context, index) {
-                            final attachment = widget.attachments[index];
+                            final draftUpload = widget.draftUpload;
+                            if (draftUpload != null && index == 0) {
+                              return _DraftUploadTile(
+                                upload: draftUpload,
+                                onCancel: widget.onCancelDraftUpload,
+                                onRetry: widget.onRetryDraftUpload,
+                              );
+                            }
+                            final attachment = widget.attachments[
+                                index - (draftUpload == null ? 0 : 1)];
                             return _PendingAttachmentTile(
                               attachment: attachment,
                               onRemove: widget.onRemoveAttachment == null
@@ -248,9 +292,10 @@ class _ComposerBarState extends State<ComposerBar>
                         ],
                         IconButton(
                           tooltip: 'Attach image',
-                          onPressed: isSending || widget.isStreaming
-                              ? null
-                              : widget.onAttachImage,
+                          onPressed:
+                              isSending || widget.isStreaming || hasDraftUpload
+                                  ? null
+                                  : widget.onAttachImage,
                           icon: Icon(
                             Icons.image_outlined,
                             color: chatColors.composerActionIdle,
@@ -406,7 +451,8 @@ class _ComposerBarState extends State<ComposerBar>
                           )
                         else
                           IconButton(
-                            onPressed: isSending ? null : _submit,
+                            onPressed:
+                                isSending || hasDraftUpload ? null : _submit,
                             icon: isSending
                                 ? const SizedBox(
                                     width: 20,
@@ -417,7 +463,7 @@ class _ComposerBarState extends State<ComposerBar>
                                   )
                                 : Icon(
                                     Icons.send,
-                                    color: _hasDraft
+                                    color: _hasDraft && !hasDraftUpload
                                         ? chatColors.sendActive
                                         : chatColors.sendIdle,
                                   ),
@@ -457,9 +503,12 @@ class _PendingAttachmentTile extends StatelessWidget {
           Positioned.fill(
             child: ClipRRect(
               borderRadius: BorderRadius.circular(BricksRadius.sm),
-              child: Container(
-                color: chatColors.composerBackground,
-                child: const Icon(Icons.image, size: 28),
+              child: _AuthenticatedAttachmentPreview(
+                previewUrl: attachment.previewUrl,
+                fallback: Container(
+                  color: chatColors.composerBackground,
+                  child: const Icon(Icons.image, size: 28),
+                ),
               ),
             ),
           ),
@@ -477,6 +526,131 @@ class _PendingAttachmentTile extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _DraftUploadTile extends StatelessWidget {
+  const _DraftUploadTile({
+    required this.upload,
+    this.onCancel,
+    this.onRetry,
+  });
+
+  final ComposerDraftUpload upload;
+  final VoidCallback? onCancel;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final chatColors =
+        Theme.of(context).extension<ChatColors>() ?? ChatColors.light;
+    final imageBytes = base64Decode(upload.dataBase64);
+    return SizedBox(
+      width: 72,
+      height: 72,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(BricksRadius.sm),
+              child: Image.memory(
+                imageBytes,
+                fit: BoxFit.cover,
+                errorBuilder: (context, _, __) => Container(
+                  color: chatColors.composerBackground,
+                  child: const Icon(Icons.broken_image_outlined, size: 28),
+                ),
+              ),
+            ),
+          ),
+          Positioned.fill(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: Colors.black
+                    .withValues(alpha: upload.hasError ? 0.34 : 0.22),
+                borderRadius: BorderRadius.circular(BricksRadius.sm),
+              ),
+              child: Center(
+                child: upload.hasError
+                    ? IconButton.filledTonal(
+                        tooltip: 'Retry upload',
+                        iconSize: 18,
+                        constraints: const BoxConstraints.tightFor(
+                            width: 36, height: 36),
+                        onPressed: onRetry,
+                        icon: const Icon(Icons.refresh),
+                      )
+                    : const SizedBox(
+                        width: 22,
+                        height: 22,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white,
+                        ),
+                      ),
+              ),
+            ),
+          ),
+          Positioned(
+            right: 2,
+            top: 2,
+            child: IconButton.filled(
+              tooltip: 'Remove image',
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints.tightFor(width: 24, height: 24),
+              iconSize: 14,
+              onPressed: onCancel,
+              icon: const Icon(Icons.close),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AuthenticatedAttachmentPreview extends StatelessWidget {
+  const _AuthenticatedAttachmentPreview({
+    required this.previewUrl,
+    required this.fallback,
+  });
+
+  final String previewUrl;
+  final Widget fallback;
+
+  Uri _mediaUri(String value) {
+    final parsed = Uri.tryParse(value);
+    if (parsed != null && parsed.hasScheme) return parsed;
+    return Uri.parse('${LlmConfigService.resolveBaseUrl()}$value');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<String?>(
+      future: AuthService.getToken(),
+      builder: (context, snapshot) {
+        final token = snapshot.data;
+        final headers = token == null || token.isEmpty
+            ? null
+            : {'Authorization': 'Bearer $token'};
+        return Image.network(
+          _mediaUri(previewUrl).toString(),
+          headers: headers,
+          fit: BoxFit.cover,
+          errorBuilder: (context, _, __) => fallback,
+          loadingBuilder: (context, child, progress) {
+            if (progress == null) return child;
+            return const Center(
+              child: SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            );
+          },
+        );
+      },
     );
   }
 }

--- a/apps/node_backend/src/llm/llm_service.ts
+++ b/apps/node_backend/src/llm/llm_service.ts
@@ -136,6 +136,13 @@ function resolveModel(
   return { model: adapter.createModel(modelId, runtimeConfig), modelId };
 }
 
+function toAiSdkMessages(request: UnifiedChatRequest) {
+  return request.messages.map((m) => ({
+    role: m.role,
+    content: m.content,
+  }));
+}
+
 export async function generateWithUserConfig(
   userId: string,
   request: UnifiedChatRequest,
@@ -150,10 +157,8 @@ export async function generateWithUserConfig(
 
   const result = await generateText({
     model,
-    messages: request.messages.map((m) => ({
-      role: m.role,
-      content: m.content,
-    })),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    messages: toAiSdkMessages(request) as any,
     temperature: request.temperature,
     maxOutputTokens: request.maxTokens ?? 1024,
   });
@@ -183,10 +188,8 @@ export async function streamWithUserConfig(
 
   const result = streamText({
     model,
-    messages: request.messages.map((m) => ({
-      role: m.role,
-      content: m.content,
-    })),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    messages: toAiSdkMessages(request) as any,
     temperature: request.temperature,
     maxOutputTokens: request.maxTokens ?? 1024,
   });
@@ -537,10 +540,8 @@ export async function streamWithAgentToolsAndUserConfig(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     stopWhen: stopConditions as any,
     abortSignal: abortController.signal,
-    messages: request.messages.map((m) => ({
-      role: m.role,
-      content: m.content,
-    })),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    messages: toAiSdkMessages(request) as any,
     temperature: request.temperature,
     maxOutputTokens: request.maxTokens ?? 1024,
     // The onStepFinish callback shape changed in AI SDK v6; cast the event to

--- a/apps/node_backend/src/llm/types.ts
+++ b/apps/node_backend/src/llm/types.ts
@@ -4,8 +4,14 @@ export type LlmProvider = 'anthropic' | 'google_ai_studio';
 
 export interface UnifiedMessage {
   role: 'system' | 'user' | 'assistant';
-  content: string;
+  content: UnifiedMessageContent;
 }
+
+export type UnifiedMessageContent = string | UnifiedMessagePart[];
+
+export type UnifiedMessagePart =
+  | { type: 'text'; text: string }
+  | { type: 'image'; image: Uint8Array; mediaType: string };
 
 export interface UnifiedChatRequest {
   model?: string;

--- a/apps/node_backend/src/routes/chat.test.ts
+++ b/apps/node_backend/src/routes/chat.test.ts
@@ -33,6 +33,8 @@ const {
   listPlatformNodesMock,
   listMediaAssetsForUserMock,
   mediaAssetToDtoMock,
+  resolveMediaAssetPathMock,
+  readFileMock,
 } = vi.hoisted(() => ({
   acceptTaskMock: vi.fn(async () => ({
     taskId: "task-1",
@@ -139,6 +141,12 @@ const {
     downloadUrl: `/api/media/${asset.id}/download`,
     channelRelativePath: asset.channelRelativePath,
   })),
+  resolveMediaAssetPathMock: vi.fn(async () => "/tmp/bricks-test-image.jpg"),
+  readFileMock: vi.fn(async () => Buffer.from("fake-image")),
+}));
+
+vi.mock("fs/promises", () => ({
+  readFile: readFileMock,
 }));
 
 vi.mock("../services/chatAsyncTransportService.js", () => ({
@@ -189,6 +197,7 @@ vi.mock('../services/localAgentLoopService.js', () => ({
 vi.mock("../services/mediaService.js", () => ({
   listMediaAssetsForUser: listMediaAssetsForUserMock,
   mediaAssetToDto: mediaAssetToDtoMock,
+  resolveMediaAssetPath: resolveMediaAssetPathMock,
 }));
 
 vi.mock("../llm/llm_service.js", () => ({
@@ -280,6 +289,13 @@ describe("chat routes", () => {
     });
     streamWithAgentToolsAndUserConfigMock.mockClear();
     buildAgentToolsMock.mockClear();
+    listMediaAssetsForUserMock.mockReset();
+    listMediaAssetsForUserMock.mockResolvedValue([]);
+    mediaAssetToDtoMock.mockClear();
+    resolveMediaAssetPathMock.mockReset();
+    resolveMediaAssetPathMock.mockResolvedValue("/tmp/bricks-test-image.jpg");
+    readFileMock.mockReset();
+    readFileMock.mockResolvedValue(Buffer.from("fake-image"));
     getPlatformNodeByNodeIdMock.mockReset();
     getPlatformNodeByNodeIdMock.mockImplementation(
       async (_userId: string, nodeId: string) => ({
@@ -480,6 +496,88 @@ describe("chat routes", () => {
         content: "sync reply",
       }),
     ]);
+  });
+
+  it("passes uploaded image attachments to Gemini as multimodal parts", async () => {
+    resolveChatScopeRoutingMock.mockResolvedValueOnce({
+      router: "local",
+      nodeId: null,
+    });
+    listSessionMessagesForModelMock.mockResolvedValueOnce([
+      { role: "user", content: "What is in this image?" },
+    ] as any);
+    listMediaAssetsForUserMock.mockResolvedValueOnce([
+      {
+        id: "media-1",
+        userId: "user-123",
+        channelId: "default",
+        threadId: null,
+        kind: "image",
+        origin: "user_upload",
+        status: "ready",
+        mimeType: "image/jpeg",
+        filename: "photo.jpg",
+        channelRelativePath: "media/uploads/media-1.jpg",
+        thumbnailChannelRelativePath: null,
+        sizeBytes: 42,
+        width: null,
+        height: null,
+        durationMs: null,
+        sourceMessageId: null,
+        provider: null,
+        providerOperationName: null,
+        prompt: null,
+        errorText: null,
+        createdAt: "2026-06-29T00:00:00.000Z",
+        updatedAt: "2026-06-29T00:00:00.000Z",
+      },
+    ] as any);
+    readFileMock.mockResolvedValueOnce(Buffer.from([1, 2, 3]));
+
+    const response = await fetch(`${baseUrl}/api/chat/respond`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        taskId: "task-image-1",
+        idempotencyKey: "idem-image-1",
+        channelId: "default",
+        sessionId: "session:default:main",
+        userMessageId: "msg-user-image-1",
+        assistantMessageId: "msg-assistant-image-1",
+        userMessage: "What is in this image?",
+        provider: "gemini",
+        mediaAttachmentIds: ["media-1"],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 0);
+    });
+    expect(resolveMediaAssetPathMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "media-1" }),
+    );
+    expect(streamWithAgentToolsAndUserConfigMock).toHaveBeenCalledWith(
+      "user-123",
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: "user",
+            content: [
+              { type: "text", text: "What is in this image?" },
+              {
+                type: "image",
+                image: Buffer.from([1, 2, 3]),
+                mediaType: "image/jpeg",
+              },
+            ],
+          }),
+        ]),
+      }),
+      expect.any(Object),
+      expect.any(Object),
+      "google_ai_studio",
+    );
   });
 
   it("auto-names a non-main thread from the first message and generates one title", async () => {

--- a/apps/node_backend/src/routes/chat.ts
+++ b/apps/node_backend/src/routes/chat.ts
@@ -1,4 +1,5 @@
 import express, { Response } from "express";
+import { readFile } from "fs/promises";
 import rateLimit from "express-rate-limit";
 import { authenticate, AuthRequest } from "../middleware/auth.js";
 import {
@@ -49,9 +50,10 @@ import {
 import {
   listMediaAssetsForUser,
   mediaAssetToDto,
+  resolveMediaAssetPath,
   type MediaAsset,
 } from "../services/mediaService.js";
-import type { AgentLoopStepResult, LlmProvider } from "../llm/types.js";
+import type { AgentLoopStepResult, LlmProvider, UnifiedMessage } from "../llm/types.js";
 import { parseMaxTokens } from "./validation.js";
 
 const router = express.Router();
@@ -606,6 +608,48 @@ function mediaAttachmentsMetadata(assets: MediaAsset[]) {
   return assets.map((asset) => mediaAssetToDto(asset));
 }
 
+async function imageAssetsToModelParts(assets: MediaAsset[]) {
+  const parts: Array<{ type: "image"; image: Uint8Array; mediaType: string }> = [];
+  for (const asset of assets) {
+    if (asset.kind !== "image" || asset.status !== "ready") continue;
+    const absolutePath = await resolveMediaAssetPath(asset);
+    const data = await readFile(absolutePath);
+    parts.push({
+      type: "image",
+      image: data,
+      mediaType: asset.mimeType,
+    });
+  }
+  return parts;
+}
+
+async function attachImagesToLatestUserMessage(
+  messages: Array<{ role: "user" | "assistant"; content: string }>,
+  assets: MediaAsset[],
+): Promise<UnifiedMessage[]> {
+  if (assets.length === 0) return messages;
+  let latestUserIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index].role === "user") {
+      latestUserIndex = index;
+      break;
+    }
+  }
+  if (latestUserIndex < 0) return messages;
+  const imageParts = await imageAssetsToModelParts(assets);
+  if (imageParts.length === 0) return messages;
+  return messages.map((message, index) => {
+    if (index !== latestUserIndex) return message;
+    const content: UnifiedMessage["content"] = [
+      ...(message.content.trim()
+        ? [{ type: "text" as const, text: message.content }]
+        : []),
+      ...imageParts,
+    ];
+    return { ...message, content };
+  });
+}
+
 function parseScopeType(value: unknown): ChatScopeType | null {
   if (value === "channel" || value === "thread") return value;
   return null;
@@ -719,6 +763,7 @@ async function runDefaultRouterRespondAsync(params: {
   systemPrompt: string | null;
   channelInstructions: string | null;
   threadInstructions: string | null;
+  mediaAttachments: MediaAsset[];
 }) {
   const {
     userId,
@@ -735,6 +780,7 @@ async function runDefaultRouterRespondAsync(params: {
     systemPrompt,
     channelInstructions,
     threadInstructions,
+    mediaAttachments,
   } = params;
 
   // NOTE: This runs after the HTTP response has been sent. On Vercel Serverless
@@ -775,6 +821,11 @@ async function runDefaultRouterRespondAsync(params: {
       limit: 40,
       maxChars: 10000,
     });
+    const preferredProvider = parseProvider(body.provider);
+    const modelMessagesWithMedia =
+      preferredProvider === "google_ai_studio"
+        ? await attachImagesToLatestUserMessage(modelMessages, mediaAttachments)
+        : modelMessages;
 
     const composedSystemPrompt = buildComposedSystemPrompt({
       systemPrompt,
@@ -784,8 +835,8 @@ async function runDefaultRouterRespondAsync(params: {
       threadId,
     });
     const messagesWithSystem = composedSystemPrompt
-      ? [{ role: 'system' as const, content: composedSystemPrompt }, ...modelMessages]
-      : modelMessages;
+      ? [{ role: 'system' as const, content: composedSystemPrompt }, ...modelMessagesWithMedia]
+      : modelMessagesWithMedia;
 
     let textStream: AsyncIterable<string>;
     let provider: string;
@@ -1097,7 +1148,7 @@ async function runDefaultRouterRespondAsync(params: {
             ]);
           },
         },
-        parseProvider(body.provider),
+        preferredProvider,
       );
     textStream = streamResult.textStream;
     provider = streamResult.provider;
@@ -1538,6 +1589,7 @@ router.post(
         systemPrompt,
         channelInstructions: scopeInstructions.channelInstructions,
         threadInstructions: scopeInstructions.threadInstructions,
+        mediaAttachments: orderedMediaAssets,
       });
 
       res.json({

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -115,7 +115,7 @@ products:
 
       - feature_id: chat_media_attachments
         name: 频道内图片附件与生成图片持久化
-        user_value: 用户可在聊天中上传图片，刷新后仍能预览/下载；AI 生成图片可作为频道内持久附件保存，供同一频道 workspace/Agent 访问。
+        user_value: 用户可在聊天中上传图片，上传中/失败时能看到草稿缩略图与重试/移除操作，刷新后仍能预览/下载；Gemini 路由会把上传图片作为多模态输入读取；AI 生成图片可作为频道内持久附件保存，供同一频道 workspace/Agent 访问。
         entry_paths:
           - screen: ChatScreen composer image action
             route_hint: apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -131,9 +131,13 @@ products:
             route_hint: apps/node_backend/src/routes/media.ts
           - route: GET /api/media/:mediaId/preview|content|download
             route_hint: apps/node_backend/src/routes/media.ts
+          - llm: Gemini multimodal image parts
+            route_hint: apps/node_backend/src/routes/chat.ts
         smoke_checks:
-          - 选择图片后，输入框上方显示待发送附件。
+          - 选择图片后，输入框上方立即显示本地缩略图与上传进度；失败后保留缩略图并提供重试和移除。
+          - 上传成功后，输入框上方显示带 Authorization header 的 media preview，而不是只显示占位 icon。
           - 发送带图片的消息后，user 气泡显示图片附件并保持原有投递状态。
+          - Gemini/Google AI Studio 路由收到上传图片时，模型请求包含 text part 与 image part，能够基于图片内容回答。
           - 刷新或 SSE 同步后，图片附件仍从 message metadata 恢复并可加载预览。
           - 访问 media preview/content/download 路由必须携带当前用户 token；跨用户 media id 返回 404。
           - 数据库 `media_assets.channel_relative_path` 只保存频道内相对路径，不保存宿主机绝对路径。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -292,7 +292,7 @@ index:
       - apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
       - apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
     doc_index:
-      - docs/tasks/doing/2026-06-29-23-06-CST-media-upload-preview-multimodal.md
+      - docs/tasks/done/2026-06-29-23-06-CST-media-upload-preview-multimodal.md
       - docs/tasks/doing/2026-06-29-16-13-CST-dokku-channel-media-deployment-plan.md
     test_index:
       - apps/node_backend/src/services/channelFileService.test.ts

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -282,6 +282,8 @@ index:
       - apps/node_backend/src/routes/media.ts
       - apps/node_backend/src/services/mediaService.ts
       - apps/node_backend/src/services/channelFileService.ts
+      - apps/node_backend/src/llm/types.ts
+      - apps/node_backend/src/llm/llm_service.ts
       - apps/node_backend/src/routes/chat.ts
       - apps/node_backend/src/services/chatAsyncTransportService.ts
       - apps/mobile_chat_app/lib/features/chat/chat_message.dart
@@ -290,6 +292,7 @@ index:
       - apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
       - apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
     doc_index:
+      - docs/tasks/doing/2026-06-29-23-06-CST-media-upload-preview-multimodal.md
       - docs/tasks/doing/2026-06-29-16-13-CST-dokku-channel-media-deployment-plan.md
     test_index:
       - apps/node_backend/src/services/channelFileService.test.ts
@@ -304,6 +307,8 @@ index:
       - mediaAttachments
       - image upload
       - generated image
+      - Gemini image input
+      - multimodal parts
       - previewUrl
       - downloadUrl
       - FilePicker
@@ -312,6 +317,7 @@ index:
       - media_assets 必须按 user_id 授权读取；若只按 media id 查找，可能泄露其他用户上传/生成图片。
       - channel_relative_path 必须拒绝绝对路径、空 path、`..` 与反斜杠逃逸；否则 Agent/media 路径可能越过当前 channel root。
       - Flutter Image.network 预览依赖 Authorization header；若 AuthService token hydration 失败，图片附件会显示 broken image 但消息文本仍可见。
+      - Gemini 多模态输入只应把当前用户可访问、当前 channel 的 ready image asset 转为 image part；错误地传递跨 channel 或失败 asset 会造成隐私或 provider 错误风险。
       - chat_messages.metadata 是第一阶段附件同步桥；后续若改为 join 查询，需要继续保证 sync/history/SSE 返回 mediaAttachments。
       - 生成图片当前只实现持久化入口，完整 provider-side image generation 仍需后续 Gemini capability/tool 集成。
 

--- a/docs/tasks/doing/2026-06-29-23-06-CST-media-upload-preview-multimodal.md
+++ b/docs/tasks/doing/2026-06-29-23-06-CST-media-upload-preview-multimodal.md
@@ -1,0 +1,36 @@
+# Media Upload Preview and Gemini Image Input
+
+## Background
+
+Production chat can log in, send text, and receive assistant replies. Image upload now reaches the backend and persists as channel media, but the draft composer shows only a generic icon after upload, the draft preview request misses the auth token, and Gemini responses do not yet use uploaded image content as multimodal input.
+
+## Goals
+
+- Show selected image attachments in the composer as real thumbnails with clear uploading, remove, and retry states.
+- Ensure authenticated media preview requests work before send and after send.
+- Send uploaded images to Gemini-capable chat requests as multimodal image parts so the model can answer based on the image.
+- Preserve existing text-only chat and unsupported-provider behavior.
+
+## Implementation Plan
+
+1. Update the mobile composer pending attachment UI to render authenticated image previews instead of a static icon.
+2. Add a temporary uploading tile with spinner and retry affordance when upload fails.
+3. Extend backend model message assembly to include media attachment metadata for recent user messages.
+4. Convert image media assets into AI SDK multimodal parts for Google AI Studio requests, while keeping Anthropic/text-only requests stable.
+5. Add focused tests for authenticated preview UI state and multimodal request construction.
+
+## Acceptance Criteria
+
+- A selected image shows a small preview tile while attached to the draft.
+- During upload, the composer shows a bounded square tile with progress indication and a close action.
+- If upload fails, the tile offers retry/removal instead of silently disappearing.
+- Draft and sent-message previews include the current auth token.
+- A Gemini-capable route receives uploaded image bytes as image parts and can answer questions about image content.
+- Text-only chat continues to work.
+
+## Validation Commands
+
+- `./tools/init_dev_env.sh`
+- `cd apps/node_backend && npm test`
+- `cd apps/node_backend && npm run type-check`
+- `cd apps/mobile_chat_app && flutter test`

--- a/docs/tasks/done/2026-06-29-23-06-CST-media-upload-preview-multimodal.md
+++ b/docs/tasks/done/2026-06-29-23-06-CST-media-upload-preview-multimodal.md
@@ -28,9 +28,21 @@ Production chat can log in, send text, and receive assistant replies. Image uplo
 - A Gemini-capable route receives uploaded image bytes as image parts and can answer questions about image content.
 - Text-only chat continues to work.
 
+## Verified Status
+
+- Production `craft.bricks.cool` login, text send, and assistant text reply were already verified before this fix.
+- Preview subdomain access was restored after Cloudflare edge certificate coverage was updated for `*.craft-dev.bricks.cool`.
+- Preview login, text/image send, uploaded image preview inside the sent message, and image persistence after refresh were manually verified.
+- Draft upload now shows a small thumbnail/progress tile during upload, and successful uploaded draft media uses an authenticated preview request.
+- Gemini image understanding was manually verified: the assistant answered based on the actual uploaded image content.
+- Upload failure retry UI is implemented but the offline/network-failure retry path has not yet been manually smoke tested.
+- Media download remains covered by the existing authenticated download endpoint, but it was not part of this manual first-batch browser pass.
+
 ## Validation Commands
 
 - `./tools/init_dev_env.sh`
 - `cd apps/node_backend && npm test`
 - `cd apps/node_backend && npm run type-check`
-- `cd apps/mobile_chat_app && flutter test`
+- `cd apps/mobile_chat_app && flutter analyze`
+- `cd apps/mobile_chat_app && flutter test test/message_list_test.dart test/chat_history_api_service_test.dart`
+- `npx js-yaml docs/code_maps/feature_map.yaml > /dev/null && npx js-yaml docs/code_maps/logic_map.yaml > /dev/null`


### PR DESCRIPTION
## Summary
- show selected chat images as draft thumbnails with upload progress, cancel, and retry states
- load pending media previews with the auth token so `/api/media/:id/preview` works before send
- pass current uploaded image attachments into Gemini/Google AI Studio requests as multimodal image parts
- update code maps and add a task note for this media upload milestone

## Validation
- `./tools/init_dev_env.sh`
- `cd apps/node_backend && npm test`
- `cd apps/node_backend && npm run type-check`
- `cd apps/mobile_chat_app && flutter analyze`
- `cd apps/mobile_chat_app && flutter test test/message_list_test.dart test/chat_history_api_service_test.dart`
- `npx js-yaml docs/code_maps/feature_map.yaml > /dev/null && npx js-yaml docs/code_maps/logic_map.yaml > /dev/null`

## Manual preview checks
- In the PR preview, log in through GitHub OAuth.
- Select an image and confirm the composer immediately shows a thumbnail with progress and a close button.
- Confirm uploaded draft preview no longer calls `/api/media/:id/preview` without Authorization.
- Send image + text on a Gemini route and ask a question requiring image content.
