### PR TITLE
Add Gemini image and video generation jobs

### DIFF
--- a/.github/workflows/dokku_preview_deploy.yml
+++ b/.github/workflows/dokku_preview_deploy.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
+permissions:
+  contents: read
+  deployments: write
+  pull-requests: read
+
 concurrency:
   group: dokku-preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -183,3 +188,39 @@ jobs:
           set -euo pipefail
           ssh -i ~/.ssh/id_ed25519 -p "${DOKKU_PORT}" "root@${DOKKU_HOST}" \
             dokku letsencrypt:enable "${APP_NAME}" || true
+
+      - name: Publish GitHub deployment status
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_URL: https://${{ needs.slug.outputs.domain }}
+          BRANCH_SLUG: ${{ needs.slug.outputs.branch_slug }}
+        with:
+          script: |
+            const previewUrl = process.env.PREVIEW_URL;
+            const branchSlug = process.env.BRANCH_SLUG;
+            const environment = `dokku-preview/${branchSlug}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request.head.sha,
+              auto_merge: false,
+              required_contexts: [],
+              environment,
+              transient_environment: true,
+              production_environment: false,
+              description: `Dokku preview for PR #${context.payload.pull_request.number}`,
+            });
+
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'success',
+              environment,
+              environment_url: previewUrl,
+              log_url: runUrl,
+              auto_inactive: true,
+              description: 'Dokku preview deployment is ready.',
+            });

--- a/apps/mobile_chat_app/lib/features/chat/media_download.dart
+++ b/apps/mobile_chat_app/lib/features/chat/media_download.dart
@@ -1,0 +1,14 @@
+import 'media_download_stub.dart'
+    if (dart.library.html) 'media_download_web.dart' as impl;
+
+Future<void> downloadChatMedia({
+  required Uri uri,
+  required String filename,
+  required String? authToken,
+}) {
+  return impl.downloadChatMedia(
+    uri: uri,
+    filename: filename,
+    authToken: authToken,
+  );
+}

--- a/apps/mobile_chat_app/lib/features/chat/media_download_stub.dart
+++ b/apps/mobile_chat_app/lib/features/chat/media_download_stub.dart
@@ -1,0 +1,7 @@
+Future<void> downloadChatMedia({
+  required Uri uri,
+  required String filename,
+  required String? authToken,
+}) async {
+  throw UnsupportedError('Media download is only available in the web app.');
+}

--- a/apps/mobile_chat_app/lib/features/chat/media_download_web.dart
+++ b/apps/mobile_chat_app/lib/features/chat/media_download_web.dart
@@ -1,0 +1,41 @@
+// TODO(migrate): Switch from `dart:html` to `package:web` + `dart:js_interop`.
+// ignore: deprecated_member_use
+import 'dart:html' as html;
+
+String _downloadFilename(String filename) {
+  final trimmed = filename.trim();
+  if (trimmed.isEmpty) return 'bricks-media';
+  return trimmed.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_');
+}
+
+Future<void> downloadChatMedia({
+  required Uri uri,
+  required String filename,
+  required String? authToken,
+}) async {
+  final response = await html.HttpRequest.request(
+    uri.toString(),
+    method: 'GET',
+    responseType: 'blob',
+    requestHeaders: {
+      if (authToken != null && authToken.isNotEmpty)
+        'Authorization': 'Bearer $authToken',
+    },
+  );
+  final blob = response.response;
+  if (blob is! html.Blob) {
+    throw StateError('Download response did not include a file.');
+  }
+
+  final objectUrl = html.Url.createObjectUrlFromBlob(blob);
+  final anchor = html.AnchorElement(href: objectUrl)
+    ..download = _downloadFilename(filename)
+    ..style.display = 'none';
+  try {
+    html.document.body?.append(anchor);
+    anchor.click();
+  } finally {
+    anchor.remove();
+    html.Url.revokeObjectUrl(objectUrl);
+  }
+}

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -1609,7 +1609,7 @@ class _MediaAttachmentStrip extends StatelessWidget {
   }
 }
 
-class _MediaAttachmentTile extends StatelessWidget {
+class _MediaAttachmentTile extends StatefulWidget {
   const _MediaAttachmentTile({
     required this.attachment,
     required this.previewUri,
@@ -1618,26 +1618,40 @@ class _MediaAttachmentTile extends StatelessWidget {
     required this.borderColor,
   });
 
+  static const double _tileWidth = 168;
+  static const double _tileHeight = 148;
+  static const double _labelHeight = 24;
+  static const double _pointerSlop = 12;
+
   final ChatMediaAttachment attachment;
   final Uri previewUri;
   final Uri contentUri;
   final Uri downloadUri;
   final Color borderColor;
 
-  static const double _tileWidth = 168;
-  static const double _tileHeight = 148;
-  static const double _labelHeight = 24;
+  @override
+  State<_MediaAttachmentTile> createState() => _MediaAttachmentTileState();
+}
+
+class _MediaAttachmentTileState extends State<_MediaAttachmentTile> {
+  int? _primaryPointer;
+  Offset? _primaryPointerDownPosition;
+  bool _suppressPrimaryPointerUp = false;
 
   Future<void> _openPreview(
     BuildContext context,
     Map<String, String>? headers,
+    String? token,
   ) async {
-    if (attachment.kind != 'image') return;
+    if (widget.attachment.kind != 'image') return;
     await Navigator.of(context, rootNavigator: true).push(
       MaterialPageRoute<void>(
         builder: (_) => _FullScreenMediaPreview(
-          uri: contentUri,
+          uri: widget.contentUri,
+          downloadUri: widget.downloadUri,
+          filename: widget.attachment.filename,
           headers: headers,
+          authToken: token,
         ),
       ),
     );
@@ -1682,8 +1696,8 @@ class _MediaAttachmentTile extends StatelessWidget {
   Future<void> _download(BuildContext context, String? token) async {
     try {
       await downloadChatMedia(
-        uri: downloadUri,
-        filename: attachment.filename,
+        uri: widget.downloadUri,
+        filename: widget.attachment.filename,
         authToken: token,
       );
       if (!context.mounted) return;
@@ -1698,6 +1712,41 @@ class _MediaAttachmentTile extends StatelessWidget {
     }
   }
 
+  void _handlePointerDown(PointerDownEvent event) {
+    if (widget.attachment.kind != 'image') return;
+    if (event.buttons != kPrimaryButton) return;
+    _primaryPointer = event.pointer;
+    _primaryPointerDownPosition = event.localPosition;
+    _suppressPrimaryPointerUp = false;
+  }
+
+  void _handlePointerCancel(PointerCancelEvent event) {
+    if (event.pointer != _primaryPointer) return;
+    _clearPrimaryPointer();
+  }
+
+  void _handlePointerUp(
+    PointerUpEvent event,
+    Map<String, String>? headers,
+    String? token,
+  ) {
+    if (event.pointer != _primaryPointer) return;
+    final downPosition = _primaryPointerDownPosition;
+    final shouldOpen = !_suppressPrimaryPointerUp &&
+        downPosition != null &&
+        (event.localPosition - downPosition).distance <=
+            _MediaAttachmentTile._pointerSlop;
+    _clearPrimaryPointer();
+    if (!shouldOpen) return;
+    _openPreview(context, headers, token);
+  }
+
+  void _clearPrimaryPointer() {
+    _primaryPointer = null;
+    _primaryPointerDownPosition = null;
+    _suppressPrimaryPointerUp = false;
+  }
+
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<String?>(
@@ -1707,67 +1756,101 @@ class _MediaAttachmentTile extends StatelessWidget {
         final headers = token == null || token.isEmpty
             ? null
             : {'Authorization': 'Bearer $token'};
-        return GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: () => _openPreview(context, headers),
-          onLongPressStart: (details) =>
-              _showContextMenu(context, details.globalPosition, token),
-          onSecondaryTapDown: (details) =>
-              _showContextMenu(context, details.globalPosition, token),
-          child: MouseRegion(
-            cursor: attachment.kind == 'image'
-                ? SystemMouseCursors.click
-                : MouseCursor.defer,
-            child: Container(
-              width: _tileWidth,
-              height: _tileHeight,
-              decoration: BoxDecoration(
-                border: Border.all(color: borderColor),
-                borderRadius: BorderRadius.circular(BricksRadius.sm),
-              ),
-              clipBehavior: Clip.antiAlias,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: Image.network(
-                      previewUri.toString(),
-                      headers: headers,
-                      fit: BoxFit.cover,
-                      errorBuilder: (context, _, __) => const Center(
-                        child: Icon(Icons.broken_image_outlined),
-                      ),
-                      loadingBuilder: (context, child, progress) {
-                        if (progress == null) return child;
-                        return const Center(
-                          child: SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(strokeWidth: 2),
+        return Listener(
+          onPointerDown: _handlePointerDown,
+          onPointerCancel: _handlePointerCancel,
+          onPointerUp: (event) => _handlePointerUp(event, headers, token),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onLongPressStart: (details) {
+              _suppressPrimaryPointerUp = true;
+              _showContextMenu(context, details.globalPosition, token);
+            },
+            onSecondaryTapDown: (details) =>
+                _showContextMenu(context, details.globalPosition, token),
+            child: MouseRegion(
+              cursor: widget.attachment.kind == 'image'
+                  ? SystemMouseCursors.click
+                  : MouseCursor.defer,
+              child: Container(
+                width: _MediaAttachmentTile._tileWidth,
+                height: _MediaAttachmentTile._tileHeight,
+                decoration: BoxDecoration(
+                  border: Border.all(color: widget.borderColor),
+                  borderRadius: BorderRadius.circular(BricksRadius.sm),
+                ),
+                clipBehavior: Clip.antiAlias,
+                child: Stack(
+                  children: [
+                    Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          child: Image.network(
+                            widget.previewUri.toString(),
+                            headers: headers,
+                            fit: BoxFit.cover,
+                            errorBuilder: (context, _, __) => const Center(
+                              child: Icon(Icons.broken_image_outlined),
+                            ),
+                            loadingBuilder: (context, child, progress) {
+                              if (progress == null) return child;
+                              return const Center(
+                                child: SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child:
+                                      CircularProgressIndicator(strokeWidth: 2),
+                                ),
+                              );
+                            },
                           ),
-                        );
-                      },
+                        ),
+                        SizedBox(
+                          height: _MediaAttachmentTile._labelHeight,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: BricksSpacing.xs,
+                            ),
+                            child: Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(
+                                widget.attachment.filename,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: Theme.of(context).textTheme.labelSmall,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
-                  ),
-                  SizedBox(
-                    height: _labelHeight,
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: BricksSpacing.xs,
-                      ),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          attachment.filename,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.labelSmall,
+                    if (widget.attachment.kind == 'image')
+                      Positioned(
+                        top: BricksSpacing.xs,
+                        right: BricksSpacing.xs,
+                        child: Material(
+                          color: AppColors.surfaceElevated,
+                          shape: const CircleBorder(),
+                          clipBehavior: Clip.antiAlias,
+                          child: IconButton(
+                            tooltip: 'Open image',
+                            constraints: const BoxConstraints.tightFor(
+                              width: 32,
+                              height: 32,
+                            ),
+                            padding: EdgeInsets.zero,
+                            iconSize: 18,
+                            color: AppColors.textPrimary,
+                            icon: const Icon(Icons.open_in_full),
+                            onPressed: () =>
+                                _openPreview(context, headers, token),
+                          ),
                         ),
                       ),
-                    ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),
@@ -1782,11 +1865,36 @@ enum _MediaAttachmentAction { download }
 class _FullScreenMediaPreview extends StatelessWidget {
   const _FullScreenMediaPreview({
     required this.uri,
+    required this.downloadUri,
+    required this.filename,
     required this.headers,
+    required this.authToken,
   });
 
   final Uri uri;
+  final Uri downloadUri;
+  final String filename;
   final Map<String, String>? headers;
+  final String? authToken;
+
+  Future<void> _download(BuildContext context) async {
+    try {
+      await downloadChatMedia(
+        uri: downloadUri,
+        filename: filename,
+        authToken: authToken,
+      );
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Download started')),
+      );
+    } catch (error) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Download failed: $error')),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -1824,16 +1932,33 @@ class _FullScreenMediaPreview extends StatelessWidget {
             Positioned(
               top: BricksSpacing.sm,
               right: BricksSpacing.sm,
-              child: Material(
-                color: AppColors.surfaceElevated,
-                shape: const CircleBorder(),
-                clipBehavior: Clip.antiAlias,
-                child: IconButton(
-                  tooltip: 'Back to chat',
-                  color: AppColors.textPrimary,
-                  icon: const Icon(Icons.close),
-                  onPressed: () => Navigator.of(context).pop(),
-                ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Material(
+                    color: AppColors.surfaceElevated,
+                    shape: const CircleBorder(),
+                    clipBehavior: Clip.antiAlias,
+                    child: IconButton(
+                      tooltip: 'Download image',
+                      color: AppColors.textPrimary,
+                      icon: const Icon(Icons.download_outlined),
+                      onPressed: () => _download(context),
+                    ),
+                  ),
+                  const SizedBox(width: BricksSpacing.xs),
+                  Material(
+                    color: AppColors.surfaceElevated,
+                    shape: const CircleBorder(),
+                    clipBehavior: Clip.antiAlias,
+                    child: IconButton(
+                      tooltip: 'Back to chat',
+                      color: AppColors.textPrimary,
+                      icon: const Icon(Icons.close),
+                      onPressed: () => Navigator.of(context).pop(),
+                    ),
+                  ),
+                ],
               ),
             ),
           ],

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -1633,7 +1633,7 @@ class _MediaAttachmentTile extends StatelessWidget {
     Map<String, String>? headers,
   ) async {
     if (attachment.kind != 'image') return;
-    await Navigator.of(context).push(
+    await Navigator.of(context, rootNavigator: true).push(
       MaterialPageRoute<void>(
         builder: (_) => _FullScreenMediaPreview(
           uri: contentUri,
@@ -1645,7 +1645,7 @@ class _MediaAttachmentTile extends StatelessWidget {
 
   Future<void> _showContextMenu(
     BuildContext context,
-    LongPressStartDetails details,
+    Offset globalPosition,
     String? token,
   ) async {
     final overlay = Overlay.of(context).context.findRenderObject();
@@ -1654,8 +1654,8 @@ class _MediaAttachmentTile extends StatelessWidget {
       context: context,
       position: RelativeRect.fromRect(
         Rect.fromLTWH(
-          details.globalPosition.dx,
-          details.globalPosition.dy,
+          globalPosition.dx,
+          globalPosition.dy,
           1,
           1,
         ),
@@ -1708,9 +1708,12 @@ class _MediaAttachmentTile extends StatelessWidget {
             ? null
             : {'Authorization': 'Bearer $token'};
         return GestureDetector(
+          behavior: HitTestBehavior.opaque,
           onTap: () => _openPreview(context, headers),
           onLongPressStart: (details) =>
-              _showContextMenu(context, details, token),
+              _showContextMenu(context, details.globalPosition, token),
+          onSecondaryTapDown: (details) =>
+              _showContextMenu(context, details.globalPosition, token),
           child: MouseRegion(
             cursor: attachment.kind == 'image'
                 ? SystemMouseCursors.click

--- a/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
+++ b/apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import '../../auth/auth_service.dart';
 import '../../settings/llm_config_service.dart';
 import '../chat_message.dart';
+import '../media_download.dart';
 import '../text_highlight_api_service.dart';
 
 // Extra bottom padding as a fraction of screen height, so the latest user
@@ -1595,7 +1596,9 @@ class _MediaAttachmentStrip extends StatelessWidget {
           .map(
             (attachment) => _MediaAttachmentTile(
               attachment: attachment,
-              uri: _mediaUri(attachment.previewUrl),
+              previewUri: _mediaUri(attachment.previewUrl),
+              contentUri: _mediaUri(attachment.contentUrl),
+              downloadUri: _mediaUri(attachment.downloadUrl),
               borderColor: isUser
                   ? chatColors.onMessageUser.withValues(alpha: 0.24)
                   : chatColors.composerBorder,
@@ -1609,13 +1612,91 @@ class _MediaAttachmentStrip extends StatelessWidget {
 class _MediaAttachmentTile extends StatelessWidget {
   const _MediaAttachmentTile({
     required this.attachment,
-    required this.uri,
+    required this.previewUri,
+    required this.contentUri,
+    required this.downloadUri,
     required this.borderColor,
   });
 
   final ChatMediaAttachment attachment;
-  final Uri uri;
+  final Uri previewUri;
+  final Uri contentUri;
+  final Uri downloadUri;
   final Color borderColor;
+
+  static const double _tileWidth = 168;
+  static const double _tileHeight = 148;
+  static const double _labelHeight = 24;
+
+  Future<void> _openPreview(
+    BuildContext context,
+    Map<String, String>? headers,
+  ) async {
+    if (attachment.kind != 'image') return;
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => _FullScreenMediaPreview(
+          uri: contentUri,
+          headers: headers,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showContextMenu(
+    BuildContext context,
+    LongPressStartDetails details,
+    String? token,
+  ) async {
+    final overlay = Overlay.of(context).context.findRenderObject();
+    if (overlay is! RenderBox) return;
+    final selected = await showMenu<_MediaAttachmentAction>(
+      context: context,
+      position: RelativeRect.fromRect(
+        Rect.fromLTWH(
+          details.globalPosition.dx,
+          details.globalPosition.dy,
+          1,
+          1,
+        ),
+        Offset.zero & overlay.size,
+      ),
+      items: const [
+        PopupMenuItem<_MediaAttachmentAction>(
+          value: _MediaAttachmentAction.download,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.download_outlined, size: 18),
+              SizedBox(width: BricksSpacing.sm),
+              Text('Download'),
+            ],
+          ),
+        ),
+      ],
+    );
+    if (selected != _MediaAttachmentAction.download) return;
+    await _download(context, token);
+  }
+
+  Future<void> _download(BuildContext context, String? token) async {
+    try {
+      await downloadChatMedia(
+        uri: downloadUri,
+        filename: attachment.filename,
+        authToken: token,
+      );
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Download started')),
+      );
+    } catch (error) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Download failed: $error')),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -1626,55 +1707,135 @@ class _MediaAttachmentTile extends StatelessWidget {
         final headers = token == null || token.isEmpty
             ? null
             : {'Authorization': 'Bearer $token'};
-        return Container(
-          width: 168,
-          constraints: const BoxConstraints(maxHeight: 148),
-          decoration: BoxDecoration(
-            border: Border.all(color: borderColor),
-            borderRadius: BorderRadius.circular(BricksRadius.sm),
-          ),
-          clipBehavior: Clip.antiAlias,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              AspectRatio(
-                aspectRatio: 4 / 3,
-                child: Image.network(
-                  uri.toString(),
-                  headers: headers,
-                  fit: BoxFit.cover,
-                  errorBuilder: (context, _, __) => const Center(
-                    child: Icon(Icons.broken_image_outlined),
-                  ),
-                  loadingBuilder: (context, child, progress) {
-                    if (progress == null) return child;
-                    return const Center(
-                      child: SizedBox(
-                        width: 18,
-                        height: 18,
-                        child: CircularProgressIndicator(strokeWidth: 2),
+        return GestureDetector(
+          onTap: () => _openPreview(context, headers),
+          onLongPressStart: (details) =>
+              _showContextMenu(context, details, token),
+          child: MouseRegion(
+            cursor: attachment.kind == 'image'
+                ? SystemMouseCursors.click
+                : MouseCursor.defer,
+            child: Container(
+              width: _tileWidth,
+              height: _tileHeight,
+              decoration: BoxDecoration(
+                border: Border.all(color: borderColor),
+                borderRadius: BorderRadius.circular(BricksRadius.sm),
+              ),
+              clipBehavior: Clip.antiAlias,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Image.network(
+                      previewUri.toString(),
+                      headers: headers,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, _, __) => const Center(
+                        child: Icon(Icons.broken_image_outlined),
                       ),
-                    );
-                  },
-                ),
+                      loadingBuilder: (context, child, progress) {
+                        if (progress == null) return child;
+                        return const Center(
+                          child: SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  SizedBox(
+                    height: _labelHeight,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: BricksSpacing.xs,
+                      ),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          attachment.filename,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.labelSmall,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: BricksSpacing.xs,
-                  vertical: 3,
-                ),
-                child: Text(
-                  attachment.filename,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.labelSmall,
-                ),
-              ),
-            ],
+            ),
           ),
         );
       },
+    );
+  }
+}
+
+enum _MediaAttachmentAction { download }
+
+class _FullScreenMediaPreview extends StatelessWidget {
+  const _FullScreenMediaPreview({
+    required this.uri,
+    required this.headers,
+  });
+
+  final Uri uri;
+  final Map<String, String>? headers;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.backgroundChrome,
+      body: SafeArea(
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: InteractiveViewer(
+                minScale: 0.8,
+                maxScale: 4,
+                child: Center(
+                  child: Image.network(
+                    uri.toString(),
+                    headers: headers,
+                    fit: BoxFit.contain,
+                    errorBuilder: (context, _, __) => const Icon(
+                      Icons.broken_image_outlined,
+                      color: AppColors.textPrimary,
+                      size: 40,
+                    ),
+                    loadingBuilder: (context, child, progress) {
+                      if (progress == null) return child;
+                      return const SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ),
+            Positioned(
+              top: BricksSpacing.sm,
+              right: BricksSpacing.sm,
+              child: Material(
+                color: AppColors.surfaceElevated,
+                shape: const CircleBorder(),
+                clipBehavior: Clip.antiAlias,
+                child: IconButton(
+                  tooltip: 'Back to chat',
+                  color: AppColors.textPrimary,
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:design_system/design_system.dart';
 import 'package:mobile_chat_app/features/chat/chat_message.dart';
 import 'package:mobile_chat_app/features/chat/widgets/message_list.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 // Must match _kBottomPaddingRatio in message_list.dart
 const double _kTestBottomPaddingRatio = 1 / 3;
@@ -31,6 +32,24 @@ List<ChatMessage> _messages(String prefix, int count) {
     ),
   );
 }
+
+ChatMediaAttachment _imageAttachment({
+  String id = 'media-1',
+  String filename = 'plant.png',
+}) =>
+    ChatMediaAttachment(
+      id: id,
+      kind: 'image',
+      origin: 'generated_image',
+      mimeType: 'image/png',
+      filename: filename,
+      previewUrl: '/api/media/$id/preview',
+      contentUrl: '/api/media/$id/content',
+      downloadUrl: '/api/media/$id/download',
+      sizeBytes: 1024,
+      status: 'ready',
+      channelRelativePath: 'media/generated/images/$filename',
+    );
 
 Widget _build(
   List<ChatMessage> messages, {
@@ -1141,6 +1160,53 @@ void main() {
     });
   });
 
+  group('Media attachment interactions', () {
+    testWidgets('tap opens full screen image preview and back closes it',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({'auth_token': 'token-123'});
+      final assistant = ChatMessage(
+        messageId: 'a-media-preview',
+        role: 'assistant',
+        content: '',
+        timestamp: DateTime.utc(2026, 1, 1, 7, 33),
+        mediaAttachments: [_imageAttachment()],
+      );
+
+      await tester.pumpWidget(_build([assistant]));
+      await tester.pump();
+
+      await tester.tap(find.text('plant.png'));
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Back to chat'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Back to chat'));
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Back to chat'), findsNothing);
+      expect(find.text('plant.png'), findsOneWidget);
+    });
+
+    testWidgets('long press shows image download action', (tester) async {
+      SharedPreferences.setMockInitialValues({'auth_token': 'token-123'});
+      final assistant = ChatMessage(
+        messageId: 'a-media-menu',
+        role: 'assistant',
+        content: '',
+        timestamp: DateTime.utc(2026, 1, 1, 7, 33),
+        mediaAttachments: [_imageAttachment()],
+      );
+
+      await tester.pumpWidget(_build([assistant]));
+      await tester.pump();
+
+      await tester.longPress(find.text('plant.png'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Download'), findsOneWidget);
+    });
+  });
+
   group('AI message avatar / header chip', () {
     testWidgets('shows dispatch placeholder header and loading state',
         (tester) async {
@@ -1637,8 +1703,7 @@ void main() {
       expect(received?.messageId, 'a-action');
     });
 
-    testWidgets('tapping fork calls onFork with message',
-        (tester) async {
+    testWidgets('tapping fork calls onFork with message', (tester) async {
       ChatMessage? received;
       await tester.pumpWidget(
         _build(

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:design_system/design_system.dart';
@@ -1201,6 +1202,29 @@ void main() {
       await tester.pump();
 
       await tester.longPress(find.text('plant.png'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Download'), findsOneWidget);
+    });
+
+    testWidgets('secondary click shows image download action', (tester) async {
+      SharedPreferences.setMockInitialValues({'auth_token': 'token-123'});
+      final assistant = ChatMessage(
+        messageId: 'a-media-secondary-menu',
+        role: 'assistant',
+        content: '',
+        timestamp: DateTime.utc(2026, 1, 1, 7, 33),
+        mediaAttachments: [_imageAttachment()],
+      );
+
+      await tester.pumpWidget(_build([assistant]));
+      await tester.pump();
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.text('plant.png')),
+        buttons: kSecondaryButton,
+      );
+      await gesture.up();
       await tester.pumpAndSettle();
 
       expect(find.text('Download'), findsOneWidget);

--- a/apps/mobile_chat_app/test/message_list_test.dart
+++ b/apps/mobile_chat_app/test/message_list_test.dart
@@ -1176,10 +1176,13 @@ void main() {
       await tester.pumpWidget(_build([assistant]));
       await tester.pump();
 
+      expect(find.byTooltip('Open image'), findsOneWidget);
+
       await tester.tap(find.text('plant.png'));
       await tester.pumpAndSettle();
 
       expect(find.byTooltip('Back to chat'), findsOneWidget);
+      expect(find.byTooltip('Download image'), findsOneWidget);
 
       await tester.tap(find.byTooltip('Back to chat'));
       await tester.pumpAndSettle();

--- a/apps/node_backend/src/app.test.ts
+++ b/apps/node_backend/src/app.test.ts
@@ -1,4 +1,7 @@
 import express from 'express';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 const runMigrationsMock = vi.fn(async () => {});
@@ -86,8 +89,18 @@ vi.mock('./routes/cron.js', () => ({
 
 let server: ReturnType<express.Express['listen']> | null = null;
 let baseUrl = '';
+let staticRoot = '';
+let previousStaticRoot: string | undefined;
 
 beforeAll(async () => {
+  previousStaticRoot = process.env.BRICKS_STATIC_ROOT;
+  staticRoot = await mkdtemp(path.join(os.tmpdir(), 'bricks-static-'));
+  await writeFile(path.join(staticRoot, 'index.html'), '<!doctype html><title>Bricks</title>');
+  await writeFile(path.join(staticRoot, 'main.dart.js'), 'console.log("app")');
+  await writeFile(path.join(staticRoot, 'flutter.js'), 'console.log("flutter")');
+  await writeFile(path.join(staticRoot, 'asset.txt'), 'asset');
+  process.env.BRICKS_STATIC_ROOT = staticRoot;
+
   const { default: app } = await import('./app.js');
 
   await new Promise<void>((resolve) => {
@@ -115,6 +128,14 @@ afterAll(async () => {
       resolve();
     });
   });
+  if (previousStaticRoot === undefined) {
+    delete process.env.BRICKS_STATIC_ROOT;
+  } else {
+    process.env.BRICKS_STATIC_ROOT = previousStaticRoot;
+  }
+  if (staticRoot) {
+    await rm(staticRoot, { recursive: true, force: true });
+  }
 });
 
 describe('app migrations', () => {
@@ -160,5 +181,27 @@ describe('app security headers', () => {
     expect(csp).toContain("script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.gstatic.com");
     expect(csp).toContain("connect-src 'self' https://www.gstatic.com https://fonts.gstatic.com");
     expect(csp).toContain("worker-src 'self' blob:");
+  });
+});
+
+describe('app static cache headers', () => {
+  it('does not cache Flutter app shell files with unversioned names', async () => {
+    for (const pathname of ['/', '/main.dart.js', '/flutter.js']) {
+      const response = await fetch(`${baseUrl}${pathname}`);
+      expect(response.status).toBe(200);
+      expect(response.headers.get('cache-control')).toContain('no-store');
+    }
+  });
+
+  it('does not cache SPA fallback index responses', async () => {
+    const response = await fetch(`${baseUrl}/chat/thread-1`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toContain('no-store');
+  });
+
+  it('keeps non-shell static assets on a short cache policy', async () => {
+    const response = await fetch(`${baseUrl}/asset.txt`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('public, max-age=60');
   });
 });

--- a/apps/node_backend/src/app.ts
+++ b/apps/node_backend/src/app.ts
@@ -118,15 +118,40 @@ app.use('/api/resources', resourcesRoutes);
 // Cron routes do NOT use the JWT authenticate middleware — they use CRON_SECRET.
 app.use('/api/cron', cronRoutes);
 
+const NO_STORE_STATIC_CACHE = 'no-store, no-cache, must-revalidate, max-age=0';
+const SHORT_STATIC_CACHE = 'public, max-age=60';
+const NO_STORE_STATIC_FILENAMES = new Set([
+  'index.html',
+  'main.dart.js',
+  'flutter.js',
+  'flutter_service_worker.js',
+  'manifest.json',
+  'version.json',
+]);
+
+function setStaticCacheHeaders(res: Response, filePath: string): void {
+  const filename = path.basename(filePath);
+  if (NO_STORE_STATIC_FILENAMES.has(filename)) {
+    res.setHeader('Cache-Control', NO_STORE_STATIC_CACHE);
+    return;
+  }
+  res.setHeader('Cache-Control', SHORT_STATIC_CACHE);
+}
+
 const staticRoot = process.env.BRICKS_STATIC_ROOT?.trim();
 if (staticRoot) {
   const resolvedStaticRoot = path.resolve(staticRoot);
-  app.use(express.static(resolvedStaticRoot));
+  app.use(
+    express.static(resolvedStaticRoot, {
+      setHeaders: setStaticCacheHeaders,
+    })
+  );
   app.get('*', (req: Request, res: Response, next: NextFunction) => {
     if (req.path.startsWith('/api/')) {
       next();
       return;
     }
+    res.setHeader('Cache-Control', NO_STORE_STATIC_CACHE);
     res.sendFile(path.join(resolvedStaticRoot, 'index.html'));
   });
 }

--- a/apps/node_backend/src/db/migrations/027_create_media_generation_jobs.sql
+++ b/apps/node_backend/src/db/migrations/027_create_media_generation_jobs.sql
@@ -1,0 +1,33 @@
+-- Migration: Create media generation jobs
+-- Description: Durable provider-side image and video generation job records.
+-- Version: 027
+-- Date: 2026-06-30
+
+CREATE TABLE IF NOT EXISTS media_generation_jobs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  channel_id VARCHAR(255) NOT NULL,
+  thread_id VARCHAR(255),
+  kind VARCHAR(32) NOT NULL CHECK (kind IN ('image', 'video')),
+  status VARCHAR(32) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'running', 'succeeded', 'failed')),
+  prompt TEXT NOT NULL,
+  input_media_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+  provider VARCHAR(64) NOT NULL,
+  model VARCHAR(255) NOT NULL,
+  provider_operation_name TEXT,
+  result_media_id UUID REFERENCES media_assets(id) ON DELETE SET NULL,
+  error_text TEXT,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_media_generation_jobs_user_channel_created
+  ON media_generation_jobs(user_id, channel_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_media_generation_jobs_user_status
+  ON media_generation_jobs(user_id, status);
+
+CREATE TRIGGER update_media_generation_jobs_updated_at
+  BEFORE UPDATE ON media_generation_jobs
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();

--- a/apps/node_backend/src/llm/llm_service.ts
+++ b/apps/node_backend/src/llm/llm_service.ts
@@ -148,7 +148,7 @@ export async function generateWithUserConfig(
   request: UnifiedChatRequest,
   preferredProvider?: LlmProvider,
 ): Promise<UnifiedChatResponse> {
-  const runtimeConfig = await resolveRuntimeConfig(
+  const runtimeConfig = await resolveRuntimeConfigForUser(
     userId,
     preferredProvider,
     request.configId,
@@ -179,7 +179,7 @@ export async function streamWithUserConfig(
   provider: LlmProvider;
   modelId: string;
 }> {
-  const runtimeConfig = await resolveRuntimeConfig(
+  const runtimeConfig = await resolveRuntimeConfigForUser(
     userId,
     preferredProvider,
     request.configId,
@@ -201,7 +201,7 @@ export async function streamWithUserConfig(
   };
 }
 
-async function resolveRuntimeConfig(
+export async function resolveRuntimeConfigForUser(
   userId: string,
   preferredProvider?: LlmProvider,
   preferredConfigId?: string,
@@ -257,7 +257,7 @@ export async function resolveRuntimeConfigForTest(
   preferredProvider?: LlmProvider,
   preferredConfigId?: string,
 ): Promise<LlmRuntimeConfig> {
-  return resolveRuntimeConfig(userId, preferredProvider, preferredConfigId);
+  return resolveRuntimeConfigForUser(userId, preferredProvider, preferredConfigId);
 }
 
 function defaultEndpoint(provider: LlmProvider): string {
@@ -469,7 +469,7 @@ export async function streamWithAgentToolsAndUserConfig(
   modelId: string;
   getStopInfo: () => AgentLoopStreamStopInfo | null;
 }> {
-  const runtimeConfig = await resolveRuntimeConfig(
+  const runtimeConfig = await resolveRuntimeConfigForUser(
     userId,
     preferredProvider,
     request.configId,

--- a/apps/node_backend/src/routes/auth.test.ts
+++ b/apps/node_backend/src/routes/auth.test.ts
@@ -1,3 +1,4 @@
+import express from 'express';
 import { describe, expect, it, vi } from 'vitest';
 import { isAllowedReturnTo } from './auth_return_to.js';
 
@@ -15,6 +16,7 @@ vi.mock('../services/userService.js', () => ({
 }));
 
 import {
+  default as authRoutes,
   buildPostLoginRedirectTarget,
   decodeOAuthState,
   validateOAuthCallbackState,
@@ -118,6 +120,36 @@ describe('auth return_to validation', () => {
         nodeEnv: 'production',
       })
     ).toBe(false);
+  });
+});
+
+describe('auth route limiter scope', () => {
+  it('does not rate limit later /api routes when authRoutes is mounted at /api for legacy callbacks', async () => {
+    const app = express();
+    app.use('/api', authRoutes);
+    app.get('/api/config/noop', (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    const server = app.listen(0, '127.0.0.1');
+    try {
+      await new Promise<void>((resolve) => server.once('listening', resolve));
+      const address = server.address();
+      if (!address || typeof address !== 'object') {
+        throw new Error('Test server did not expose an address');
+      }
+      const baseUrl = `http://127.0.0.1:${address.port}`;
+      for (let i = 0; i < 40; i += 1) {
+        const response = await fetch(`${baseUrl}/api/config/noop`, {
+          headers: { Authorization: 'Bearer test-token' },
+        });
+        expect(response.status).toBe(200);
+      }
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
   });
 });
 

--- a/apps/node_backend/src/routes/auth.ts
+++ b/apps/node_backend/src/routes/auth.ts
@@ -20,7 +20,20 @@ const anonymousAuthLimiter = rateLimit({
     error: 'Too many anonymous auth requests from this IP, please try again later.',
   },
 });
-router.use(anonymousAuthLimiter);
+
+function isAnonymousAuthPath(pathname: string): boolean {
+  return pathname === '/github' ||
+    pathname === '/github/callback' ||
+    pathname === '/callback';
+}
+
+router.use((req, res, next) => {
+  if (!isAnonymousAuthPath(req.path)) {
+    next();
+    return;
+  }
+  anonymousAuthLimiter(req, res, next);
+});
 
 interface GitHubUser {
   id: number;

--- a/apps/node_backend/src/routes/chat.test.ts
+++ b/apps/node_backend/src/routes/chat.test.ts
@@ -1573,6 +1573,107 @@ describe("chat routes", () => {
     ]);
   });
 
+  it('attaches generated media from successful agent tool results to the final assistant message', async () => {
+    const generatedMedia = {
+      id: 'generated-image-1',
+      kind: 'image',
+      origin: 'generated_image',
+      status: 'ready',
+      mimeType: 'image/png',
+      filename: 'generated-image-1.png',
+      sizeBytes: 12345,
+      previewUrl: '/api/media/generated-image-1/preview',
+      contentUrl: '/api/media/generated-image-1/content',
+      downloadUrl: '/api/media/generated-image-1/download',
+      channelRelativePath: 'media/generated/images/generated-image-1.png',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const implGeneratedMedia = async (...args: any[]) => {
+      const options = args[3] as {
+        onStepFinish?: (
+          stepResults: Array<{
+            toolName: string;
+            args: Record<string, unknown>;
+            result: unknown;
+          }>,
+        ) => Promise<void>;
+      };
+      if (options.onStepFinish) {
+        await options.onStepFinish([
+          {
+            toolName: 'media_image_generate',
+            args: {
+              prompt: 'Generate a Mars greenhouse',
+            },
+            result: {
+              ok: true,
+              toolName: 'media.image.generate',
+              data: {
+                job: {
+                  id: 'job-generated-image-1',
+                  kind: 'image',
+                  status: 'succeeded',
+                  resultMediaId: 'generated-image-1',
+                  resultMedia: generatedMedia,
+                },
+                media: generatedMedia,
+              },
+              error: null,
+            },
+          },
+        ]);
+      }
+      return {
+        textStream: (async function* () {
+          yield '图像生成完成\n\n';
+          yield '[image: media/generated/images/generated-image-1.png (image/png)]\n\n';
+          yield '渲染日志';
+        })(),
+        provider: 'google_ai_studio',
+        modelId: 'gemini-flash-latest',
+      };
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    streamWithAgentToolsAndUserConfigMock.mockImplementationOnce(implGeneratedMedia as any);
+
+    const response = await fetch(`${baseUrl}/api/chat/respond`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        taskId: 'task-generated-media-1',
+        idempotencyKey: 'idem-generated-media-1',
+        channelId: 'default',
+        sessionId: 'session:default:main',
+        userMessageId: 'msg-u-generated-media-1',
+        assistantMessageId: 'msg-a-generated-media-1',
+        userMessage: 'generate an image',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(upsertMessagesMock).toHaveBeenCalledWith('user-123', [
+      expect.objectContaining({
+        messageId: 'msg-a-generated-media-1:ts:1',
+        metadata: expect.objectContaining({
+          mediaAttachments: [generatedMedia],
+        }),
+      }),
+    ]);
+    expect(upsertMessagesMock).toHaveBeenCalledWith('user-123', [
+      expect.objectContaining({
+        messageId: 'msg-a-generated-media-1',
+        role: 'assistant',
+        taskState: 'completed',
+        content: '图像生成完成\n\n渲染日志',
+        metadata: expect.objectContaining({
+          mediaAttachments: [generatedMedia],
+        }),
+      }),
+    ]);
+  });
+
   it('writes reasoning DB message when onReasoningChunk callback is triggered', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const implR = async (...args: any[]) => {

--- a/apps/node_backend/src/routes/chat.test.ts
+++ b/apps/node_backend/src/routes/chat.test.ts
@@ -715,7 +715,11 @@ describe("chat routes", () => {
 
     expect(response.status).toBe(200);
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(buildAgentToolsMock).toHaveBeenCalledWith('user-123');
+    expect(buildAgentToolsMock).toHaveBeenCalledWith('user-123', {
+      channelId: 'default',
+      threadId: null,
+      defaultPrompt: '/channel create ops',
+    });
     expect(streamWithAgentToolsAndUserConfigMock).toHaveBeenCalled();
   });
 
@@ -739,7 +743,11 @@ describe("chat routes", () => {
 
     expect(response.status).toBe(200);
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(buildAgentToolsMock).toHaveBeenCalledWith('user-123');
+    expect(buildAgentToolsMock).toHaveBeenCalledWith('user-123', {
+      channelId: 'default',
+      threadId: null,
+      defaultPrompt: 'create a channel called ops',
+    });
     expect(streamWithAgentToolsAndUserConfigMock).toHaveBeenCalled();
   });
 

--- a/apps/node_backend/src/routes/chat.ts
+++ b/apps/node_backend/src/routes/chat.ts
@@ -109,6 +109,88 @@ function toolResultSucceeded(result: unknown): boolean {
   return isRecord(result) && result.ok === true;
 }
 
+function isGeneratedMediaToolName(toolName: string): boolean {
+  return toolName === "media_image_generate" || toolName === "media_video_generate";
+}
+
+function isMediaAttachmentMetadata(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === "string" &&
+    typeof value.kind === "string" &&
+    typeof value.origin === "string" &&
+    typeof value.mimeType === "string" &&
+    typeof value.filename === "string" &&
+    typeof value.previewUrl === "string" &&
+    typeof value.contentUrl === "string" &&
+    typeof value.downloadUrl === "string"
+  );
+}
+
+function mediaAttachmentsForToolResult(
+  stepResult: AgentLoopStepResult,
+): Record<string, unknown>[] {
+  if (!isGeneratedMediaToolName(stepResult.toolName) || !toolResultSucceeded(stepResult.result)) {
+    return [];
+  }
+  const resultData = isRecord(stepResult.result)
+    ? isRecord(stepResult.result.data)
+      ? stepResult.result.data
+      : {}
+    : {};
+  const attachments: Record<string, unknown>[] = [];
+  if (isMediaAttachmentMetadata(resultData.media)) {
+    attachments.push(resultData.media);
+  }
+  const resultJob = isRecord(resultData.job) ? resultData.job : null;
+  if (isMediaAttachmentMetadata(resultJob?.resultMedia)) {
+    attachments.push(resultJob.resultMedia);
+  }
+  return attachments;
+}
+
+function appendMediaAttachments(
+  target: Record<string, unknown>[],
+  additions: Record<string, unknown>[],
+): void {
+  const seenIds = new Set(
+    target
+      .map((item) => item.id)
+      .filter((id): id is string => typeof id === "string" && id.trim().length > 0),
+  );
+  for (const addition of additions) {
+    const id = typeof addition.id === "string" ? addition.id.trim() : "";
+    if (!id || seenIds.has(id)) continue;
+    seenIds.add(id);
+    target.push(addition);
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stripGeneratedMediaReferenceText(
+  content: string,
+  attachments: Record<string, unknown>[],
+): string {
+  if (attachments.length === 0 || content.length === 0) return content;
+  let next = content;
+  for (const attachment of attachments) {
+    const relativePath =
+      typeof attachment.channelRelativePath === "string"
+        ? attachment.channelRelativePath.trim()
+        : "";
+    if (!relativePath) continue;
+    const markerPattern = new RegExp(
+      `\\[\\s*(?:image|video):\\s*${escapeRegExp(relativePath)}(?:\\s*\\([^\\)]*\\))?\\s*\\]`,
+      "g",
+    );
+    next = next.replace(markerPattern, "");
+  }
+  return next.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
 function invalidationsForToolResult(
   stepResult: AgentLoopStepResult,
 ): ChatClientInvalidation[] {
@@ -846,6 +928,7 @@ async function runDefaultRouterRespondAsync(params: {
     let completedToolCallCount = 0;
     let failedToolCallCount = 0;
     const collectedInvalidations: ChatClientInvalidation[] = [];
+    const collectedMediaAttachments: Record<string, unknown>[] = [];
     try {
       collectedInvalidations.push(
         ...(await insertFirstMessageExactThreadName({
@@ -893,6 +976,12 @@ async function runDefaultRouterRespondAsync(params: {
             const stepInvalidations = dedupeInvalidations(
               stepResults.flatMap(invalidationsForToolResult),
             );
+            const stepMediaAttachments: Record<string, unknown>[] = [];
+            appendMediaAttachments(
+              stepMediaAttachments,
+              stepResults.flatMap(mediaAttachmentsForToolResult),
+            );
+            appendMediaAttachments(collectedMediaAttachments, stepMediaAttachments);
             collectedInvalidations.push(...stepInvalidations);
             const stepSuffix = `:ts:${toolStepIndex}`;
             const stepMessageId = `${assistantMessageId.slice(0, 255 - stepSuffix.length)}${stepSuffix}`;
@@ -929,6 +1018,9 @@ async function runDefaultRouterRespondAsync(params: {
 	                  ...(stepInvalidations.length > 0
 	                    ? { invalidations: stepInvalidations }
 	                    : {}),
+                    ...(stepMediaAttachments.length > 0
+                      ? { mediaAttachments: stepMediaAttachments }
+                      : {}),
 	                },
 	                createdAt: null,
 	              },
@@ -1171,7 +1263,7 @@ async function runDefaultRouterRespondAsync(params: {
       sessionId: acceptedSessionId,
       threadId,
       role: "assistant",
-      content,
+      content: stripGeneratedMediaReferenceText(content, collectedMediaAttachments),
       taskState: "dispatched",
       checkpointCursor: null,
       metadata: {
@@ -1183,6 +1275,9 @@ async function runDefaultRouterRespondAsync(params: {
         }),
         provider,
         streamMode: "model-chunk",
+        ...(collectedMediaAttachments.length > 0
+          ? { mediaAttachments: collectedMediaAttachments }
+          : {}),
       },
       createdAt: null,
     });
@@ -1236,7 +1331,9 @@ async function runDefaultRouterRespondAsync(params: {
     const finalInvalidations = dedupeInvalidations(collectedInvalidations);
     const streamStopInfo = getStreamStopInfo();
     const emptyFinalStopReason =
-      assistantContent.trim().length === 0 && totalToolCallCount > 0
+      assistantContent.trim().length === 0 &&
+      collectedMediaAttachments.length === 0 &&
+      totalToolCallCount > 0
         ? classifyEmptyFinalStopReason({
             totalToolCallCount,
             loopMaxToolCalls,
@@ -1245,14 +1342,20 @@ async function runDefaultRouterRespondAsync(params: {
             streamStopInfo,
           })
         : null;
+    const visibleAssistantContent = stripGeneratedMediaReferenceText(
+      assistantContent,
+      collectedMediaAttachments,
+    );
+    const hasVisibleAssistantContent = visibleAssistantContent.trim().length > 0;
+    const hasGeneratedMediaAttachments = collectedMediaAttachments.length > 0;
     const finalContent =
-      assistantContent.trim().length > 0
-        ? assistantContent
+      hasVisibleAssistantContent
+        ? visibleAssistantContent
         : emptyFinalStopReason != null
           ? emptyFinalStopReason.message
-          : assistantContent;
+          : visibleAssistantContent;
     const finalTaskState =
-      assistantContent.trim().length === 0 && totalToolCallCount > 0
+      !hasVisibleAssistantContent && !hasGeneratedMediaAttachments && totalToolCallCount > 0
         ? "failed"
         : "completed";
     const agentLoopStopReason =
@@ -1289,6 +1392,9 @@ async function runDefaultRouterRespondAsync(params: {
           }),
           provider,
           streamMode: "model-chunk",
+          ...(collectedMediaAttachments.length > 0
+            ? { mediaAttachments: collectedMediaAttachments }
+            : {}),
           ...(finalInvalidations.length > 0
             ? { invalidations: finalInvalidations }
             : {}),

--- a/apps/node_backend/src/routes/chat.ts
+++ b/apps/node_backend/src/routes/chat.ts
@@ -869,7 +869,11 @@ async function runDefaultRouterRespondAsync(params: {
     // plain natural language.  The managedStream generator yields text deltas
     // eagerly for tool-free steps, so streaming UX is equivalent to the direct
     // streamWithUserConfig path for ordinary chat messages.
-    const agentTools = buildAgentTools(userId);
+    const agentTools = buildAgentTools(userId, {
+      channelId,
+      threadId,
+      defaultPrompt: userMessage,
+    });
     const streamResult = await streamWithAgentToolsAndUserConfig(
         userId,
         {

--- a/apps/node_backend/src/routes/media.test.ts
+++ b/apps/node_backend/src/routes/media.test.ts
@@ -1,0 +1,189 @@
+import express from 'express';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  generateImageMediaMock,
+  startVideoGenerationJobMock,
+  getMediaGenerationJobForUserMock,
+  refreshVideoGenerationJobForUserMock,
+  mediaGenerationJobToDtoMock,
+  mediaAssetToDtoMock,
+} = vi.hoisted(() => ({
+  generateImageMediaMock: vi.fn(),
+  startVideoGenerationJobMock: vi.fn(),
+  getMediaGenerationJobForUserMock: vi.fn(),
+  refreshVideoGenerationJobForUserMock: vi.fn(),
+  mediaGenerationJobToDtoMock: vi.fn((job: Record<string, unknown>, media?: Record<string, unknown> | null) => ({
+    id: job.id,
+    kind: job.kind,
+    status: job.status,
+    resultMediaId: media?.id ?? job.resultMediaId ?? null,
+  })),
+  mediaAssetToDtoMock: vi.fn((media: Record<string, unknown>) => ({
+    id: media.id,
+    kind: media.kind,
+    previewUrl: `/api/media/${media.id}/preview`,
+  })),
+}));
+
+vi.mock('../middleware/auth.js', () => ({
+  authenticate: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    (req as express.Request & { userId?: string }).userId = 'user-123';
+    next();
+  },
+}));
+
+vi.mock('../services/mediaGenerationService.js', () => {
+  class MockMediaGenerationError extends Error {
+    constructor(message: string, readonly statusCode = 400) {
+      super(message);
+      this.name = 'MediaGenerationError';
+    }
+  }
+  return {
+    generateImageMedia: generateImageMediaMock,
+    startVideoGenerationJob: startVideoGenerationJobMock,
+    getMediaGenerationJobForUser: getMediaGenerationJobForUserMock,
+    refreshVideoGenerationJobForUser: refreshVideoGenerationJobForUserMock,
+    mediaGenerationJobToDto: mediaGenerationJobToDtoMock,
+    MediaGenerationError: MockMediaGenerationError,
+  };
+});
+
+vi.mock('../services/mediaService.js', () => ({
+  createImageMediaAsset: vi.fn(),
+  getMediaAssetForUser: vi.fn(),
+  mediaAssetToDto: mediaAssetToDtoMock,
+  resolveMediaAssetPath: vi.fn(),
+}));
+
+let server: ReturnType<express.Express['listen']> | null = null;
+let baseUrl = '';
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json({ limit: '5mb' }));
+  const { default: mediaRoutes } = await import('./media.js');
+  app.use('/api/media', mediaRoutes);
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const address = server?.address();
+      if (address && typeof address === 'object') {
+        baseUrl = `http://127.0.0.1:${address.port}`;
+      }
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    if (!server) return resolve();
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+describe('media routes', () => {
+  beforeEach(() => {
+    generateImageMediaMock.mockReset();
+    startVideoGenerationJobMock.mockReset();
+    getMediaGenerationJobForUserMock.mockReset();
+    refreshVideoGenerationJobForUserMock.mockReset();
+    mediaGenerationJobToDtoMock.mockClear();
+    mediaAssetToDtoMock.mockClear();
+  });
+
+  it('creates a provider-side image generation and returns the generated media', async () => {
+    generateImageMediaMock.mockResolvedValue({
+      job: { id: 'job-1', kind: 'image', status: 'succeeded', resultMediaId: 'media-1' },
+      media: { id: 'media-1', kind: 'image' },
+    });
+
+    const response = await fetch(`${baseUrl}/api/media/image-generations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        channelId: 'default',
+        threadId: 'thread-1',
+        prompt: 'Make a tiny studio photo',
+        referenceMediaIds: ['image-1'],
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(generateImageMediaMock).toHaveBeenCalledWith({
+      userId: 'user-123',
+      channelId: 'default',
+      threadId: 'thread-1',
+      prompt: 'Make a tiny studio photo',
+      referenceMediaIds: ['image-1'],
+      model: null,
+      configId: null,
+    });
+    const body = (await response.json()) as {
+      media?: { id?: string; previewUrl?: string };
+    };
+    expect(body.media).toEqual(
+      expect.objectContaining({ id: 'media-1', previewUrl: '/api/media/media-1/preview' }),
+    );
+  });
+
+  it('starts a provider-side video generation job', async () => {
+    startVideoGenerationJobMock.mockResolvedValue({
+      id: 'job-video-1',
+      kind: 'video',
+      status: 'running',
+      resultMediaId: null,
+    });
+
+    const response = await fetch(`${baseUrl}/api/media/video-generations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        channelId: 'default',
+        prompt: 'A product turntable video',
+        referenceMediaIds: ['image-1', 'image-2'],
+        durationSeconds: 8,
+        aspectRatio: '16:9',
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    expect(startVideoGenerationJobMock).toHaveBeenCalledWith({
+      userId: 'user-123',
+      channelId: 'default',
+      threadId: null,
+      prompt: 'A product turntable video',
+      referenceMediaIds: ['image-1', 'image-2'],
+      firstFrameMediaId: null,
+      lastFrameMediaId: null,
+      aspectRatio: '16:9',
+      durationSeconds: 8,
+      resolution: null,
+      model: null,
+      configId: null,
+    });
+    const body = (await response.json()) as {
+      job?: { id?: string; status?: string };
+    };
+    expect(body.job).toEqual(
+      expect.objectContaining({ id: 'job-video-1', status: 'running' }),
+    );
+  });
+
+  it('returns cached generation job state when refresh is false', async () => {
+    getMediaGenerationJobForUserMock.mockResolvedValue({
+      id: 'job-video-1',
+      kind: 'video',
+      status: 'running',
+      resultMediaId: null,
+    });
+
+    const response = await fetch(`${baseUrl}/api/media/generation-jobs/job-video-1?refresh=false`);
+
+    expect(response.status).toBe(200);
+    expect(getMediaGenerationJobForUserMock).toHaveBeenCalledWith('user-123', 'job-video-1');
+    expect(refreshVideoGenerationJobForUserMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/node_backend/src/routes/media.ts
+++ b/apps/node_backend/src/routes/media.ts
@@ -6,6 +6,14 @@ import {
   mediaAssetToDto,
   resolveMediaAssetPath,
 } from '../services/mediaService.js';
+import {
+  generateImageMedia,
+  getMediaGenerationJobForUser,
+  mediaGenerationJobToDto,
+  MediaGenerationError,
+  refreshVideoGenerationJobForUser,
+  startVideoGenerationJob,
+} from '../services/mediaGenerationService.js';
 
 const router = express.Router();
 router.use(authenticate);
@@ -16,12 +24,33 @@ function readString(value: unknown): string | null {
     : null;
 }
 
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function readPositiveInteger(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  const integer = Math.trunc(value);
+  return integer > 0 ? integer : null;
+}
+
 function sendMediaError(res: Response, error: unknown): void {
+  if (error instanceof MediaGenerationError) {
+    res.status(error.statusCode).json({ error: error.message });
+    return;
+  }
   const message = error instanceof Error ? error.message : String(error);
   if (
     message.includes('Unsupported image MIME type') ||
+    message.includes('Unsupported video MIME type') ||
     message.includes('Image data is empty') ||
+    message.includes('Video data is empty') ||
     message.includes('20MB') ||
+    message.includes('512MB') ||
     message.includes('Invalid channel-relative path')
   ) {
     res.status(400).json({ error: message });
@@ -60,6 +89,37 @@ router.post('/uploads', async (req: AuthRequest, res: Response) => {
   }
 });
 
+router.post('/image-generations', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const channelId = readString(req.body?.channelId);
+    const prompt = readString(req.body?.prompt);
+    if (!channelId || !prompt) {
+      res.status(400).json({ error: 'channelId and prompt are required' });
+      return;
+    }
+    const { job, media } = await generateImageMedia({
+      userId,
+      channelId,
+      threadId: readString(req.body?.threadId),
+      prompt,
+      referenceMediaIds: readStringArray(req.body?.referenceMediaIds),
+      model: readString(req.body?.model),
+      configId: readString(req.body?.configId),
+    });
+    res.status(201).json({
+      job: mediaGenerationJobToDto(job, media),
+      media: mediaAssetToDto(media),
+    });
+  } catch (error) {
+    sendMediaError(res, error);
+  }
+});
+
 router.post('/generated-images', async (req: AuthRequest, res: Response) => {
   try {
     const userId = req.userId;
@@ -88,6 +148,96 @@ router.post('/generated-images', async (req: AuthRequest, res: Response) => {
       prompt: readString(req.body?.prompt),
     });
     res.status(201).json({ media: mediaAssetToDto(asset) });
+  } catch (error) {
+    sendMediaError(res, error);
+  }
+});
+
+router.post('/video-generations', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const channelId = readString(req.body?.channelId);
+    const prompt = readString(req.body?.prompt);
+    if (!channelId || !prompt) {
+      res.status(400).json({ error: 'channelId and prompt are required' });
+      return;
+    }
+    const job = await startVideoGenerationJob({
+      userId,
+      channelId,
+      threadId: readString(req.body?.threadId),
+      prompt,
+      referenceMediaIds: readStringArray(req.body?.referenceMediaIds),
+      firstFrameMediaId: readString(req.body?.firstFrameMediaId),
+      lastFrameMediaId: readString(req.body?.lastFrameMediaId),
+      aspectRatio: readString(req.body?.aspectRatio),
+      durationSeconds: readPositiveInteger(req.body?.durationSeconds),
+      resolution: readString(req.body?.resolution),
+      model: readString(req.body?.model),
+      configId: readString(req.body?.configId),
+    });
+    res.status(202).json({ job: mediaGenerationJobToDto(job) });
+  } catch (error) {
+    sendMediaError(res, error);
+  }
+});
+
+router.get('/generation-jobs/:jobId', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const jobId = readString(req.params.jobId);
+    if (!jobId) {
+      res.status(400).json({ error: 'jobId is required' });
+      return;
+    }
+    const shouldRefresh = req.query.refresh !== 'false';
+    if (shouldRefresh) {
+      const { job, media } = await refreshVideoGenerationJobForUser({
+        userId,
+        jobId,
+        configId: readString(req.query.configId),
+      });
+      res.json({ job: mediaGenerationJobToDto(job, media), media: media ? mediaAssetToDto(media) : null });
+      return;
+    }
+    const job = await getMediaGenerationJobForUser(userId, jobId);
+    if (!job) {
+      res.status(404).json({ error: 'Media generation job not found' });
+      return;
+    }
+    const media = job.resultMediaId ? await getMediaAssetForUser(userId, job.resultMediaId) : null;
+    res.json({ job: mediaGenerationJobToDto(job, media), media: media ? mediaAssetToDto(media) : null });
+  } catch (error) {
+    sendMediaError(res, error);
+  }
+});
+
+router.post('/generation-jobs/:jobId/poll', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const jobId = readString(req.params.jobId);
+    if (!jobId) {
+      res.status(400).json({ error: 'jobId is required' });
+      return;
+    }
+    const { job, media } = await refreshVideoGenerationJobForUser({
+      userId,
+      jobId,
+      configId: readString(req.body?.configId),
+    });
+    res.json({ job: mediaGenerationJobToDto(job, media), media: media ? mediaAssetToDto(media) : null });
   } catch (error) {
     sendMediaError(res, error);
   }

--- a/apps/node_backend/src/services/channelFileService.ts
+++ b/apps/node_backend/src/services/channelFileService.ts
@@ -51,6 +51,7 @@ export async function ensureChannelBaseDirectories(channelId: string): Promise<v
   await fs.mkdir(path.join(channelDir, 'workspace'), { recursive: true });
   await fs.mkdir(path.join(channelDir, 'media', 'uploads'), { recursive: true });
   await fs.mkdir(path.join(channelDir, 'media', 'generated', 'images'), { recursive: true });
+  await fs.mkdir(path.join(channelDir, 'media', 'generated', 'videos'), { recursive: true });
   await fs.mkdir(path.join(channelDir, 'media', 'thumbnails'), { recursive: true });
   await fs.mkdir(path.join(channelDir, 'web', 'dist'), { recursive: true });
   await fs.mkdir(path.join(channelDir, 'jobs'), { recursive: true });

--- a/apps/node_backend/src/services/localAgentLoopService.test.ts
+++ b/apps/node_backend/src/services/localAgentLoopService.test.ts
@@ -773,7 +773,7 @@ describe('localAgentLoopService', () => {
     expect(tools.media_video_generate).toBeDefined();
     expect(tools.media_video_generate.parametersSchema).toMatchObject({
       type: 'object',
-      required: ['channelId', 'prompt'],
+      required: ['prompt'],
       properties: {
         referenceMediaIds: {
           type: 'array',
@@ -825,6 +825,45 @@ describe('localAgentLoopService', () => {
     expect(result.data?.media).toEqual(
       expect.objectContaining({ id: 'media-1', previewUrl: '/api/media/media-1/preview' }),
     );
+  });
+
+  it('injects current chat context into media generation agent tools', async () => {
+    generateImageMediaMock.mockResolvedValue({
+      job: {
+        id: 'job-context-1',
+        kind: 'image',
+        status: 'succeeded',
+        resultMediaId: 'media-context-1',
+      },
+      media: {
+        id: 'media-context-1',
+        kind: 'image',
+      },
+    });
+    const { buildAgentTools } = await import('./localAgentLoopService.js');
+
+    const tools = buildAgentTools('u-1', {
+      channelId: 'default',
+      threadId: 'thread-1',
+      defaultPrompt: 'Generate a pixel spaceship',
+    });
+    const result = await tools.media_image_generate.execute({});
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        toolName: 'media.image.generate',
+      }),
+    );
+    expect(generateImageMediaMock).toHaveBeenCalledWith({
+      userId: 'u-1',
+      channelId: 'default',
+      threadId: 'thread-1',
+      prompt: 'Generate a pixel spaceship',
+      referenceMediaIds: [],
+      model: null,
+      configId: null,
+    });
   });
 
   it('dispatches media_video_generate and returns a running job DTO', async () => {

--- a/apps/node_backend/src/services/localAgentLoopService.test.ts
+++ b/apps/node_backend/src/services/localAgentLoopService.test.ts
@@ -4,6 +4,14 @@ const upsertChatScopeSettingMock = vi.fn();
 const upsertChatChannelMock = vi.fn();
 const listChatScopeSettingsMock = vi.fn().mockResolvedValue([]);
 const listChatChannelsMock = vi.fn().mockResolvedValue([]);
+const generateImageMediaMock = vi.fn();
+const startVideoGenerationJobMock = vi.fn();
+const mediaAssetToDtoMock = vi.fn((asset: Record<string, unknown>) => ({
+  id: asset.id,
+  kind: asset.kind,
+  previewUrl: `/api/media/${asset.id}/preview`,
+  downloadUrl: `/api/media/${asset.id}/download`,
+}));
 
 vi.mock('./chatRouterService.js', () => ({
   CHAT_ROUTER_LOCAL: 'local',
@@ -111,10 +119,38 @@ vi.mock('./scheduledActionService.js', () => ({
   deleteScheduledAction: vi.fn().mockResolvedValue({ deleted: true }),
 }));
 
+vi.mock('./mediaGenerationService.js', () => {
+  class MockMediaGenerationError extends Error {
+    constructor(message: string, readonly statusCode = 400) {
+      super(message);
+      this.name = 'MediaGenerationError';
+    }
+  }
+
+  return {
+    generateImageMedia: generateImageMediaMock,
+    startVideoGenerationJob: startVideoGenerationJobMock,
+    mediaGenerationJobToDto: vi.fn((job: Record<string, unknown>, media?: Record<string, unknown>) => ({
+      id: job.id,
+      kind: job.kind,
+      status: job.status,
+      resultMediaId: media?.id ?? job.resultMediaId ?? null,
+    })),
+    MediaGenerationError: MockMediaGenerationError,
+  };
+});
+
+vi.mock('./mediaService.js', () => ({
+  mediaAssetToDto: mediaAssetToDtoMock,
+}));
+
 describe('localAgentLoopService', () => {
   beforeEach(() => {
     upsertChatScopeSettingMock.mockReset();
     upsertChatChannelMock.mockReset();
+    generateImageMediaMock.mockReset();
+    startVideoGenerationJobMock.mockReset();
+    mediaAssetToDtoMock.mockClear();
   });
 
   it('rejects tools outside allowlist', async () => {
@@ -722,6 +758,116 @@ describe('localAgentLoopService', () => {
       { name: 'Alice', age: '30', active: 'true' },
       { name: 'Bob', score: '7', archived: null },
     ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Media generation tool tests
+  // -------------------------------------------------------------------------
+
+  it('exposes media generation tools in buildAgentTools', async () => {
+    const { buildAgentTools } = await import('./localAgentLoopService.js');
+
+    const tools = buildAgentTools('u-1');
+
+    expect(tools.media_image_generate).toBeDefined();
+    expect(tools.media_video_generate).toBeDefined();
+    expect(tools.media_video_generate.parametersSchema).toMatchObject({
+      type: 'object',
+      required: ['channelId', 'prompt'],
+      properties: {
+        referenceMediaIds: {
+          type: 'array',
+          maxItems: 3,
+        },
+      },
+    });
+  });
+
+  it('dispatches media_image_generate and returns job and media DTOs', async () => {
+    generateImageMediaMock.mockResolvedValue({
+      job: {
+        id: 'job-1',
+        kind: 'image',
+        status: 'succeeded',
+        resultMediaId: 'media-1',
+      },
+      media: {
+        id: 'media-1',
+        kind: 'image',
+      },
+    });
+    const {
+      executeInternalTool,
+      INTERNAL_TOOL_MEDIA_IMAGE_GENERATE,
+    } = await import('./localAgentLoopService.js');
+
+    const result = await executeInternalTool({
+      userId: 'u-1',
+      toolName: INTERNAL_TOOL_MEDIA_IMAGE_GENERATE,
+      args: {
+        channelId: 'default',
+        threadId: 'thread-1',
+        prompt: 'Create a tiny isometric house',
+        referenceMediaIds: ['media-ref'],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(generateImageMediaMock).toHaveBeenCalledWith({
+      userId: 'u-1',
+      channelId: 'default',
+      threadId: 'thread-1',
+      prompt: 'Create a tiny isometric house',
+      referenceMediaIds: ['media-ref'],
+      model: null,
+      configId: null,
+    });
+    expect(result.data?.media).toEqual(
+      expect.objectContaining({ id: 'media-1', previewUrl: '/api/media/media-1/preview' }),
+    );
+  });
+
+  it('dispatches media_video_generate and returns a running job DTO', async () => {
+    startVideoGenerationJobMock.mockResolvedValue({
+      id: 'job-video-1',
+      kind: 'video',
+      status: 'running',
+      resultMediaId: null,
+    });
+    const {
+      executeInternalTool,
+      INTERNAL_TOOL_MEDIA_VIDEO_GENERATE,
+    } = await import('./localAgentLoopService.js');
+
+    const result = await executeInternalTool({
+      userId: 'u-1',
+      toolName: INTERNAL_TOOL_MEDIA_VIDEO_GENERATE,
+      args: {
+        channelId: 'default',
+        prompt: 'Animate this product photo',
+        referenceMediaIds: ['image-1', 'image-2'],
+        durationSeconds: 8,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(startVideoGenerationJobMock).toHaveBeenCalledWith({
+      userId: 'u-1',
+      channelId: 'default',
+      threadId: null,
+      prompt: 'Animate this product photo',
+      referenceMediaIds: ['image-1', 'image-2'],
+      firstFrameMediaId: null,
+      lastFrameMediaId: null,
+      aspectRatio: null,
+      durationSeconds: 8,
+      resolution: null,
+      model: null,
+      configId: null,
+    });
+    expect(result.data?.job).toEqual(
+      expect.objectContaining({ id: 'job-video-1', status: 'running' }),
+    );
   });
 
   // -------------------------------------------------------------------------

--- a/apps/node_backend/src/services/localAgentLoopService.ts
+++ b/apps/node_backend/src/services/localAgentLoopService.ts
@@ -214,6 +214,12 @@ export interface ExecuteInternalToolSequenceResult {
   failedCall: ExecuteInternalToolResult | null;
 }
 
+export interface AgentToolContext {
+  channelId?: string | null;
+  threadId?: string | null;
+  defaultPrompt?: string | null;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -1540,9 +1546,28 @@ export async function executeInternalToolSequence(params: {
  * The tool implementations delegate to `executeInternalTool` using the
  * canonical dot-delimited internal names.
  */
-export function buildAgentTools(userId: string): Record<string, AgentTool> {
-  const runTool = (toolName: string, args: Record<string, unknown>) =>
-    executeInternalTool({ userId, toolName, args });
+export function buildAgentTools(
+  userId: string,
+  context: AgentToolContext = {},
+): Record<string, AgentTool> {
+  const runTool = (toolName: string, args: Record<string, unknown>) => {
+    const effectiveArgs = { ...args };
+    if (
+      toolName === INTERNAL_TOOL_MEDIA_IMAGE_GENERATE ||
+      toolName === INTERNAL_TOOL_MEDIA_VIDEO_GENERATE
+    ) {
+      if (typeof effectiveArgs.channelId !== 'string' && context.channelId) {
+        effectiveArgs.channelId = context.channelId;
+      }
+      if (typeof effectiveArgs.threadId !== 'string' && context.threadId) {
+        effectiveArgs.threadId = context.threadId;
+      }
+      if (typeof effectiveArgs.prompt !== 'string' && context.defaultPrompt) {
+        effectiveArgs.prompt = context.defaultPrompt;
+      }
+    }
+    return executeInternalTool({ userId, toolName, args: effectiveArgs });
+  };
 
   return {
     chat_channel_instruction_set: {
@@ -1773,7 +1798,7 @@ export function buildAgentTools(userId: string): Record<string, AgentTool> {
             items: { type: 'string' },
           },
         },
-        required: ['channelId', 'prompt'],
+        required: ['prompt'],
         additionalProperties: false,
       },
       execute: (args) => runTool(INTERNAL_TOOL_MEDIA_IMAGE_GENERATE, args),
@@ -1828,7 +1853,7 @@ export function buildAgentTools(userId: string): Record<string, AgentTool> {
             description: 'Optional Veo output resolution.',
           },
         },
-        required: ['channelId', 'prompt'],
+        required: ['prompt'],
         additionalProperties: false,
       },
       execute: (args) => runTool(INTERNAL_TOOL_MEDIA_VIDEO_GENERATE, args),

--- a/apps/node_backend/src/services/localAgentLoopService.ts
+++ b/apps/node_backend/src/services/localAgentLoopService.ts
@@ -59,6 +59,13 @@ import {
   type CreateScheduledActionInput,
   type UpdateScheduledActionInput,
 } from './scheduledActionService.js';
+import {
+  generateImageMedia,
+  mediaGenerationJobToDto,
+  startVideoGenerationJob,
+  MediaGenerationError,
+} from './mediaGenerationService.js';
+import { mediaAssetToDto } from './mediaService.js';
 import type { AgentTool } from '../llm/types.js';
 
 export const INTERNAL_TOOL_CHAT_CHANNEL_INSTRUCTION_SET = 'chat.channel.instruction.set';
@@ -71,6 +78,10 @@ export const INTERNAL_TOOL_CHAT_CHANNEL_LIST = 'chat.channel.list';
 export const INTERNAL_TOOL_CHAT_CHANNEL_GET = 'chat.channel.get';
 export const INTERNAL_TOOL_CHAT_THREAD_LIST = 'chat.thread.list';
 export const INTERNAL_TOOL_CHAT_THREAD_GET = 'chat.thread.get';
+
+// Media generation tools
+export const INTERNAL_TOOL_MEDIA_IMAGE_GENERATE = 'media.image.generate';
+export const INTERNAL_TOOL_MEDIA_VIDEO_GENERATE = 'media.video.generate';
 
 // Todo list tools (parent entities that group todo items)
 export const INTERNAL_TOOL_TODO_LIST_CREATE = 'todolist.create';
@@ -131,6 +142,8 @@ export const INTERNAL_TOOLS = [
   INTERNAL_TOOL_CHAT_CHANNEL_GET,
   INTERNAL_TOOL_CHAT_THREAD_LIST,
   INTERNAL_TOOL_CHAT_THREAD_GET,
+  INTERNAL_TOOL_MEDIA_IMAGE_GENERATE,
+  INTERNAL_TOOL_MEDIA_VIDEO_GENERATE,
   INTERNAL_TOOL_TODO_LIST_CREATE,
   INTERNAL_TOOL_TODO_LIST_LIST,
   INTERNAL_TOOL_TODO_LIST_GET,
@@ -183,7 +196,7 @@ export interface ExecuteInternalToolResult {
   data: Record<string, unknown> | null;
   error:
     | {
-        code: 'invalid_args' | 'not_implemented' | 'tool_not_allowed' | 'not_found';
+        code: 'invalid_args' | 'not_implemented' | 'tool_not_allowed' | 'not_found' | 'provider_error';
         message: string;
       }
     | null;
@@ -302,6 +315,22 @@ function invalidNoteMutation(toolName: string, error: unknown): ExecuteInternalT
       code: 'invalid_args',
       message: error instanceof Error ? error.message : 'Invalid note mutation',
     },
+  };
+}
+
+function mediaGenerationFailure(toolName: string, error: unknown): ExecuteInternalToolResult {
+  const message = error instanceof Error ? error.message : 'Media generation failed';
+  const code =
+    error instanceof MediaGenerationError && error.statusCode === 404
+      ? 'not_found'
+      : error instanceof MediaGenerationError && error.statusCode >= 500
+        ? 'provider_error'
+        : 'invalid_args';
+  return {
+    ok: false,
+    toolName,
+    data: null,
+    error: { code, message },
   };
 }
 
@@ -809,6 +838,97 @@ export async function executeInternalTool(
         };
       }
       return renameThread({ userId, channelId, threadId, displayName });
+    }
+    case INTERNAL_TOOL_MEDIA_IMAGE_GENERATE: {
+      const channelId = readStringArg(args, 'channelId', MAX_IDENTIFIER_LENGTH);
+      const threadId = readStringArg(args, 'threadId', MAX_IDENTIFIER_LENGTH);
+      const prompt = readStringArg(args, 'prompt');
+      const referenceMediaIds = readLineArrayArg(args, 'referenceMediaIds') ?? [];
+      const model = readStringArg(args, 'model', MAX_IDENTIFIER_LENGTH);
+      const configId = readStringArg(args, 'configId', MAX_IDENTIFIER_LENGTH);
+      if (!channelId || !prompt) {
+        return {
+          ok: false,
+          toolName,
+          data: null,
+          error: {
+            code: 'invalid_args',
+            message: 'channelId and prompt are required string arguments',
+          },
+        };
+      }
+      try {
+        const { job, media } = await generateImageMedia({
+          userId,
+          channelId,
+          threadId,
+          prompt,
+          referenceMediaIds,
+          model,
+          configId,
+        });
+        return {
+          ok: true,
+          toolName,
+          data: {
+            job: mediaGenerationJobToDto(job, media),
+            media: mediaAssetToDto(media),
+          },
+          error: null,
+        };
+      } catch (error) {
+        return mediaGenerationFailure(toolName, error);
+      }
+    }
+    case INTERNAL_TOOL_MEDIA_VIDEO_GENERATE: {
+      const channelId = readStringArg(args, 'channelId', MAX_IDENTIFIER_LENGTH);
+      const threadId = readStringArg(args, 'threadId', MAX_IDENTIFIER_LENGTH);
+      const prompt = readStringArg(args, 'prompt');
+      const referenceMediaIds = readLineArrayArg(args, 'referenceMediaIds') ?? [];
+      const firstFrameMediaId = readStringArg(args, 'firstFrameMediaId', MAX_IDENTIFIER_LENGTH);
+      const lastFrameMediaId = readStringArg(args, 'lastFrameMediaId', MAX_IDENTIFIER_LENGTH);
+      const aspectRatio = readStringArg(args, 'aspectRatio', MAX_IDENTIFIER_LENGTH);
+      const durationSeconds = readPositiveIntegerArg(args, 'durationSeconds');
+      const resolution = readStringArg(args, 'resolution', MAX_IDENTIFIER_LENGTH);
+      const model = readStringArg(args, 'model', MAX_IDENTIFIER_LENGTH);
+      const configId = readStringArg(args, 'configId', MAX_IDENTIFIER_LENGTH);
+      if (!channelId || !prompt) {
+        return {
+          ok: false,
+          toolName,
+          data: null,
+          error: {
+            code: 'invalid_args',
+            message: 'channelId and prompt are required string arguments',
+          },
+        };
+      }
+      try {
+        const job = await startVideoGenerationJob({
+          userId,
+          channelId,
+          threadId,
+          prompt,
+          referenceMediaIds,
+          firstFrameMediaId,
+          lastFrameMediaId,
+          aspectRatio,
+          durationSeconds,
+          resolution,
+          model,
+          configId,
+        });
+        return {
+          ok: true,
+          toolName,
+          data: {
+            job: mediaGenerationJobToDto(job),
+          },
+          error: null,
+        };
+      } catch (error) {
+        return mediaGenerationFailure(toolName, error);
+      }
     }
     // -------------------------------------------------------------------------
     case INTERNAL_TOOL_TODO_LIST_CREATE: {
@@ -1626,6 +1746,92 @@ export function buildAgentTools(userId: string): Record<string, AgentTool> {
         additionalProperties: false,
       },
       execute: (args) => runTool(INTERNAL_TOOL_CHAT_THREAD_RENAME, args),
+    },
+
+    media_image_generate: {
+      description:
+        'Generate a durable image attachment in a Bricks channel using Gemini image generation. ' +
+        'Use when the user explicitly asks to create or edit an image. For image editing, pass uploaded image media IDs as referenceMediaIds.',
+      parametersSchema: {
+        type: 'object',
+        properties: {
+          channelId: {
+            type: 'string',
+            description: 'The channel where the generated image should be stored.',
+          },
+          threadId: {
+            type: 'string',
+            description: 'Optional thread identifier for the generated media.',
+          },
+          prompt: {
+            type: 'string',
+            description: 'The image generation or editing prompt.',
+          },
+          referenceMediaIds: {
+            type: 'array',
+            description: 'Optional image media IDs to use as references for image editing.',
+            items: { type: 'string' },
+          },
+        },
+        required: ['channelId', 'prompt'],
+        additionalProperties: false,
+      },
+      execute: (args) => runTool(INTERNAL_TOOL_MEDIA_IMAGE_GENERATE, args),
+    },
+
+    media_video_generate: {
+      description:
+        'Start a durable Veo video generation job in a Bricks channel. ' +
+        'Use referenceMediaIds for up to three style/content reference images, or firstFrameMediaId and optional lastFrameMediaId for interpolation.',
+      parametersSchema: {
+        type: 'object',
+        properties: {
+          channelId: {
+            type: 'string',
+            description: 'The channel where the generated video should be stored.',
+          },
+          threadId: {
+            type: 'string',
+            description: 'Optional thread identifier for the video job.',
+          },
+          prompt: {
+            type: 'string',
+            description: 'The video generation prompt, including motion, camera, style, and audio cues where needed.',
+          },
+          referenceMediaIds: {
+            type: 'array',
+            description: 'Optional image media IDs used as Veo referenceImages; maximum three.',
+            items: { type: 'string' },
+            maxItems: 3,
+          },
+          firstFrameMediaId: {
+            type: 'string',
+            description: 'Optional image media ID to use as the starting frame.',
+          },
+          lastFrameMediaId: {
+            type: 'string',
+            description: 'Optional image media ID to use as the ending frame; requires firstFrameMediaId.',
+          },
+          aspectRatio: {
+            type: 'string',
+            enum: ['16:9', '9:16'],
+            description: 'Optional Veo aspect ratio.',
+          },
+          durationSeconds: {
+            type: 'number',
+            enum: [4, 6, 8],
+            description: 'Optional Veo duration. Use 8 when using reference images or 1080p/4k.',
+          },
+          resolution: {
+            type: 'string',
+            enum: ['720p', '1080p', '4k'],
+            description: 'Optional Veo output resolution.',
+          },
+        },
+        required: ['channelId', 'prompt'],
+        additionalProperties: false,
+      },
+      execute: (args) => runTool(INTERNAL_TOOL_MEDIA_VIDEO_GENERATE, args),
     },
 
     // -------------------------------------------------------------------------

--- a/apps/node_backend/src/services/mediaGenerationService.test.ts
+++ b/apps/node_backend/src/services/mediaGenerationService.test.ts
@@ -171,6 +171,8 @@ describe('mediaGenerationService', () => {
         providerOperationName: 'interaction-1',
       }),
     );
+    expect(poolMock.query.mock.calls[1][0]).toContain('CURRENT_TIMESTAMP');
+    expect(poolMock.query.mock.calls[1][0]).not.toContain('NOW()');
   });
 
   it('starts a Veo video job with up to three referenceImages', async () => {

--- a/apps/node_backend/src/services/mediaGenerationService.test.ts
+++ b/apps/node_backend/src/services/mediaGenerationService.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { poolMock, resolveRuntimeConfigForUserMock, mediaMocks, readFileMock } = vi.hoisted(() => ({
+  poolMock: {
+    query: vi.fn(),
+  },
+  resolveRuntimeConfigForUserMock: vi.fn(),
+  mediaMocks: {
+    createImageMediaAsset: vi.fn(),
+    createVideoMediaAsset: vi.fn(),
+    getMediaAssetForUser: vi.fn(),
+    mediaAssetToDto: vi.fn((asset: Record<string, unknown>) => ({ id: asset.id, kind: asset.kind })),
+    resolveMediaAssetPath: vi.fn(),
+  },
+  readFileMock: vi.fn(),
+}));
+
+vi.mock('../db/index.js', () => ({
+  default: poolMock,
+}));
+
+vi.mock('../llm/llm_service.js', () => ({
+  resolveRuntimeConfigForUser: resolveRuntimeConfigForUserMock,
+}));
+
+vi.mock('./mediaService.js', () => mediaMocks);
+
+vi.mock('fs/promises', () => ({
+  readFile: readFileMock,
+}));
+
+function jobRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'job-1',
+    user_id: 'user-1',
+    channel_id: 'default',
+    thread_id: null,
+    kind: 'image',
+    status: 'running',
+    prompt: 'make an image',
+    input_media_ids: '[]',
+    provider: 'google_ai_studio',
+    model: 'gemini-3.1-flash-image',
+    provider_operation_name: null,
+    result_media_id: null,
+    error_text: null,
+    created_at: '2026-06-30T00:00:00.000Z',
+    updated_at: '2026-06-30T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function mediaAsset(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'media-1',
+    userId: 'user-1',
+    channelId: 'default',
+    threadId: null,
+    kind: 'image',
+    origin: 'user_upload',
+    status: 'ready',
+    mimeType: 'image/png',
+    filename: 'image.png',
+    channelRelativePath: 'media/uploads/media-1.png',
+    thumbnailChannelRelativePath: null,
+    sizeBytes: 10,
+    width: null,
+    height: null,
+    durationMs: null,
+    sourceMessageId: null,
+    provider: null,
+    providerOperationName: null,
+    prompt: null,
+    errorText: null,
+    createdAt: '2026-06-30T00:00:00.000Z',
+    updatedAt: '2026-06-30T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('mediaGenerationService', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    poolMock.query.mockReset();
+    resolveRuntimeConfigForUserMock.mockReset();
+    mediaMocks.createImageMediaAsset.mockReset();
+    mediaMocks.createVideoMediaAsset.mockReset();
+    mediaMocks.getMediaAssetForUser.mockReset();
+    mediaMocks.mediaAssetToDto.mockClear();
+    mediaMocks.resolveMediaAssetPath.mockReset();
+    readFileMock.mockReset();
+    resolveRuntimeConfigForUserMock.mockResolvedValue({
+      provider: 'google_ai_studio',
+      baseUrl: 'https://generativelanguage.googleapis.com',
+      apiKey: 'gemini-key',
+      defaultModel: 'gemini-flash-latest',
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('generates an image with text and reference image parts', async () => {
+    poolMock.query
+      .mockResolvedValueOnce({ rows: [jobRow({ input_media_ids: '["ref-1"]' })] })
+      .mockResolvedValueOnce({
+        rows: [
+          jobRow({
+            status: 'succeeded',
+            provider_operation_name: 'interaction-1',
+            result_media_id: 'generated-1',
+            input_media_ids: '["ref-1"]',
+          }),
+        ],
+      });
+    mediaMocks.getMediaAssetForUser.mockResolvedValue(mediaAsset({ id: 'ref-1' }));
+    mediaMocks.resolveMediaAssetPath.mockResolvedValue('/tmp/ref.png');
+    readFileMock.mockResolvedValue(Buffer.from('reference-image'));
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 'interaction-1',
+          output_image: {
+            data: Buffer.from('generated-image').toString('base64'),
+            mime_type: 'image/png',
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    mediaMocks.createImageMediaAsset.mockResolvedValue(
+      mediaAsset({ id: 'generated-1', origin: 'generated_image' }),
+    );
+
+    const { generateImageMedia } = await import('./mediaGenerationService.js');
+    const result = await generateImageMedia({
+      userId: 'user-1',
+      channelId: 'default',
+      prompt: 'make an image',
+      referenceMediaIds: ['ref-1'],
+    });
+
+    expect(result.job.status).toBe('succeeded');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://generativelanguage.googleapis.com/v1beta/interactions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'x-goog-api-key': 'gemini-key' }),
+      }),
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body).toMatchObject({
+      model: 'gemini-3.1-flash-image',
+      input: [
+        { type: 'text', text: 'make an image' },
+        {
+          type: 'image',
+          mime_type: 'image/png',
+          data: Buffer.from('reference-image').toString('base64'),
+        },
+      ],
+    });
+    expect(mediaMocks.createImageMediaAsset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: 'generated_image',
+        provider: 'google_ai_studio',
+        providerOperationName: 'interaction-1',
+      }),
+    );
+  });
+
+  it('starts a Veo video job with up to three referenceImages', async () => {
+    poolMock.query
+      .mockResolvedValueOnce({
+        rows: [
+          jobRow({
+            kind: 'video',
+            model: 'veo-3.1-generate-preview',
+            input_media_ids: '["ref-1","ref-2"]',
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          jobRow({
+            kind: 'video',
+            model: 'veo-3.1-generate-preview',
+            provider_operation_name: 'operations/video-1',
+            input_media_ids: '["ref-1","ref-2"]',
+          }),
+        ],
+      });
+    mediaMocks.getMediaAssetForUser.mockImplementation(async (_userId: string, mediaId: string) =>
+      mediaAsset({ id: mediaId, channelRelativePath: `media/uploads/${mediaId}.png` }),
+    );
+    mediaMocks.resolveMediaAssetPath.mockImplementation(async (asset: { id: string }) => `/tmp/${asset.id}.png`);
+    readFileMock.mockImplementation(async (filePath: string) => Buffer.from(filePath));
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ name: 'operations/video-1' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { startVideoGenerationJob } = await import('./mediaGenerationService.js');
+    const job = await startVideoGenerationJob({
+      userId: 'user-1',
+      channelId: 'default',
+      prompt: 'cinematic product shot',
+      referenceMediaIds: ['ref-1', 'ref-2'],
+    });
+
+    expect(job.providerOperationName).toBe('operations/video-1');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://generativelanguage.googleapis.com/v1beta/models/veo-3.1-generate-preview:predictLongRunning',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.instances[0].referenceImages).toEqual([
+      {
+        image: {
+          inlineData: {
+            mimeType: 'image/png',
+            data: Buffer.from('/tmp/ref-1.png').toString('base64'),
+          },
+        },
+        referenceType: 'asset',
+      },
+      {
+        image: {
+          inlineData: {
+            mimeType: 'image/png',
+            data: Buffer.from('/tmp/ref-2.png').toString('base64'),
+          },
+        },
+        referenceType: 'asset',
+      },
+    ]);
+    expect(body.parameters.durationSeconds).toBe('8');
+  });
+
+  it('downloads a completed Veo operation into a generated video media asset', async () => {
+    poolMock.query
+      .mockResolvedValueOnce({
+        rows: [
+          jobRow({
+            kind: 'video',
+            model: 'veo-3.1-generate-preview',
+            prompt: 'make a video',
+            provider_operation_name: 'operations/video-1',
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          jobRow({
+            kind: 'video',
+            status: 'succeeded',
+            model: 'veo-3.1-generate-preview',
+            provider_operation_name: 'operations/video-1',
+            result_media_id: 'video-1',
+          }),
+        ],
+      });
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            done: true,
+            response: {
+              generateVideoResponse: {
+                generatedSamples: [
+                  { video: { uri: 'https://files.example/video.mp4' } },
+                ],
+              },
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from('mp4-data'), {
+          status: 200,
+          headers: { 'Content-Type': 'video/mp4' },
+        }),
+      );
+    mediaMocks.createVideoMediaAsset.mockResolvedValue(
+      mediaAsset({
+        id: 'video-1',
+        kind: 'video',
+        origin: 'generated_video',
+        mimeType: 'video/mp4',
+      }),
+    );
+
+    const { refreshVideoGenerationJobForUser } = await import('./mediaGenerationService.js');
+    const result = await refreshVideoGenerationJobForUser({
+      userId: 'user-1',
+      jobId: 'job-1',
+    });
+
+    expect(result.job.status).toBe('succeeded');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/operations/video-1',
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe('https://files.example/video.mp4');
+    expect(mediaMocks.createVideoMediaAsset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: 'generated_video',
+        mimeType: 'video/mp4',
+        data: Buffer.from('mp4-data'),
+        providerOperationName: 'operations/video-1',
+      }),
+    );
+  });
+});

--- a/apps/node_backend/src/services/mediaGenerationService.ts
+++ b/apps/node_backend/src/services/mediaGenerationService.ts
@@ -1,0 +1,740 @@
+import { readFile } from 'fs/promises';
+import pool from '../db/index.js';
+import { resolveRuntimeConfigForUser } from '../llm/llm_service.js';
+import type { LlmRuntimeConfig } from '../llm/types.js';
+import {
+  createImageMediaAsset,
+  createVideoMediaAsset,
+  getMediaAssetForUser,
+  mediaAssetToDto,
+  resolveMediaAssetPath,
+  type MediaAsset,
+} from './mediaService.js';
+
+export const GEMINI_IMAGE_GENERATION_MODEL = 'gemini-3.1-flash-image';
+export const GEMINI_VIDEO_GENERATION_MODEL = 'veo-3.1-generate-preview';
+
+export type MediaGenerationKind = 'image' | 'video';
+export type MediaGenerationStatus = 'pending' | 'running' | 'succeeded' | 'failed';
+
+export interface MediaGenerationJob {
+  id: string;
+  userId: string;
+  channelId: string;
+  threadId: string | null;
+  kind: MediaGenerationKind;
+  status: MediaGenerationStatus;
+  prompt: string;
+  inputMediaIds: string[];
+  provider: string;
+  model: string;
+  providerOperationName: string | null;
+  resultMediaId: string | null;
+  errorText: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MediaGenerationJobRow {
+  id: string;
+  user_id: string;
+  channel_id: string;
+  thread_id: string | null;
+  kind: MediaGenerationKind;
+  status: MediaGenerationStatus;
+  prompt: string;
+  input_media_ids: unknown;
+  provider: string;
+  model: string;
+  provider_operation_name: string | null;
+  result_media_id: string | null;
+  error_text: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export class MediaGenerationError extends Error {
+  constructor(
+    message: string,
+    readonly statusCode = 400,
+  ) {
+    super(message);
+    this.name = 'MediaGenerationError';
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseInputMediaIds(value: unknown): string[] {
+  const parsed =
+    typeof value === 'string'
+      ? (() => {
+          try {
+            return JSON.parse(value) as unknown;
+          } catch {
+            return [];
+          }
+        })()
+      : value;
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter((item): item is string => typeof item === 'string');
+}
+
+function toMediaGenerationJob(row: MediaGenerationJobRow): MediaGenerationJob {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    channelId: row.channel_id,
+    threadId: row.thread_id,
+    kind: row.kind,
+    status: row.status,
+    prompt: row.prompt,
+    inputMediaIds: parseInputMediaIds(row.input_media_ids),
+    provider: row.provider,
+    model: row.model,
+    providerOperationName: row.provider_operation_name,
+    resultMediaId: row.result_media_id,
+    errorText: row.error_text,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function mediaGenerationJobToDto(
+  job: MediaGenerationJob,
+  resultMedia?: MediaAsset | null,
+) {
+  return {
+    id: job.id,
+    kind: job.kind,
+    status: job.status,
+    prompt: job.prompt,
+    inputMediaIds: job.inputMediaIds,
+    provider: job.provider,
+    model: job.model,
+    providerOperationName: job.providerOperationName,
+    resultMediaId: job.resultMediaId,
+    resultMedia: resultMedia ? mediaAssetToDto(resultMedia) : null,
+    errorText: job.errorText,
+    channelId: job.channelId,
+    threadId: job.threadId,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+  };
+}
+
+async function createMediaGenerationJob(params: {
+  userId: string;
+  channelId: string;
+  threadId?: string | null;
+  kind: MediaGenerationKind;
+  status: MediaGenerationStatus;
+  prompt: string;
+  inputMediaIds?: string[];
+  provider: string;
+  model: string;
+}): Promise<MediaGenerationJob> {
+  const result = await pool.query<MediaGenerationJobRow>(
+    `INSERT INTO media_generation_jobs (
+        user_id,
+        channel_id,
+        thread_id,
+        kind,
+        status,
+        prompt,
+        input_media_ids,
+        provider,
+        model
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+      RETURNING *`,
+    [
+      params.userId,
+      params.channelId,
+      params.threadId ?? null,
+      params.kind,
+      params.status,
+      params.prompt,
+      JSON.stringify(params.inputMediaIds ?? []),
+      params.provider,
+      params.model,
+    ],
+  );
+  return toMediaGenerationJob(result.rows[0]);
+}
+
+async function updateMediaGenerationJob(
+  jobId: string,
+  updates: {
+    status?: MediaGenerationStatus;
+    providerOperationName?: string | null;
+    resultMediaId?: string | null;
+    errorText?: string | null;
+  },
+): Promise<MediaGenerationJob> {
+  const result = await pool.query<MediaGenerationJobRow>(
+    `UPDATE media_generation_jobs
+       SET status = COALESCE($2, status),
+           provider_operation_name = COALESCE($3, provider_operation_name),
+           result_media_id = COALESCE($4, result_media_id),
+           error_text = $5,
+           updated_at = NOW()
+     WHERE id = $1
+     RETURNING *`,
+    [
+      jobId,
+      updates.status ?? null,
+      updates.providerOperationName ?? null,
+      updates.resultMediaId ?? null,
+      updates.errorText ?? null,
+    ],
+  );
+  return toMediaGenerationJob(result.rows[0]);
+}
+
+export async function getMediaGenerationJobForUser(
+  userId: string,
+  jobId: string,
+): Promise<MediaGenerationJob | null> {
+  const result = await pool.query<MediaGenerationJobRow>(
+    `SELECT * FROM media_generation_jobs WHERE user_id = $1 AND id = $2 LIMIT 1`,
+    [userId, jobId],
+  );
+  return result.rows[0] ? toMediaGenerationJob(result.rows[0]) : null;
+}
+
+async function resolveGoogleConfig(
+  userId: string,
+  configId?: string,
+): Promise<LlmRuntimeConfig> {
+  try {
+    return await resolveRuntimeConfigForUser(userId, 'google_ai_studio', configId);
+  } catch (error) {
+    throw new MediaGenerationError(
+      error instanceof Error ? error.message : 'Google AI Studio configuration is required',
+      400,
+    );
+  }
+}
+
+function geminiApiUrl(config: LlmRuntimeConfig, path: string): string {
+  const root = new URL(config.baseUrl);
+  root.search = '';
+  root.hash = '';
+  root.pathname = root.pathname.replace(/\/+$/, '');
+  if (root.pathname.endsWith('/v1beta')) {
+    root.pathname = root.pathname.slice(0, -'/v1beta'.length) || '/';
+  }
+  return new URL(`/v1beta/${path.replace(/^\/+/, '')}`, root).toString();
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return { raw: text };
+  }
+}
+
+function providerErrorMessage(payload: unknown, fallback: string): string {
+  if (isRecord(payload)) {
+    const error = payload.error;
+    if (isRecord(error) && typeof error.message === 'string') {
+      return error.message;
+    }
+    if (typeof payload.message === 'string') {
+      return payload.message;
+    }
+  }
+  return fallback;
+}
+
+async function postGeminiJson(
+  config: LlmRuntimeConfig,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<unknown> {
+  const response = await fetch(geminiApiUrl(config, path), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-goog-api-key': config.apiKey,
+    },
+    body: JSON.stringify(body),
+  });
+  const payload = await readJsonResponse(response);
+  if (!response.ok) {
+    throw new MediaGenerationError(
+      providerErrorMessage(payload, `Gemini request failed with ${response.status}`),
+      502,
+    );
+  }
+  return payload;
+}
+
+async function getGeminiJson(
+  config: LlmRuntimeConfig,
+  path: string,
+): Promise<unknown> {
+  const response = await fetch(geminiApiUrl(config, path), {
+    headers: { 'x-goog-api-key': config.apiKey },
+  });
+  const payload = await readJsonResponse(response);
+  if (!response.ok) {
+    throw new MediaGenerationError(
+      providerErrorMessage(payload, `Gemini request failed with ${response.status}`),
+      502,
+    );
+  }
+  return payload;
+}
+
+function collectStringValues(value: unknown, keyNames: Set<string>, output: string[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectStringValues(item, keyNames, output);
+    return;
+  }
+  if (!isRecord(value)) return;
+  for (const [key, nested] of Object.entries(value)) {
+    if (keyNames.has(key) && typeof nested === 'string' && nested.trim()) {
+      output.push(nested.trim());
+    }
+    collectStringValues(nested, keyNames, output);
+  }
+}
+
+function findGeneratedImage(payload: unknown): { dataBase64: string; mimeType: string } {
+  const records: Record<string, unknown>[] = [];
+  if (isRecord(payload)) {
+    const direct = payload.output_image ?? payload.outputImage;
+    if (isRecord(direct)) records.push(direct);
+  }
+  const dataCandidates: string[] = [];
+  collectStringValues(payload, new Set(['data']), dataCandidates);
+  for (const record of records) {
+    const data = record.data;
+    if (typeof data === 'string' && data.trim()) {
+      return {
+        dataBase64: data.trim(),
+        mimeType:
+          (typeof record.mime_type === 'string' && record.mime_type.trim()) ||
+          (typeof record.mimeType === 'string' && record.mimeType.trim()) ||
+          'image/png',
+      };
+    }
+  }
+  const dataBase64 = dataCandidates[0];
+  if (dataBase64) {
+    return { dataBase64, mimeType: 'image/png' };
+  }
+  throw new MediaGenerationError('Gemini did not return generated image data', 502);
+}
+
+function findProviderOperationName(payload: unknown): string | null {
+  if (!isRecord(payload)) return null;
+  const id = payload.id ?? payload.name;
+  return typeof id === 'string' && id.trim() ? id.trim() : null;
+}
+
+async function loadReadyImageMedia(params: {
+  userId: string;
+  channelId: string;
+  mediaId: string;
+}): Promise<MediaAsset> {
+  const asset = await getMediaAssetForUser(params.userId, params.mediaId);
+  if (!asset || asset.channelId !== params.channelId) {
+    throw new MediaGenerationError('Reference image not found', 404);
+  }
+  if (asset.kind !== 'image' || asset.status !== 'ready') {
+    throw new MediaGenerationError('Reference media must be a ready image', 400);
+  }
+  return asset;
+}
+
+async function assetToBase64ImagePart(asset: MediaAsset): Promise<{
+  mimeType: string;
+  data: string;
+}> {
+  const filePath = await resolveMediaAssetPath(asset);
+  const bytes = await readFile(filePath);
+  return {
+    mimeType: asset.mimeType,
+    data: bytes.toString('base64'),
+  };
+}
+
+async function loadImageParts(params: {
+  userId: string;
+  channelId: string;
+  mediaIds: string[];
+  maxCount?: number;
+}): Promise<Array<{ mediaId: string; mimeType: string; data: string }>> {
+  const maxCount = params.maxCount ?? params.mediaIds.length;
+  if (params.mediaIds.length > maxCount) {
+    throw new MediaGenerationError(`Reference images are limited to ${maxCount}`, 400);
+  }
+  const parts = [];
+  for (const mediaId of params.mediaIds) {
+    const asset = await loadReadyImageMedia({
+      userId: params.userId,
+      channelId: params.channelId,
+      mediaId,
+    });
+    const image = await assetToBase64ImagePart(asset);
+    parts.push({ mediaId, ...image });
+  }
+  return parts;
+}
+
+function uniqueIds(ids: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const id of ids) {
+    const trimmed = id?.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+export async function generateImageMedia(params: {
+  userId: string;
+  channelId: string;
+  threadId?: string | null;
+  prompt: string;
+  referenceMediaIds?: string[];
+  model?: string | null;
+  configId?: string | null;
+}): Promise<{ job: MediaGenerationJob; media: MediaAsset }> {
+  const prompt = params.prompt.trim();
+  if (!prompt) throw new MediaGenerationError('prompt is required', 400);
+  const referenceMediaIds = uniqueIds(params.referenceMediaIds ?? []);
+  const model = params.model?.trim() || GEMINI_IMAGE_GENERATION_MODEL;
+
+  const references = await loadImageParts({
+    userId: params.userId,
+    channelId: params.channelId,
+    mediaIds: referenceMediaIds,
+  });
+  let job = await createMediaGenerationJob({
+    userId: params.userId,
+    channelId: params.channelId,
+    threadId: params.threadId,
+    kind: 'image',
+    status: 'running',
+    prompt,
+    inputMediaIds: referenceMediaIds,
+    provider: 'google_ai_studio',
+    model,
+  });
+
+  try {
+    const config = await resolveGoogleConfig(params.userId, params.configId ?? undefined);
+    const payload = await postGeminiJson(config, 'interactions', {
+      model,
+      input: [
+        { type: 'text', text: prompt },
+        ...references.map((reference) => ({
+          type: 'image',
+          mime_type: reference.mimeType,
+          data: reference.data,
+        })),
+      ],
+    });
+    const generated = findGeneratedImage(payload);
+    const providerOperationName = findProviderOperationName(payload);
+    const media = await createImageMediaAsset({
+      userId: params.userId,
+      channelId: params.channelId,
+      threadId: params.threadId,
+      origin: 'generated_image',
+      mimeType: generated.mimeType,
+      dataBase64: generated.dataBase64,
+      provider: 'google_ai_studio',
+      providerOperationName,
+      prompt,
+    });
+    job = await updateMediaGenerationJob(job.id, {
+      status: 'succeeded',
+      providerOperationName,
+      resultMediaId: media.id,
+      errorText: null,
+    });
+    return { job, media };
+  } catch (error) {
+    await updateMediaGenerationJob(job.id, {
+      status: 'failed',
+      errorText: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
+function validateVideoOptions(params: {
+  referenceMediaIds: string[];
+  firstFrameMediaId?: string | null;
+  lastFrameMediaId?: string | null;
+  aspectRatio?: string | null;
+  durationSeconds?: number | null;
+  resolution?: string | null;
+}): void {
+  if (params.referenceMediaIds.length > 3) {
+    throw new MediaGenerationError('Veo referenceImages supports at most 3 images', 400);
+  }
+  if (params.referenceMediaIds.length > 0 && (params.firstFrameMediaId || params.lastFrameMediaId)) {
+    throw new MediaGenerationError(
+      'Use either referenceMediaIds or first/last frame inputs, not both',
+      400,
+    );
+  }
+  if (params.lastFrameMediaId && !params.firstFrameMediaId) {
+    throw new MediaGenerationError('lastFrameMediaId requires firstFrameMediaId', 400);
+  }
+  if (params.aspectRatio && !['16:9', '9:16'].includes(params.aspectRatio)) {
+    throw new MediaGenerationError('aspectRatio must be 16:9 or 9:16', 400);
+  }
+  if (
+    params.durationSeconds != null &&
+    ![4, 6, 8].includes(params.durationSeconds)
+  ) {
+    throw new MediaGenerationError('durationSeconds must be 4, 6, or 8', 400);
+  }
+  if (params.referenceMediaIds.length > 0 && params.durationSeconds != null && params.durationSeconds !== 8) {
+    throw new MediaGenerationError('durationSeconds must be 8 when using reference images', 400);
+  }
+  if (params.resolution && !['720p', '1080p', '4k'].includes(params.resolution)) {
+    throw new MediaGenerationError('resolution must be 720p, 1080p, or 4k', 400);
+  }
+  if (params.resolution && ['1080p', '4k'].includes(params.resolution)) {
+    const duration = params.durationSeconds ?? 8;
+    if (duration !== 8) {
+      throw new MediaGenerationError('durationSeconds must be 8 for 1080p or 4k video', 400);
+    }
+  }
+}
+
+export async function startVideoGenerationJob(params: {
+  userId: string;
+  channelId: string;
+  threadId?: string | null;
+  prompt: string;
+  referenceMediaIds?: string[];
+  firstFrameMediaId?: string | null;
+  lastFrameMediaId?: string | null;
+  aspectRatio?: string | null;
+  durationSeconds?: number | null;
+  resolution?: string | null;
+  model?: string | null;
+  configId?: string | null;
+}): Promise<MediaGenerationJob> {
+  const prompt = params.prompt.trim();
+  if (!prompt) throw new MediaGenerationError('prompt is required', 400);
+  const referenceMediaIds = uniqueIds(params.referenceMediaIds ?? []);
+  const firstFrameMediaId = params.firstFrameMediaId?.trim() || null;
+  const lastFrameMediaId = params.lastFrameMediaId?.trim() || null;
+  validateVideoOptions({
+    referenceMediaIds,
+    firstFrameMediaId,
+    lastFrameMediaId,
+    aspectRatio: params.aspectRatio,
+    durationSeconds: params.durationSeconds,
+    resolution: params.resolution,
+  });
+
+  const inputMediaIds = uniqueIds([
+    ...referenceMediaIds,
+    firstFrameMediaId,
+    lastFrameMediaId,
+  ]);
+  const model = params.model?.trim() || GEMINI_VIDEO_GENERATION_MODEL;
+  let job = await createMediaGenerationJob({
+    userId: params.userId,
+    channelId: params.channelId,
+    threadId: params.threadId,
+    kind: 'video',
+    status: 'running',
+    prompt,
+    inputMediaIds,
+    provider: 'google_ai_studio',
+    model,
+  });
+
+  try {
+    const [references, firstFrame, lastFrame] = await Promise.all([
+      loadImageParts({
+        userId: params.userId,
+        channelId: params.channelId,
+        mediaIds: referenceMediaIds,
+        maxCount: 3,
+      }),
+      firstFrameMediaId
+        ? loadImageParts({
+            userId: params.userId,
+            channelId: params.channelId,
+            mediaIds: [firstFrameMediaId],
+            maxCount: 1,
+          })
+        : Promise.resolve([]),
+      lastFrameMediaId
+        ? loadImageParts({
+            userId: params.userId,
+            channelId: params.channelId,
+            mediaIds: [lastFrameMediaId],
+            maxCount: 1,
+          })
+        : Promise.resolve([]),
+    ]);
+    const instance: Record<string, unknown> = { prompt };
+    if (references.length > 0) {
+      instance.referenceImages = references.map((reference) => ({
+        image: {
+          inlineData: {
+            mimeType: reference.mimeType,
+            data: reference.data,
+          },
+        },
+        referenceType: 'asset',
+      }));
+    }
+    if (firstFrame[0]) {
+      instance.image = {
+        inlineData: {
+          mimeType: firstFrame[0].mimeType,
+          data: firstFrame[0].data,
+        },
+      };
+    }
+    if (lastFrame[0]) {
+      instance.lastFrame = {
+        inlineData: {
+          mimeType: lastFrame[0].mimeType,
+          data: lastFrame[0].data,
+        },
+      };
+    }
+
+    const parameters: Record<string, unknown> = {};
+    if (params.aspectRatio) parameters.aspectRatio = params.aspectRatio;
+    if (params.durationSeconds) parameters.durationSeconds = String(params.durationSeconds);
+    if (!params.durationSeconds && references.length > 0) parameters.durationSeconds = '8';
+    if (params.resolution) parameters.resolution = params.resolution;
+
+    const config = await resolveGoogleConfig(params.userId, params.configId ?? undefined);
+    const payload = await postGeminiJson(config, `models/${model}:predictLongRunning`, {
+      instances: [instance],
+      ...(Object.keys(parameters).length > 0 ? { parameters } : {}),
+    });
+    const operationName = findProviderOperationName(payload);
+    if (!operationName) {
+      throw new MediaGenerationError('Veo did not return an operation name', 502);
+    }
+    job = await updateMediaGenerationJob(job.id, {
+      status: 'running',
+      providerOperationName: operationName,
+      errorText: null,
+    });
+    return job;
+  } catch (error) {
+    await updateMediaGenerationJob(job.id, {
+      status: 'failed',
+      errorText: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
+function extractVideoUri(payload: unknown): string | null {
+  const values: string[] = [];
+  collectStringValues(payload, new Set(['uri']), values);
+  return values.find((value) => /^https:\/\//i.test(value)) ?? null;
+}
+
+async function downloadGeneratedVideo(
+  config: LlmRuntimeConfig,
+  uri: string,
+): Promise<{ data: Buffer; mimeType: string }> {
+  const response = await fetch(uri, {
+    headers: { 'x-goog-api-key': config.apiKey },
+  });
+  if (!response.ok) {
+    throw new MediaGenerationError(
+      `Generated video download failed with ${response.status}`,
+      502,
+    );
+  }
+  const data = Buffer.from(await response.arrayBuffer());
+  const contentType = response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase();
+  return {
+    data,
+    mimeType: contentType && contentType.startsWith('video/') ? contentType : 'video/mp4',
+  };
+}
+
+export async function refreshVideoGenerationJobForUser(params: {
+  userId: string;
+  jobId: string;
+  configId?: string | null;
+}): Promise<{ job: MediaGenerationJob; media: MediaAsset | null }> {
+  let job = await getMediaGenerationJobForUser(params.userId, params.jobId);
+  if (!job) throw new MediaGenerationError('Media generation job not found', 404);
+  let media: MediaAsset | null = null;
+  if (job.resultMediaId) {
+    media = await getMediaAssetForUser(params.userId, job.resultMediaId);
+  }
+  if (job.kind !== 'video' || job.status === 'succeeded' || job.status === 'failed') {
+    return { job, media };
+  }
+  if (!job.providerOperationName) {
+    job = await updateMediaGenerationJob(job.id, {
+      status: 'failed',
+      errorText: 'Veo operation name is missing',
+    });
+    return { job, media: null };
+  }
+
+  const config = await resolveGoogleConfig(params.userId, params.configId ?? undefined);
+  const payload = await getGeminiJson(config, job.providerOperationName);
+  if (isRecord(payload) && isRecord(payload.error)) {
+    const message = providerErrorMessage(payload, 'Veo operation failed');
+    job = await updateMediaGenerationJob(job.id, {
+      status: 'failed',
+      errorText: message,
+    });
+    return { job, media: null };
+  }
+  const done = isRecord(payload) && payload.done === true;
+  if (!done) {
+    return { job, media: null };
+  }
+  const videoUri = extractVideoUri(payload);
+  if (!videoUri) {
+    job = await updateMediaGenerationJob(job.id, {
+      status: 'failed',
+      errorText: 'Veo operation completed without a video URI',
+    });
+    return { job, media: null };
+  }
+  const generated = await downloadGeneratedVideo(config, videoUri);
+  media = await createVideoMediaAsset({
+    userId: job.userId,
+    channelId: job.channelId,
+    threadId: job.threadId,
+    origin: 'generated_video',
+    mimeType: generated.mimeType,
+    filename: `${job.id}.mp4`,
+    data: generated.data,
+    provider: job.provider,
+    providerOperationName: job.providerOperationName,
+    prompt: job.prompt,
+  });
+  job = await updateMediaGenerationJob(job.id, {
+    status: 'succeeded',
+    resultMediaId: media.id,
+    errorText: null,
+  });
+  return { job, media };
+}

--- a/apps/node_backend/src/services/mediaGenerationService.ts
+++ b/apps/node_backend/src/services/mediaGenerationService.ts
@@ -63,6 +63,8 @@ export class MediaGenerationError extends Error {
   }
 }
 
+const currentTimestampSql = 'CURRENT_TIMESTAMP';
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -179,7 +181,7 @@ async function updateMediaGenerationJob(
            provider_operation_name = COALESCE($3, provider_operation_name),
            result_media_id = COALESCE($4, result_media_id),
            error_text = $5,
-           updated_at = NOW()
+           updated_at = ${currentTimestampSql}
      WHERE id = $1
      RETURNING *`,
     [

--- a/apps/node_backend/src/services/mediaService.test.ts
+++ b/apps/node_backend/src/services/mediaService.test.ts
@@ -27,4 +27,15 @@ describe('mediaService validation', () => {
       /Image data is empty/,
     );
   });
+
+  it('accepts mp4 generated videos and rejects unsupported or empty video data', async () => {
+    const { assertSupportedVideo } = await import('./mediaService.js');
+    expect(assertSupportedVideo('video/mp4', Buffer.from('data'))).toBe('mp4');
+    expect(() => assertSupportedVideo('video/quicktime', Buffer.from('data'))).toThrow(
+      /Unsupported video MIME type/,
+    );
+    expect(() => assertSupportedVideo('video/mp4', Buffer.alloc(0))).toThrow(
+      /Video data is empty/,
+    );
+  });
 });

--- a/apps/node_backend/src/services/mediaService.ts
+++ b/apps/node_backend/src/services/mediaService.ts
@@ -69,7 +69,12 @@ const IMAGE_MIME_TO_EXTENSION = new Map<string, string>([
   ['image/gif', 'gif'],
 ]);
 
+const VIDEO_MIME_TO_EXTENSION = new Map<string, string>([
+  ['video/mp4', 'mp4'],
+]);
+
 const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+const MAX_VIDEO_BYTES = 512 * 1024 * 1024;
 
 function toMediaAsset(row: MediaAssetRow): MediaAsset {
   return {
@@ -109,6 +114,21 @@ export function assertSupportedImage(mimeType: string, data: Buffer): string {
   }
   if (data.length > MAX_IMAGE_BYTES) {
     throw new Error('Image exceeds the 20MB limit');
+  }
+  return extension;
+}
+
+export function assertSupportedVideo(mimeType: string, data: Buffer): string {
+  const normalizedMime = mimeType.trim().toLowerCase();
+  const extension = VIDEO_MIME_TO_EXTENSION.get(normalizedMime);
+  if (!extension) {
+    throw new Error('Unsupported video MIME type');
+  }
+  if (data.length === 0) {
+    throw new Error('Video data is empty');
+  }
+  if (data.length > MAX_VIDEO_BYTES) {
+    throw new Error('Video exceeds the 512MB limit');
   }
   return extension;
 }
@@ -182,6 +202,70 @@ export async function createImageMediaAsset(params: {
       filename,
       relativePath,
       data.length,
+      params.sourceMessageId ?? null,
+      params.provider ?? null,
+      params.providerOperationName ?? null,
+      params.prompt ?? null,
+    ],
+  );
+  return toMediaAsset(result.rows[0]);
+}
+
+export async function createVideoMediaAsset(params: {
+  userId: string;
+  channelId: string;
+  threadId?: string | null;
+  origin: Extract<MediaOrigin, 'generated_video'>;
+  mimeType: string;
+  filename?: string;
+  data: Buffer;
+  sourceMessageId?: string | null;
+  provider?: string | null;
+  providerOperationName?: string | null;
+  prompt?: string | null;
+  durationMs?: number | null;
+}): Promise<MediaAsset> {
+  const extension = assertSupportedVideo(params.mimeType, params.data);
+  const id = crypto.randomUUID();
+  const filename = sanitizeFilename(params.filename, `${id}.${extension}`);
+  const relativePath = `media/generated/videos/${id}.${extension}`;
+  await writeChannelFile({
+    channelId: params.channelId,
+    relativePath,
+    data: params.data,
+  });
+
+  const result = await pool.query<MediaAssetRow>(
+    `INSERT INTO media_assets (
+        id,
+        user_id,
+        channel_id,
+        thread_id,
+        kind,
+        origin,
+        status,
+        mime_type,
+        filename,
+        channel_relative_path,
+        size_bytes,
+        duration_ms,
+        source_message_id,
+        provider,
+        provider_operation_name,
+        prompt
+      ) VALUES ($1,$2,$3,$4,'video',$5,'ready',$6,$7,$8,$9,$10,$11,$12,$13,$14)
+      RETURNING *`,
+    [
+      id,
+      params.userId,
+      params.channelId,
+      params.threadId ?? null,
+      params.origin,
+      params.mimeType.trim().toLowerCase(),
+      filename,
+      relativePath,
+      params.data.length,
+      params.durationMs ?? null,
       params.sourceMessageId ?? null,
       params.provider ?? null,
       params.providerOperationName ?? null,

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -114,8 +114,8 @@ products:
           - 用户消息与 assistant 消息正文应共享同一文本样式基线（字号一致）；时间/thread 等 meta 信息应统一为次级灰。
 
       - feature_id: chat_media_attachments
-        name: 频道内图片附件与生成图片持久化
-        user_value: 用户可在聊天中上传图片，上传中/失败时能看到草稿缩略图与重试/移除操作，刷新后仍能预览/下载；Gemini 路由会把上传图片作为多模态输入读取；AI 生成图片可作为频道内持久附件保存，供同一频道 workspace/Agent 访问。
+        name: 频道内图片附件、生成图片与生成视频持久化
+        user_value: 用户可在聊天中上传图片，上传中/失败时能看到草稿缩略图与重试/移除操作，刷新后仍能预览/下载；Gemini 路由会把上传图片作为多模态输入读取；AI 生成图片和 Veo 生成视频可作为频道内持久附件保存，供同一频道 workspace/Agent 访问。
         entry_paths:
           - screen: ChatScreen composer image action
             route_hint: apps/mobile_chat_app/lib/features/chat/chat_screen.dart
@@ -129,8 +129,18 @@ products:
             route_hint: apps/node_backend/src/routes/media.ts
           - route: POST /api/media/generated-images
             route_hint: apps/node_backend/src/routes/media.ts
+          - route: POST /api/media/image-generations
+            route_hint: apps/node_backend/src/routes/media.ts
+          - route: POST /api/media/video-generations
+            route_hint: apps/node_backend/src/routes/media.ts
+          - route: GET|POST /api/media/generation-jobs/:jobId
+            route_hint: apps/node_backend/src/routes/media.ts
           - route: GET /api/media/:mediaId/preview|content|download
             route_hint: apps/node_backend/src/routes/media.ts
+          - service: Gemini media generation provider integration
+            route_hint: apps/node_backend/src/services/mediaGenerationService.ts
+          - tool: media_image_generate / media_video_generate
+            route_hint: apps/node_backend/src/services/localAgentLoopService.ts
           - llm: Gemini multimodal image parts
             route_hint: apps/node_backend/src/routes/chat.ts
         smoke_checks:
@@ -141,8 +151,11 @@ products:
           - 刷新或 SSE 同步后，图片附件仍从 message metadata 恢复并可加载预览。
           - 访问 media preview/content/download 路由必须携带当前用户 token；跨用户 media id 返回 404。
           - 数据库 `media_assets.channel_relative_path` 只保存频道内相对路径，不保存宿主机绝对路径。
-          - 同一 channel 的上传图片写入该 channel 目录下 `media/uploads/`，生成图片写入 `media/generated/images/`。
-          - 不支持的 MIME、空图片、超过 20MB 的图片被后端拒绝。
+          - 同一 channel 的上传图片写入该 channel 目录下 `media/uploads/`，生成图片写入 `media/generated/images/`，生成视频写入 `media/generated/videos/`。
+          - "`POST /api/media/image-generations` 使用用户的 Google AI Studio 配置调用 Gemini Interactions API，并把返回图片保存成 `generated_image`。"
+          - "`POST /api/media/video-generations` 创建 `media_generation_jobs` 记录并保存 Veo operation name；轮询 job 完成后下载 provider video URI 并保存成 `generated_video`。"
+          - Veo `referenceImages` 最多接受 3 张 ready image media；`lastFrameMediaId` 必须搭配 `firstFrameMediaId`。
+          - 不支持的 MIME、空图片、超过 20MB 的图片、空视频或非 mp4 视频被后端拒绝。
 
       - feature_id: scope_instructions_config
         name: 频道和分区会话指令配置

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -153,6 +153,7 @@ products:
           - 数据库 `media_assets.channel_relative_path` 只保存频道内相对路径，不保存宿主机绝对路径。
           - 同一 channel 的上传图片写入该 channel 目录下 `media/uploads/`，生成图片写入 `media/generated/images/`，生成视频写入 `media/generated/videos/`。
           - "`POST /api/media/image-generations` 使用用户的 Google AI Studio 配置调用 Gemini Interactions API，并把返回图片保存成 `generated_image`。"
+          - "AI 通过 `media_image_generate` 生成成功后，最终 assistant 消息 metadata 应包含 `mediaAttachments`，UI 显示真实预览而不是 `[image: ...]` 文本占位。"
           - "`POST /api/media/video-generations` 创建 `media_generation_jobs` 记录并保存 Veo operation name；轮询 job 完成后下载 provider video URI 并保存成 `generated_video`。"
           - Veo `referenceImages` 最多接受 3 张 ready image media；`lastFrameMediaId` 必须搭配 `firstFrameMediaId`。
           - 不支持的 MIME、空图片、超过 20MB 的图片、空视频或非 mp4 视频被后端拒绝。

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -543,5 +543,6 @@ products:
           - 每个 preview app mount 到 `/home/bricks/data/previews/<branch-slug>/channels`，不共享 production 或其他 preview 的 channel 文件。
           - Turso credentials, JWT signing secret, and encryption key stay in Dokku server config; preview apps copy them from the production app on the server instead of reading GitHub Actions secrets.
           - Production CSP must allow Flutter Web bootstrap scripts so `craft.bricks.cool` renders the login app instead of a blank page.
+          - Flutter Web app shell files such as `index.html`, `main.dart.js`, `flutter.js`, and `flutter_service_worker.js` must return no-store/no-cache headers so preview deploys do not serve stale UI bundles.
           - PR close/merge 后对应 preview app 被 destroy，preview data root 被删除。
           - GitHub OAuth callback 固定为 `https://craft.bricks.cool/api/callback`，preview 登录完成后可 redirect 回 preview 域名。

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -405,6 +405,7 @@ products:
           - 未登录请求返回预期状态码。
           - 合法回跳参数通过校验。
           - 仅允许受控 native OAuth callback，拒绝任意自定义 scheme 回跳。
+          - legacy `/api` OAuth route mount 只应限流 OAuth anonymous endpoints，不得让已认证的 `/api/config?category=llm` 读请求误返回 anonymous auth 429。
 
       - feature_id: backend_chat_llm
         name: Chat 与 LLM 调用

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -147,6 +147,8 @@ products:
           - 选择图片后，输入框上方立即显示本地缩略图与上传进度；失败后保留缩略图并提供重试和移除。
           - 上传成功后，输入框上方显示带 Authorization header 的 media preview，而不是只显示占位 icon。
           - 发送带图片的消息后，user 气泡显示图片附件并保持原有投递状态。
+          - 点击/点按聊天图片附件会打开全屏预览；右上角关闭按钮返回聊天。
+          - 长按聊天图片附件会显示 Download 菜单项，并通过带 Authorization 的下载请求保存图片。
           - Gemini/Google AI Studio 路由收到上传图片时，模型请求包含 text part 与 image part，能够基于图片内容回答。
           - 刷新或 SSE 同步后，图片附件仍从 message metadata 恢复并可加载预览。
           - 访问 media preview/content/download 路由必须携带当前用户 token；跨用户 media id 返回 404。

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -147,8 +147,8 @@ products:
           - 选择图片后，输入框上方立即显示本地缩略图与上传进度；失败后保留缩略图并提供重试和移除。
           - 上传成功后，输入框上方显示带 Authorization header 的 media preview，而不是只显示占位 icon。
           - 发送带图片的消息后，user 气泡显示图片附件并保持原有投递状态。
-          - 点击/点按聊天图片附件会打开全屏预览；右上角关闭按钮返回聊天。
-          - 长按或右键/两指点按聊天图片附件会显示 Download 菜单项，并通过带 Authorization 的下载请求保存图片。
+          - 点击/点按聊天图片附件会通过 primary pointer 打开全屏预览；Safari/Chrome 桌面浏览器均应可用，右上角关闭按钮返回聊天。
+          - 长按或右键/两指点按聊天图片附件会显示 Download 菜单项；全屏预览右上角也提供 Download image 按钮，并通过带 Authorization 的下载请求保存图片。
           - Gemini/Google AI Studio 路由收到上传图片时，模型请求包含 text part 与 image part，能够基于图片内容回答。
           - 刷新或 SSE 同步后，图片附件仍从 message metadata 恢复并可加载预览。
           - 访问 media preview/content/download 路由必须携带当前用户 token；跨用户 media id 返回 404。

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -540,6 +540,7 @@ products:
         smoke_checks:
           - main push 后 production app 重新部署并继续使用 `/home/bricks/data/production/channels`。
           - PR open/synchronize 后创建或更新 `bricks-preview-<branch-slug>`，域名为 `<branch-slug>.craft-dev.bricks.cool`。
+          - Dokku preview deploy 成功后发布 GitHub Deployment status，PR timeline 的 `View deployment` 按钮指向 preview 域名。
           - 每个 preview app mount 到 `/home/bricks/data/previews/<branch-slug>/channels`，不共享 production 或其他 preview 的 channel 文件。
           - Turso credentials, JWT signing secret, and encryption key stay in Dokku server config; preview apps copy them from the production app on the server instead of reading GitHub Actions secrets.
           - Production CSP must allow Flutter Web bootstrap scripts so `craft.bricks.cool` renders the login app instead of a blank page.

--- a/docs/code_maps/feature_map.yaml
+++ b/docs/code_maps/feature_map.yaml
@@ -148,7 +148,7 @@ products:
           - 上传成功后，输入框上方显示带 Authorization header 的 media preview，而不是只显示占位 icon。
           - 发送带图片的消息后，user 气泡显示图片附件并保持原有投递状态。
           - 点击/点按聊天图片附件会打开全屏预览；右上角关闭按钮返回聊天。
-          - 长按聊天图片附件会显示 Download 菜单项，并通过带 Authorization 的下载请求保存图片。
+          - 长按或右键/两指点按聊天图片附件会显示 Download 菜单项，并通过带 Authorization 的下载请求保存图片。
           - Gemini/Google AI Studio 路由收到上传图片时，模型请求包含 text part 与 image part，能够基于图片内容回答。
           - 刷新或 SSE 同步后，图片附件仍从 message metadata 恢复并可加载预览。
           - 访问 media preview/content/download 路由必须携带当前用户 token；跨用户 media id 返回 404。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -279,9 +279,12 @@ index:
     capability: 频道作用域图片上传、预览/下载、生成图片持久化与聊天附件同步
     code_index:
       - apps/node_backend/src/db/migrations/026_create_media_assets.sql
+      - apps/node_backend/src/db/migrations/027_create_media_generation_jobs.sql
       - apps/node_backend/src/routes/media.ts
       - apps/node_backend/src/services/mediaService.ts
+      - apps/node_backend/src/services/mediaGenerationService.ts
       - apps/node_backend/src/services/channelFileService.ts
+      - apps/node_backend/src/services/localAgentLoopService.ts
       - apps/node_backend/src/llm/types.ts
       - apps/node_backend/src/llm/llm_service.ts
       - apps/node_backend/src/routes/chat.ts
@@ -293,10 +296,14 @@ index:
       - apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
     doc_index:
       - docs/tasks/done/2026-06-29-23-06-CST-media-upload-preview-multimodal.md
+      - docs/tasks/doing/2026-06-29-14-32-CST-gemini-image-video-generation-architecture.md
       - docs/tasks/doing/2026-06-29-16-13-CST-dokku-channel-media-deployment-plan.md
     test_index:
       - apps/node_backend/src/services/channelFileService.test.ts
       - apps/node_backend/src/services/mediaService.test.ts
+      - apps/node_backend/src/services/mediaGenerationService.test.ts
+      - apps/node_backend/src/routes/media.test.ts
+      - apps/node_backend/src/services/localAgentLoopService.test.ts
       - apps/node_backend/src/routes/chat.test.ts
       - apps/mobile_chat_app/test/message_list_test.dart
       - apps/mobile_chat_app/test/chat_history_api_service_test.dart
@@ -307,7 +314,14 @@ index:
       - mediaAttachments
       - image upload
       - generated image
+      - generated video
+      - media_generation_jobs
       - Gemini image input
+      - Gemini image generation
+      - Veo video generation
+      - referenceImages
+      - firstFrame
+      - lastFrame
       - multimodal parts
       - previewUrl
       - downloadUrl
@@ -318,8 +332,11 @@ index:
       - channel_relative_path 必须拒绝绝对路径、空 path、`..` 与反斜杠逃逸；否则 Agent/media 路径可能越过当前 channel root。
       - Flutter Image.network 预览依赖 Authorization header；若 AuthService token hydration 失败，图片附件会显示 broken image 但消息文本仍可见。
       - Gemini 多模态输入只应把当前用户可访问、当前 channel 的 ready image asset 转为 image part；错误地传递跨 channel 或失败 asset 会造成隐私或 provider 错误风险。
+      - Gemini image generation 和 Veo reference images 只能读取当前用户、当前 channel、ready image asset；跨 channel 或非 image media 必须被拒绝。
+      - Veo operation 完成后必须及时下载 provider video URI 到 Bricks-owned storage；只保存 provider URI 会受 2 天 provider retention 影响。
+      - "`media_generation_jobs` 轮询依赖用户仍有可用 Google AI Studio 配置；若 key 被删除或替换，running job 需要进入显式 failed 状态而不是永久 pending。"
       - chat_messages.metadata 是第一阶段附件同步桥；后续若改为 join 查询，需要继续保证 sync/history/SSE 返回 mediaAttachments。
-      - 生成图片当前只实现持久化入口，完整 provider-side image generation 仍需后续 Gemini capability/tool 集成。
+      - 生成媒体已接入 backend API 和 local agent tools；移动端显式生成 UI、poster/thumbnail rendition、后台 cron worker 仍是后续风险点。
 
 
   - feature_id: scope_instructions_config

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -318,6 +318,8 @@ index:
       - media_generation_jobs
       - Gemini image input
       - Gemini image generation
+      - media_image_generate
+      - media_video_generate
       - Veo video generation
       - referenceImages
       - firstFrame
@@ -336,6 +338,7 @@ index:
       - Veo operation 完成后必须及时下载 provider video URI 到 Bricks-owned storage；只保存 provider URI 会受 2 天 provider retention 影响。
       - "`media_generation_jobs` 轮询依赖用户仍有可用 Google AI Studio 配置；若 key 被删除或替换，running job 需要进入显式 failed 状态而不是永久 pending。"
       - chat_messages.metadata 是第一阶段附件同步桥；后续若改为 join 查询，需要继续保证 sync/history/SSE 返回 mediaAttachments。
+      - Agent tool 生成的 media 不应只作为模型文本里的 `[image: ...]` 标记返回；最终 assistant 消息必须结构化写入 mediaAttachments，否则刷新和真实预览都会丢失。
       - 生成媒体已接入 backend API 和 local agent tools；移动端显式生成 UI、poster/thumbnail rendition、后台 cron worker 仍是后续风险点。
 
 

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -730,6 +730,7 @@ index:
       - preview branch slug 必须同时满足 Dokku app name、DNS label 与 Cloudflare wildcard 约束；过长或含非法字符会导致 app/domain 创建失败。
       - GitHub OAuth 只能回调主域名；`return_to` allowlist 必须允许合法 preview 子域名，并拒绝 apex、大小写/下划线和相邻恶意域名。
       - 静态资源回退必须避开 `/api` 路由，否则 API 404 会被 SPA index.html 覆盖。
+      - Flutter Web app shell 文件名不带内容 hash；若 `main.dart.js` 或 `flutter.js` 被长缓存，preview deploy 后浏览器会继续运行旧 UI。
       - PR close/merge 清理必须限制在 `/home/bricks/data/previews/<slug>` 命名空间内，避免误删生产数据。
 
   - feature_id: conversational_todos

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -555,6 +555,7 @@ index:
       - return_to 校验规则变动可能引入开放重定向漏洞。
       - native callback target 放宽过度会引入自定义 scheme 开放跳转风险。
       - 认证路由限流策略过严会导致正常登录流程误触发 429。
+      - authRoutes 同时挂载在 `/api/auth` 与 legacy `/api`；anonymous OAuth limiter 必须只包 OAuth endpoints，否则会在 `/api/config` 等后续路由前返回 429。
 
   - feature_id: backend_chat_llm
     capability: 后端聊天与 LLM 路由

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -724,6 +724,7 @@ index:
       - Flutter Web CSP
       - production deploy
       - pull request preview
+      - GitHub deployment status
       - preview cleanup
     change_risks:
       - production app 与 preview app 不能共用 `/home/bricks/data` 子目录；否则 PR 构建可能读取或污染生产 channel media/workspace。
@@ -731,6 +732,7 @@ index:
       - GitHub OAuth 只能回调主域名；`return_to` allowlist 必须允许合法 preview 子域名，并拒绝 apex、大小写/下划线和相邻恶意域名。
       - 静态资源回退必须避开 `/api` 路由，否则 API 404 会被 SPA index.html 覆盖。
       - Flutter Web app shell 文件名不带内容 hash；若 `main.dart.js` 或 `flutter.js` 被长缓存，preview deploy 后浏览器会继续运行旧 UI。
+      - Dokku preview workflow 必须创建成功的 GitHub Deployment status 并设置 `environment_url`，否则 PR timeline 不会显示原生 `View deployment` 按钮。
       - PR close/merge 清理必须限制在 `/home/bricks/data/previews/<slug>` 命名空间内，避免误删生产数据。
 
   - feature_id: conversational_todos

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -338,6 +338,7 @@ index:
       - media_assets 必须按 user_id 授权读取；若只按 media id 查找，可能泄露其他用户上传/生成图片。
       - channel_relative_path 必须拒绝绝对路径、空 path、`..` 与反斜杠逃逸；否则 Agent/media 路径可能越过当前 channel root。
       - Flutter Image.network 预览依赖 Authorization header；若 AuthService token hydration 失败，图片附件会显示 broken image 但消息文本仍可见。
+      - 桌面 Safari 对聊天图片 tile 的高阶 tap 手势可能不稳定；缩略图打开必须保留 primary pointer down/up 链路和可见 Open image 入口，避免只依赖 GestureDetector.onTap。
       - Web 下载不能直接导航到 `/download`，必须用当前 token 拉取 Blob 后触发浏览器下载；否则受保护 media 会返回 401。
       - Gemini 多模态输入只应把当前用户可访问、当前 channel 的 ready image asset 转为 image part；错误地传递跨 channel 或失败 asset 会造成隐私或 provider 错误风险。
       - Gemini image generation 和 Veo reference images 只能读取当前用户、当前 channel、ready image asset；跨 channel 或非 image media 必须被拒绝。

--- a/docs/code_maps/logic_map.yaml
+++ b/docs/code_maps/logic_map.yaml
@@ -291,6 +291,9 @@ index:
       - apps/node_backend/src/services/chatAsyncTransportService.ts
       - apps/mobile_chat_app/lib/features/chat/chat_message.dart
       - apps/mobile_chat_app/lib/features/chat/chat_history_api_service.dart
+      - apps/mobile_chat_app/lib/features/chat/media_download.dart
+      - apps/mobile_chat_app/lib/features/chat/media_download_stub.dart
+      - apps/mobile_chat_app/lib/features/chat/media_download_web.dart
       - apps/mobile_chat_app/lib/features/chat/chat_screen.dart
       - apps/mobile_chat_app/lib/features/chat/widgets/composer_bar.dart
       - apps/mobile_chat_app/lib/features/chat/widgets/message_list.dart
@@ -327,12 +330,15 @@ index:
       - multimodal parts
       - previewUrl
       - downloadUrl
+      - full-screen media preview
+      - authenticated media download
       - FilePicker
       - Image.network Authorization
     change_risks:
       - media_assets 必须按 user_id 授权读取；若只按 media id 查找，可能泄露其他用户上传/生成图片。
       - channel_relative_path 必须拒绝绝对路径、空 path、`..` 与反斜杠逃逸；否则 Agent/media 路径可能越过当前 channel root。
       - Flutter Image.network 预览依赖 Authorization header；若 AuthService token hydration 失败，图片附件会显示 broken image 但消息文本仍可见。
+      - Web 下载不能直接导航到 `/download`，必须用当前 token 拉取 Blob 后触发浏览器下载；否则受保护 media 会返回 401。
       - Gemini 多模态输入只应把当前用户可访问、当前 channel 的 ready image asset 转为 image part；错误地传递跨 channel 或失败 asset 会造成隐私或 provider 错误风险。
       - Gemini image generation 和 Veo reference images 只能读取当前用户、当前 channel、ready image asset；跨 channel 或非 image media 必须被拒绝。
       - Veo operation 完成后必须及时下载 provider video URI 到 Bricks-owned storage；只保存 provider URI 会受 2 天 provider retention 影响。

--- a/docs/tasks/doing/2026-06-29-14-32-CST-gemini-image-video-generation-architecture.md
+++ b/docs/tasks/doing/2026-06-29-14-32-CST-gemini-image-video-generation-architecture.md
@@ -1,0 +1,129 @@
+# Gemini Media Generation and Preview Architecture
+
+## Background
+
+Bricks currently routes local chat through `/api/chat/respond`, persists `chat_messages.content` as plain text, synchronizes message rows over `/api/chat/sync` and `/api/chat/events/:sessionId`, and sends model requests through the backend LLM abstraction backed by AI SDK `LanguageModel` adapters. The current `UnifiedMessage` contract only carries string content, and the mobile chat composer calls `onSend(String text)`.
+
+The `chat_domain` package already defines attachment concepts, but the production mobile chat view-model, API DTOs, async transport service, database schema, and model prompt assembly do not carry attachments.
+
+Gemini image understanding supports mixed text and image input, either as inline base64 data with a 20MB total request limit or via uploaded File API URIs for larger/reused media. Gemini image generation supports text-to-image, text-and-image-to-image editing, multi-turn image iteration, configurable image response formats, and multi-reference-image workflows. Gemini Veo video generation is a long-running operation, currently exposed separately from normal chat streaming, with generated video files retained by Google for a limited time and requiring explicit download for durable storage.
+
+Because uploaded images, generated images, and generated videos all need preview, download, ownership, retention, and message attachment behavior, this work should be designed as a shared media capability rather than three unrelated feature patches.
+
+## Goals
+
+- Let users send one or more images together with text in a normal chat message.
+- Let users generate images from text and edit/generate images from uploaded reference images.
+- Let users generate videos from text and, where supported by the selected model, from image references.
+- Preserve image attachments through mobile UI, backend validation, database persistence, sync/SSE, message rendering, and model-context replay.
+- Add generated image and video capabilities through asynchronous media jobs where useful, not as fragile blocking chat requests.
+- Support preview, full-size open, and download for uploaded images, generated images, and generated videos.
+- Store generated media durably in Bricks-owned storage or a repository-approved asset store before provider-side temporary retention expires.
+- Keep provider-specific media behavior behind backend capability interfaces so Anthropic/OpenClaw/plugin routes remain stable.
+- Update code maps once implementation changes feature entry points, backend logic, database schema, tests, and documentation indexes.
+
+## Implementation Status: 2026-06-30
+
+The first production slice implements provider-side Gemini media generation on the Node backend:
+
+- `POST /api/media/image-generations` calls the Gemini Interactions API, supports text-to-image and text-plus-reference-image generation, and persists the returned image as a Bricks `generated_image` media asset.
+- `POST /api/media/video-generations` starts a Veo long-running operation and persists a `media_generation_jobs` row with the provider operation name.
+- `GET /api/media/generation-jobs/:jobId` and `POST /api/media/generation-jobs/:jobId/poll` refresh pending video jobs; when Veo completes, Bricks downloads the provider video URI into `media/generated/videos/` and creates a `generated_video` media asset.
+- Local agent tools now expose `media_image_generate` and `media_video_generate`, so Bricks Default can invoke generation through the normal tool loop.
+- Video reference-image input follows the official Veo REST shape: `referenceImages` contains up to three `{ image: { inlineData: { mimeType, data } }, referenceType: "asset" }` entries. First/last frame support is also wired as `image` and `lastFrame`, with `lastFrame` requiring a first frame.
+- The dedicated durable worker/cron loop, generated-media chat attachment UX, poster/thumbnail renditions, and full mobile controls remain follow-up work.
+
+Official docs checked:
+
+- Gemini image generation / editing: https://ai.google.dev/gemini-api/docs/image-generation
+- Veo video generation, reference images, first/last frames, operation polling, and download: https://ai.google.dev/gemini-api/docs/video
+
+## Implementation Plan
+
+1. Define a production media asset and attachment contract.
+   - Add a shared media DTO for uploaded and generated assets with stable fields such as `id`, `kind`, `origin`, `mimeType`, `sizeBytes`, `filename`, `storageKey` or `url`, `thumbnailStorageKey` or `thumbnailUrl`, `providerFileUri`, `providerOperationName`, `width`, `height`, `durationMs`, `status`, and optional moderation/error metadata.
+   - Use `kind` values such as `image`, `video`, and future-safe `file`; use `origin` values such as `user_upload`, `generated_image`, and `generated_video`.
+   - Add a message attachment DTO that references media asset IDs and controls per-message presentation, caption text, ordering, and whether the attachment is an input reference or generated output.
+   - Reconcile this with `packages/chat_domain/lib/src/attachments.dart` instead of inventing a second unrelated shape.
+   - Decide whether original uploads are stored in Bricks storage first, Gemini File API first, or both. Prefer Bricks-owned storage as the canonical record, with provider file URIs treated as cache/adapter metadata.
+   - Generate and persist thumbnails/posters for previews rather than forcing every chat list render to load original files.
+
+2. Add upload, preview, and download APIs.
+   - Add backend routes such as `POST /api/media/uploads` and `GET /api/media/:id` or signed-URL endpoints.
+   - Add preview/download routes such as `GET /api/media/:id/preview`, `GET /api/media/:id/content`, and `GET /api/media/:id/download`, or signed URL equivalents with ownership checks.
+   - Add database tables for media assets, media renditions, and message-attachment joins, or extend `chat_messages.metadata` only for a short migration bridge. Prefer normalized tables for binary lifecycle, reuse, status, cleanup, and download auditability.
+   - Enforce per-user ownership, MIME allowlists, size limits, image dimension limits, and request-rate limits.
+   - Return enough metadata for clients to render previews without additional heavy lookups: media ID, kind, MIME type, dimensions, duration, thumbnail URL, content URL, download URL, status, and error text.
+   - For Flutter mobile/web, use `file_picker` or platform image picking to select images, preview them in the composer, upload before send, and include attachment IDs in `/api/chat/respond`.
+
+3. Extend chat transport to carry attachments.
+   - Update `ChatMessage`, `ChatHistoryApiService`, `/api/chat/respond`, `/api/chat/messages/batch`, `MessageUpsertInput`, `toMessageDto`, sync, SSE, and message rendering to include attachments.
+   - Allow text to be empty only when attachments are present if product wants image-only sends.
+   - Make user bubble rendering show image thumbnails with retry/remove states before send and durable preview states after sync.
+   - Make assistant bubble rendering show generated image and video outputs as first-class attachments, with preview, open, and download actions.
+   - Ensure plugin/OpenClaw dispatch receives attachment metadata without assuming local filesystem paths are available.
+
+4. Extend LLM request types from text-only to multi-part messages.
+   - Change `UnifiedMessage.content` from `string` to a typed text/image/file part list, while preserving a simple helper for existing text-only callers.
+   - In `listSessionMessagesForModel`, reconstruct recent messages with attachments and budget text plus media references deliberately.
+   - For Google AI Studio, map image attachments to AI SDK/Gemini multimodal parts or to direct `@google/genai` Interactions API inputs. Use inline data only for small images; use Gemini Files API for larger or repeated images.
+   - For Anthropic and any unsupported route, either map to that provider's media format or return a clear capability error.
+
+5. Add provider capability detection.
+   - Extend model/provider config metadata with capabilities such as `textInput`, `imageInput`, `imageGeneration`, `imageEditing`, `videoGeneration`, `referenceImages`, `fileUpload`, `streamingText`, and `backgroundJobs`.
+   - Surface unsupported combinations in UI before send, for example when the active route cannot accept images, cannot generate images, or cannot generate video.
+   - Keep display labels and stable capability IDs separate so model names can change without rewriting feature logic.
+   - Add smoke tests for Gemini text+image, image generation, and negative tests for unsupported providers/routes.
+
+6. Implement image generation and editing.
+   - Add `POST /api/media/image-generations` or a chat command/tool path that accepts a prompt, optional reference media IDs, response format options, and an idempotency key.
+   - Use Gemini image models for text-to-image and text-and-image-to-image flows, decoding provider output images and saving them as Bricks media assets immediately.
+   - Treat multi-turn image editing as a media job/session concern: store provider interaction IDs only as provider metadata, while keeping the generated media asset as the durable product record.
+   - Attach generated images to assistant messages and update the chat over existing sync/SSE.
+   - Support image preview, full-size open, and download from the same media APIs used for uploads.
+   - Represent safety blocks, provider errors, empty image responses, and unsupported format requests as explicit failed assistant/job states.
+
+7. Implement video generation as a durable async job.
+   - Add a media job table with `job_id`, `job_type`, `user_id`, `channel_id`, `session_id`, `thread_id`, `prompt`, input attachment IDs, provider, model, provider operation name, status, progress/status text, result media IDs, error, timestamps, and idempotency key.
+   - Add `POST /api/media/video-generations` or a chat command/tool path that creates a job and writes a chat status message.
+   - Support text-to-video first, then image-to-video/reference-image generation when the selected Veo model supports it.
+   - Poll Veo long-running operations from a durable worker/cron/retry loop, not from a post-response in-process async function.
+   - Download finished videos immediately into Bricks-owned storage, create poster/thumbnail renditions, attach the result to an assistant message, and update status over the existing SSE/sync mechanism.
+   - Support video preview/playback, open, and download from the same media APIs used for generated images.
+   - Represent failure states explicitly in chat so safety blocks, provider errors, timeouts, and expired provider files do not leave a permanent spinner.
+
+8. Design unified media UI entry points.
+   - Add an image attach icon to the composer and thumbnail strip above the text field.
+   - Add generation actions for `Generate image` and `Generate video`, either through a composer mode selector, slash commands, or agent tools. Keep these modes explicit until media generation behavior is stable.
+   - Provide per-attachment actions for preview/open, download, remove-before-send, retry-upload, retry-generation, and copy media link where appropriate.
+   - Render uploaded images, generated images, and generated videos consistently in the message list, while preserving compact chat readability.
+   - Use icon buttons and tooltips for attachment, preview, download, remove, and retry actions.
+   - Ensure mobile and desktop layouts have bounded preview sizes, no text overlap, and no layout shift while thumbnails load.
+
+9. Validate and document.
+   - Add backend unit tests for attachment validation, ownership, preview/download authorization, sync serialization, model part conversion, generated image persistence, and Veo job state transitions.
+   - Add Flutter widget tests for composer image attachment, media preview/download actions, generated media rendering, and unsupported-provider UI states.
+   - Add provider smoke coverage in `packages/bricks_ai_smoke_test` for Gemini image input and Gemini image generation, plus a gated Veo smoke test if cost/availability allows.
+   - Update `docs/code_maps/feature_map.yaml` and `docs/code_maps/logic_map.yaml` after implementation.
+
+## Acceptance Criteria
+
+- A user can attach an image, type text, send both together, refresh the conversation, and still see the image and text in the same message.
+- A Gemini-capable local route receives the image and text as multimodal input and can answer questions about the image.
+- A user can generate an image from text and see the result as a durable assistant attachment with preview and download actions.
+- A user can generate or edit an image using uploaded reference images when the selected model supports image editing/reference images.
+- Unsupported providers/routes show a clear error before or during send, without losing the draft or creating a stuck assistant message.
+- A user can request video generation, see an accepted/pending state, leave and return to the thread, and later see either a playable generated video or a clear failure message.
+- Uploaded images, generated images, and generated videos support preview/open and download with ownership checks.
+- Generated videos and generated images are downloaded or decoded into Bricks-owned storage before any provider-side retention window expires.
+- Video generation does not depend on Vercel post-response in-process work continuing after the HTTP response has been sent.
+- Existing text-only chat, OpenClaw plugin routing, message sync, and thread naming continue to work.
+- Code maps are updated to include the new media upload, preview/download, multimodal model routing, image generation, and video generation job paths.
+
+## Validation Commands
+
+- `./tools/init_dev_env.sh`
+- `cd apps/node_backend && npm test`
+- `cd apps/node_backend && npm run type-check`
+- `cd apps/mobile_chat_app && flutter test`
+- `cd packages/bricks_ai_smoke_test && dart test`

--- a/docs/tasks/doing/2026-06-29-14-32-CST-gemini-image-video-generation-architecture.md
+++ b/docs/tasks/doing/2026-06-29-14-32-CST-gemini-image-video-generation-architecture.md
@@ -31,6 +31,7 @@ The first production slice implements provider-side Gemini media generation on t
 - `GET /api/media/generation-jobs/:jobId` and `POST /api/media/generation-jobs/:jobId/poll` refresh pending video jobs; when Veo completes, Bricks downloads the provider video URI into `media/generated/videos/` and creates a `generated_video` media asset.
 - Local agent tools now expose `media_image_generate` and `media_video_generate`, so Bricks Default can invoke generation through the normal tool loop.
 - Video reference-image input follows the official Veo REST shape: `referenceImages` contains up to three `{ image: { inlineData: { mimeType, data } }, referenceType: "asset" }` entries. First/last frame support is also wired as `image` and `lastFrame`, with `lastFrame` requiring a first frame.
+- Follow-up fix from preview testing: media generation job updates use `CURRENT_TIMESTAMP` instead of PostgreSQL-only `NOW()`, and chat-scoped agent tools receive the current `channelId`, `threadId`, and user message as prompt fallback when the model omits them.
 - The dedicated durable worker/cron loop, generated-media chat attachment UX, poster/thumbnail renditions, and full mobile controls remain follow-up work.
 
 Official docs checked:

--- a/docs/tasks/doing/2026-06-29-14-32-CST-gemini-image-video-generation-architecture.md
+++ b/docs/tasks/doing/2026-06-29-14-32-CST-gemini-image-video-generation-architecture.md
@@ -32,7 +32,8 @@ The first production slice implements provider-side Gemini media generation on t
 - Local agent tools now expose `media_image_generate` and `media_video_generate`, so Bricks Default can invoke generation through the normal tool loop.
 - Video reference-image input follows the official Veo REST shape: `referenceImages` contains up to three `{ image: { inlineData: { mimeType, data } }, referenceType: "asset" }` entries. First/last frame support is also wired as `image` and `lastFrame`, with `lastFrame` requiring a first frame.
 - Follow-up fix from preview testing: media generation job updates use `CURRENT_TIMESTAMP` instead of PostgreSQL-only `NOW()`, and chat-scoped agent tools receive the current `channelId`, `threadId`, and user message as prompt fallback when the model omits them.
-- The dedicated durable worker/cron loop, generated-media chat attachment UX, poster/thumbnail renditions, and full mobile controls remain follow-up work.
+- Follow-up fix from preview testing: successful `media_image_generate` tool results are copied into assistant `mediaAttachments`, so generated images render through the existing authenticated preview UI instead of only appearing as `[image: ...]` text markers.
+- The dedicated durable worker/cron loop, generated-video completion attachment updates, poster/thumbnail renditions, and full mobile controls remain follow-up work.
 
 Official docs checked:
 

--- a/docs/tasks/doing/2026-06-30-13-09-CST-media-preview-download-actions.md
+++ b/docs/tasks/doing/2026-06-30-13-09-CST-media-preview-download-actions.md
@@ -1,0 +1,39 @@
+# Media Preview and Download Actions
+
+## Background
+
+Chat media attachments already render authenticated thumbnails in message bubbles. Users can see generated or uploaded images, but the thumbnail itself is not interactive and there is no direct download action from the chat message.
+
+## Goals
+
+- Let users tap or click an image attachment to open a full-screen preview.
+- Let users close the preview and return to chat with a clear icon button.
+- Let users long-press an image attachment to open a context menu with a download action.
+- Keep downloads authenticated by using the current bearer token instead of unauthenticated navigation.
+
+## Implementation Plan
+
+1. Add a small chat media download helper with a web implementation that fetches `downloadUrl` using the auth token and triggers a browser download.
+2. Update message media tiles to handle tap/click and long-press gestures.
+3. Add a full-screen image preview route/dialog that uses the existing media `contentUrl` and auth headers.
+4. Add widget coverage for opening the preview and exposing the download menu.
+
+## Implementation Status: 2026-06-30
+
+- Added a web media downloader that fetches protected media with the current bearer token and saves it through a browser Blob download.
+- Added tap/click handling on chat image attachments to open a full-screen authenticated preview with a close button back to chat.
+- Added long-press handling on chat image attachments to show a Download context menu action.
+- Added `MessageList` widget tests for opening/closing the preview and exposing the download action.
+
+## Acceptance Criteria
+
+- Tapping or clicking a chat image opens a full-screen preview.
+- The preview has a close/cancel icon button that returns to chat.
+- Long-pressing a chat image shows a context menu with Download.
+- Download uses the authenticated media download URL.
+
+## Validation Commands
+
+- `./tools/init_dev_env.sh`
+- `cd apps/mobile_chat_app && dart format lib/features/chat/widgets/message_list.dart lib/features/chat/media_download.dart lib/features/chat/media_download_stub.dart lib/features/chat/media_download_web.dart test/message_list_test.dart`
+- `cd apps/mobile_chat_app && flutter test test/message_list_test.dart`

--- a/docs/tasks/doing/2026-06-30-13-09-CST-media-preview-download-actions.md
+++ b/docs/tasks/doing/2026-06-30-13-09-CST-media-preview-download-actions.md
@@ -22,14 +22,14 @@ Chat media attachments already render authenticated thumbnails in message bubble
 
 - Added a web media downloader that fetches protected media with the current bearer token and saves it through a browser Blob download.
 - Added tap/click handling on chat image attachments to open a full-screen authenticated preview with a close button back to chat.
-- Added long-press handling on chat image attachments to show a Download context menu action.
+- Added long-press and secondary-click handling on chat image attachments to show a Download context menu action.
 - Added `MessageList` widget tests for opening/closing the preview and exposing the download action.
 
 ## Acceptance Criteria
 
 - Tapping or clicking a chat image opens a full-screen preview.
 - The preview has a close/cancel icon button that returns to chat.
-- Long-pressing a chat image shows a context menu with Download.
+- Long-pressing or right-clicking/two-finger-clicking a chat image shows a context menu with Download.
 - Download uses the authenticated media download URL.
 
 ## Validation Commands

--- a/docs/tasks/doing/2026-06-30-14-33-CST-media-fullscreen-download-action.md
+++ b/docs/tasks/doing/2026-06-30-14-33-CST-media-fullscreen-download-action.md
@@ -1,0 +1,33 @@
+# Media Fullscreen Download Action
+
+## Background
+
+Desktop browser long-press and secondary-click gestures are unreliable for image attachment downloads. Chrome can open the fullscreen image preview, while Safari may not consistently trigger the thumbnail tap path.
+
+## Goals
+
+- Make thumbnail primary click/tap reliable in desktop browsers, including Safari.
+- Add a visible download control to the fullscreen image preview.
+- Keep the existing close/back-to-chat control.
+- Reuse the existing authenticated media download implementation.
+
+## Implementation Plan
+
+1. Pass download URL, filename, and auth token into the fullscreen media preview.
+2. Add a download icon button next to the close button.
+3. Open image thumbnails from primary pointer down/up instead of relying only on the tap recognizer.
+4. Keep long-press and secondary-click menus from also opening the preview.
+5. Cover the thumbnail and fullscreen controls with a widget test.
+
+## Acceptance Criteria
+
+- Opening an image preview shows both `Download image` and `Back to chat` controls.
+- Tapping `Back to chat` still closes the preview.
+- Image thumbnails expose an `Open image` control and primary click/tap opens the preview.
+- The download button uses the existing authenticated download path.
+
+## Validation Commands
+
+- `./tools/init_dev_env.sh`
+- `cd apps/mobile_chat_app && dart format lib/features/chat/widgets/message_list.dart test/message_list_test.dart`
+- `cd apps/mobile_chat_app && flutter test test/message_list_test.dart`

--- a/docs/tasks/doing/2026-06-30-15-02-CST-auth-limiter-scope.md
+++ b/docs/tasks/doing/2026-06-30-15-02-CST-auth-limiter-scope.md
@@ -1,0 +1,27 @@
+# Auth Limiter Scope
+
+## Background
+
+The preview app returned `Too many anonymous auth requests from this IP` for an authenticated `GET /api/config?category=llm` request. The request carried an Authorization bearer token, so the failure was not an anonymous user state.
+
+## Goals
+
+- Keep anonymous OAuth rate limiting for GitHub login start/callback routes.
+- Prevent the legacy `/api` auth mount from applying the anonymous auth limiter to later API routes such as `/api/config`.
+- Add regression coverage for the production route mounting order.
+
+## Implementation Plan
+
+1. Scope `anonymousAuthLimiter` to OAuth anonymous endpoints only.
+2. Add an auth route integration test that mounts `authRoutes` at `/api` before a config route and repeatedly reads config.
+3. Update code maps for the auth limiter routing risk.
+
+## Acceptance Criteria
+
+- Authenticated `GET /api/config?category=llm` is not blocked by anonymous auth rate limiting.
+- OAuth start/callback routes still keep the anonymous auth limiter.
+- Focused backend route tests pass.
+
+## Validation Commands
+
+- `cd apps/node_backend && npm test -- --run src/routes/auth.test.ts src/routes/config.test.ts`

--- a/docs/tasks/doing/2026-06-30-15-23-CST-flutter-web-static-cache.md
+++ b/docs/tasks/doing/2026-06-30-15-23-CST-flutter-web-static-cache.md
@@ -1,0 +1,29 @@
+# Flutter Web Static Cache Headers
+
+## Background
+
+The Dokku preview deployed the latest commit, but browsers could still run an old Flutter Web bundle because `main.dart.js` was served with `Cache-Control: public, max-age=14400`.
+
+## Goals
+
+- Prevent preview and production browsers from keeping stale app shell JavaScript after deploys.
+- Keep ordinary static files cacheable for a short period.
+- Cover the cache policy in backend app tests.
+
+## Implementation Plan
+
+1. Add explicit static cache headers in the Express static file server.
+2. Set `no-store, no-cache, must-revalidate, max-age=0` for unversioned Flutter app shell files and SPA fallback responses.
+3. Keep non-shell static files on a short cache policy.
+4. Add app-level tests for static cache headers.
+
+## Acceptance Criteria
+
+- `/`, `/main.dart.js`, `/flutter.js`, and SPA fallback paths return no-store/no-cache headers.
+- Non-shell static assets return the short cache policy.
+- Backend app tests and type-check pass.
+
+## Validation Commands
+
+- `cd apps/node_backend && npm test -- --run src/app.test.ts`
+- `cd apps/node_backend && npm run type-check`

--- a/docs/tasks/doing/2026-06-30-16-39-CST-dokku-preview-github-deployment-button.md
+++ b/docs/tasks/doing/2026-06-30-16-39-CST-dokku-preview-github-deployment-button.md
@@ -1,0 +1,39 @@
+# Dokku Preview GitHub Deployment Button
+
+## Background
+
+Vercel creates GitHub deployment timeline events on pull requests, which makes
+GitHub show a native "View deployment" button. The Dokku preview workflow
+currently deploys the preview app successfully but only exposes the result as an
+Actions job, so the PR timeline does not get the same deployment affordance.
+
+## Goals
+
+- Publish a GitHub Deployment after a Dokku preview deploy succeeds.
+- Attach the preview URL as the deployment `environment_url` so GitHub renders a
+  "View deployment" button.
+- Keep each PR preview environment transient and tied to the branch slug.
+
+## Implementation Plan
+
+1. Grant the Dokku preview workflow `deployments: write` permission.
+2. After HTTPS enablement, create a GitHub Deployment for the pull request head
+   SHA.
+3. Create a successful Deployment Status with the Dokku preview URL and Actions
+   run URL.
+4. Update code maps so future deployment changes preserve the GitHub PR
+   timeline integration.
+
+## Acceptance Criteria
+
+- When a Dokku PR preview deploy succeeds, the PR timeline shows a GitHub
+  deployment event with a "View deployment" button.
+- The button opens `https://<branch-slug>.craft-dev.bricks.cool`.
+- The deployment is marked as a non-production transient environment.
+- The workflow still cleans up Dokku preview apps on PR close.
+
+## Validation Commands
+
+- `npx js-yaml .github/workflows/dokku_preview_deploy.yml > /dev/null`
+- `npx js-yaml docs/code_maps/feature_map.yaml > /dev/null`
+- `npx js-yaml docs/code_maps/logic_map.yaml > /dev/null`


### PR DESCRIPTION
Summary
- Add provider-side Gemini image generation via /api/media/image-generations and persist returned images as generated_image media assets.
- Add durable media_generation_jobs plus Veo video generation start/poll flow; completed videos are downloaded into Bricks media storage as generated_video assets.
- Expose media_image_generate and media_video_generate local agent tools.
- Document official Gemini/Veo input shapes and update code maps.

Validation
- cd apps/node_backend && npm run type-check
- cd apps/node_backend && npm test
- ruby YAML parse for docs/code_maps/feature_map.yaml and docs/code_maps/logic_map.yaml

Notes
- This slice is backend/API/tool flow first. Explicit mobile generation UI, poster thumbnails, and a durable worker/cron poller remain follow-up work.
- Official docs checked: https://ai.google.dev/gemini-api/docs/image-generation and https://ai.google.dev/gemini-api/docs/video