### PR TITLE
[codex] Preserve craft-spaces wildcard domain

### DIFF
--- a/.github/workflows/dokku_production_deploy.yml
+++ b/.github/workflows/dokku_production_deploy.yml
@@ -18,6 +18,7 @@ jobs:
       DOKKU_PORT: ${{ secrets.DOKKU_PORT || '22' }}
       DOKKU_APP: bricks
       PRODUCTION_DOMAIN: craft.bricks.cool
+      PUBLIC_SITE_DOMAIN: craft-spaces.bricks.cool
       PRODUCTION_SANDBOX_ROOT: /home/bricks/data/production/sandboxes
     steps:
       - name: Checkout repository
@@ -41,12 +42,13 @@ jobs:
             app="bricks"
             data_root="/home/bricks/data/production/sandboxes"
             domain="craft.bricks.cool"
+            public_site_domain="craft-spaces.bricks.cool"
             dokku apps:exists "$app" || dokku apps:create "$app"
             mkdir -p "$data_root"
             if ! dokku storage:list "$app" | grep -Fq "$data_root:/app/data/sandboxes"; then
               dokku storage:mount "$app" "$data_root:/app/data/sandboxes"
             fi
-            dokku domains:set "$app" "$domain"
+            dokku domains:set "$app" "$domain" "$public_site_domain" "*.$public_site_domain"
             if ! dokku ports:list "$app" | grep -Eq 'http:80:3000|http[[:space:]]+80[[:space:]]+3000'; then
               dokku ports:set "$app" http:80:3000
             fi

--- a/docs/deploy/dokku.md
+++ b/docs/deploy/dokku.md
@@ -25,9 +25,16 @@ Preview host data:
 dokku apps:create bricks
 mkdir -p /home/bricks/data/production/sandboxes
 dokku storage:mount bricks /home/bricks/data/production/sandboxes:/app/data/sandboxes
-dokku domains:set bricks craft.bricks.cool
+dokku domains:set bricks craft.bricks.cool craft-spaces.bricks.cool '*.craft-spaces.bricks.cool'
 dokku letsencrypt:enable bricks
 ```
+
+Generated channel sites use stable wildcard hosts such as
+`https://s-abc123.craft-spaces.bricks.cool/`. The production app must keep both
+`craft-spaces.bricks.cool` and `*.craft-spaces.bricks.cool` bound to the same
+Dokku app so future site slugs route without per-site domain changes. Cloudflare
+edge certificates cover the browser-to-Cloudflare hop; the Dokku origin must
+also accept the wildcard SNI for Cloudflare-to-origin TLS.
 
 Install the same-host sandbox runner before enabling AI shell execution:
 

--- a/docs/tasks/done/2026-07-03-19-22-CST-craft-spaces-wildcard-origin-tls.md
+++ b/docs/tasks/done/2026-07-03-19-22-CST-craft-spaces-wildcard-origin-tls.md
@@ -1,0 +1,43 @@
+# Craft Spaces Wildcard Origin TLS
+
+## Background
+
+Published channel sites use canonical URLs under
+`https://<slug>.craft-spaces.bricks.cool/`. Cloudflare edge certificates cover
+`*.craft-spaces.bricks.cool`, but requests currently fail before reaching the
+Bricks backend because the Dokku origin only knows `craft.bricks.cool`.
+
+## Goals
+
+- Configure the production Dokku origin to accept `craft-spaces.bricks.cool`
+  and `*.craft-spaces.bricks.cool`.
+- Install or document the required origin TLS certificate for wildcard site
+  hosts.
+- Verify that a published site such as
+  `https://s-d1893c434ca7.craft-spaces.bricks.cool/` reaches the Bricks static
+  site host and returns the generated site.
+
+## Acceptance Criteria
+
+- Source-side TLS succeeds for `SNI=s-d1893c434ca7.craft-spaces.bricks.cool`.
+- `https://s-d1893c434ca7.craft-spaces.bricks.cool/` returns HTTP 200.
+- The response includes `X-Robots-Tag: noindex`.
+- Dokku `bricks` domains include `craft.bricks.cool`,
+  `craft-spaces.bricks.cool`, and `*.craft-spaces.bricks.cool`.
+
+## Validation Commands
+
+- `ssh -p 59322 root@149.28.225.252 dokku domains:report bricks`
+- `ssh -p 59322 root@149.28.225.252 dokku certs:report bricks`
+- `openssl s_client -connect 149.28.225.252:443 -servername s-d1893c434ca7.craft-spaces.bricks.cool -brief`
+- `curl -I https://s-d1893c434ca7.craft-spaces.bricks.cool/`
+
+## Result
+
+- Added `craft-spaces.bricks.cool` and `*.craft-spaces.bricks.cool` to the
+  production `bricks` Dokku app.
+- Updated the production deploy workflow so future deployments preserve the
+  wildcard site host instead of resetting domains back to only
+  `craft.bricks.cool`.
+- Verified `https://s-d1893c434ca7.craft-spaces.bricks.cool/` returns HTTP 200
+  with `X-Robots-Tag: noindex`.


### PR DESCRIPTION
## Summary
- keep craft-spaces.bricks.cool and *.craft-spaces.bricks.cool bound to the production Dokku app during deploys
- document the wildcard host requirement for generated channel sites
- record the completed production fix task

## Validation
- curl -fsSI https://s-d1893c434ca7.craft-spaces.bricks.cool/
- ssh -p 59322 root@149.28.225.252 dokku domains:report bricks
- git diff --check